### PR TITLE
ToArray() and ToList() with length

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ The documentation for the SuperLinq.Async methods can be found [here](Source/Sup
 | TakeEvery						  | ✔️ | ✔️ |
 | TakeUntil						  | ✔️ | ✔️ |
 | ThenBy						  | ✔️ | ✔️ |
-| ToArray (with length)			  | ✔️ | ❌ |
+| ToArray						  | ✔️ | ❌ |
 | ToArrayByIndex				  | ✔️ | ✔️ |
 | ToDataTable					  | ✔️ | ❌ |
 | ToDelimitedString				  | ✔️ | ❌ |
 | ToDictionary					  | ✔️ | ❌ |
-| ToList (with length)			  | ✔️ | ❌ |
+| ToList						  | ✔️ | ❌ |
 | ToLookup						  | ✔️ | ❌ |
 | Trace							  | ✔️ | ❌ |
 | Transpose						  | ✔️ | ❌ |

--- a/README.md
+++ b/README.md
@@ -137,10 +137,12 @@ The documentation for the SuperLinq.Async methods can be found [here](Source/Sup
 | TakeEvery						  | ✔️ | ✔️ |
 | TakeUntil						  | ✔️ | ✔️ |
 | ThenBy						  | ✔️ | ✔️ |
+| ToArray (with length)			  | ✔️ | ❌ |
 | ToArrayByIndex				  | ✔️ | ✔️ |
 | ToDataTable					  | ✔️ | ❌ |
 | ToDelimitedString				  | ✔️ | ❌ |
 | ToDictionary					  | ✔️ | ❌ |
+| ToList (with length)			  | ✔️ | ❌ |
 | ToLookup						  | ✔️ | ❌ |
 | Trace							  | ✔️ | ❌ |
 | Transpose						  | ✔️ | ❌ |

--- a/Source/SuperLinq/ToArray.cs
+++ b/Source/SuperLinq/ToArray.cs
@@ -34,7 +34,9 @@ public static partial class SuperEnumerable
 
 	private static T[] CreateTwiceBiggerArray<T>(T[] array)
 	{
-		var resultArray = new T[array.Length * 2];
+		var newLength = array.Length == 0 ? 1 : array.Length * 2;
+		var resultArray = new T[newLength];
+
 		for (var i = 0; i < array.Length; i++)
 		{
 			resultArray[i] = array[i];

--- a/Source/SuperLinq/ToArray.cs
+++ b/Source/SuperLinq/ToArray.cs
@@ -1,0 +1,46 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates an array from <see cref="IEnumerable{T}"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of list elements.</typeparam>
+	/// <param name="source">The <see cref="IEnumerable{T}"/> to create array" /> from.</param >
+	/// <param name="length">Expected length of source.</param>
+	/// <returns>
+	/// An array that contains elements from the input sequence
+	/// </returns>
+	public static T[] ToArray<T>(this IEnumerable<T> source, int length)
+	{
+		var resultArray = new T[length];
+		var i = 0;
+		foreach (var item in source)
+		{
+			if (i >= resultArray.Length)
+			{
+				resultArray = CreateTwiceBiggerArray(resultArray);
+			}
+			resultArray[i++] = item;
+		}
+		return i < resultArray.Length
+			? resultArray.TrimArray(i) : resultArray;
+	}
+
+	private static T[] CreateTwiceBiggerArray<T>(T[] array)
+	{
+		var resultArray = new T[array.Length * 2];
+		for (var i = 0; i < array.Length; i++)
+		{
+			resultArray[i] = array[i];
+		}
+		return resultArray;
+	}
+
+	private static T[] TrimArray<T>(this T[] array, int length)
+	{
+		var resultArray = new T[length];
+		Array.Copy(array, resultArray, length);
+		return resultArray;
+	}
+}

--- a/Source/SuperLinq/ToArray.cs
+++ b/Source/SuperLinq/ToArray.cs
@@ -11,8 +11,13 @@ public static partial class SuperEnumerable
 	/// <returns>
 	/// An array that contains elements from the input sequence
 	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is <see langword="null"/>.</exception>
 	public static T[] ToArray<T>(this IEnumerable<T> source, int length)
 	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(length, 0);
+
 		var resultArray = new T[length];
 		var i = 0;
 		foreach (var item in source)

--- a/Source/SuperLinq/ToList.cs
+++ b/Source/SuperLinq/ToList.cs
@@ -1,0 +1,20 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates a <see cref="List{T}" /> from <see cref="IEnumerable{T}"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of list elements.</typeparam>
+	/// <param name="source">The <see cref="IEnumerable{T}"/> to create <see cref="List{T}" /> from.</param >
+	/// <param name="length">Expected length of source.</param>
+	/// <returns>
+	/// A <see cref="List{T}"/> that contains elements from the input sequence
+	/// </returns>
+	public static List<T> ToList<T>(this IEnumerable<T> source, int length)
+	{
+		var resultList = new List<T>(length);
+		source.ForEach(resultList.Add);
+		return resultList;
+	}
+}

--- a/Source/SuperLinq/ToList.cs
+++ b/Source/SuperLinq/ToList.cs
@@ -14,7 +14,7 @@ public static partial class SuperEnumerable
 	public static List<T> ToList<T>(this IEnumerable<T> source, int length)
 	{
 		var resultList = new List<T>(length);
-		source.ForEach(resultList.Add);
+		resultList.AddRange(source);
 		return resultList;
 	}
 }

--- a/Source/SuperLinq/ToList.cs
+++ b/Source/SuperLinq/ToList.cs
@@ -11,8 +11,13 @@ public static partial class SuperEnumerable
 	/// <returns>
 	/// A <see cref="List{T}"/> that contains elements from the input sequence
 	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is <see langword="null"/>.</exception>
 	public static List<T> ToList<T>(this IEnumerable<T> source, int length)
 	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(length, 0);
+
 		var resultList = new List<T>(length);
 		resultList.AddRange(source);
 		return resultList;

--- a/Source/SuperLinq/readme.md
+++ b/Source/SuperLinq/readme.md
@@ -752,6 +752,11 @@ direction (ascending, descending) according to a key.
 
 This method has 2 overloads.
 
+### ToArray (with length)
+
+Optimized version of ToArray(). Creates first array with expected length
+to avoid multiply copying items from smaller arrays to bigger.
+
 ### ToArrayByIndex
 
 Creates an array from an IEnumerable<T> where a function is used to determine
@@ -780,6 +785,12 @@ Creates a [dictionary][dict] from a sequence of [key-value pair][kvp] elements
 or tuples of 2.
 
 This method has 4 overloads.
+
+### ToList (with length)
+
+Optimized version of ToList(). Creates list with expected length
+to avoid multiply copying items from smaller lists to bigger.
+
 ### ToLookup
 
 Creates a [lookup][lookup] from a sequence of [key-value pair][kvp] elements

--- a/Tests/SuperLinq.Test/ToArrayTests.cs
+++ b/Tests/SuperLinq.Test/ToArrayTests.cs
@@ -25,4 +25,13 @@ public class ToArrayTests
 
 		Assert.Equal(enumerable, result);
 	}
+
+	[Fact]
+	public void ToArrayWithLengthSmallerThan0()
+	{
+		const int Length = -1;
+		var enumerable = Enumerable.Range(0, 1);
+
+		Assert.Throws<ArgumentOutOfRangeException>(() => enumerable.ToArray(Length));
+	}
 }

--- a/Tests/SuperLinq.Test/ToArrayTests.cs
+++ b/Tests/SuperLinq.Test/ToArrayTests.cs
@@ -27,6 +27,17 @@ public class ToArrayTests
 	}
 
 	[Fact]
+	public void ToArrayWithLengthEqualTo0()
+	{
+		const int Length = 0;
+		var enumerable = Enumerable.Range(0, 1);
+
+		var result = enumerable.ToArray(Length);
+
+		Assert.Equal(enumerable, result);
+	}
+
+	[Fact]
 	public void ToArrayWithLengthSmallerThan0()
 	{
 		const int Length = -1;

--- a/Tests/SuperLinq.Test/ToArrayTests.cs
+++ b/Tests/SuperLinq.Test/ToArrayTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Test;
+
+public class ToArrayTests
+{
+	[Fact]
+	public void ToArrayWithSmallerAmountOfElementsThanLength()
+	{
+		const int Length = 2;
+		var enumerable = Enumerable.Range(0, 1);
+
+		var result = enumerable.ToArray(Length);
+
+		Assert.Equal(enumerable, result);
+	}
+
+	[Theory]
+	[InlineData(3)]
+	[InlineData(5)]
+	public void ToArrayWithHigherAmountOfElementsThanLength(int dataLength)
+	{
+		const int Length = 2;
+		var enumerable = Enumerable.Range(0, dataLength);
+
+		var result = enumerable.ToArray(Length);
+
+		Assert.Equal(enumerable, result);
+	}
+}

--- a/Tests/SuperLinq.Test/ToListTests.cs
+++ b/Tests/SuperLinq.Test/ToListTests.cs
@@ -27,4 +27,13 @@ public class ToListTests
 		Assert.Equal(enumerable, result);
 		Assert.True(result.Capacity > Length);
 	}
+
+	[Fact]
+	public void ToListWithLengthSmallerThan0()
+	{
+		const int Length = -1;
+		var enumerable = Enumerable.Range(0, 1);
+
+		Assert.Throws<ArgumentOutOfRangeException>(() => enumerable.ToList(Length));
+	}
 }

--- a/Tests/SuperLinq.Test/ToListTests.cs
+++ b/Tests/SuperLinq.Test/ToListTests.cs
@@ -29,6 +29,17 @@ public class ToListTests
 	}
 
 	[Fact]
+	public void ToListWithLengthEqualTo0()
+	{
+		const int Length = 0;
+		var enumerable = Enumerable.Range(0, 1);
+
+		var result = enumerable.ToList(Length);
+
+		Assert.Equal(enumerable, result);
+	}
+
+	[Fact]
 	public void ToListWithLengthSmallerThan0()
 	{
 		const int Length = -1;

--- a/Tests/SuperLinq.Test/ToListTests.cs
+++ b/Tests/SuperLinq.Test/ToListTests.cs
@@ -1,0 +1,30 @@
+﻿namespace Test;
+
+public class ToListTests
+{
+	[Fact]
+	public void ToListWithSmallerAmountOfElementsThanLength()
+	{
+		const int Length = 2;
+		var enumerable = Enumerable.Range(0, 1);
+
+		var result = enumerable.ToList(Length);
+
+		Assert.Equal(enumerable, result);
+		Assert.Equal(Length, result.Capacity);
+	}
+
+	[Theory]
+	[InlineData(3)]
+	[InlineData(5)]
+	public void ToListWithHigherAmountOfElementsThanLength(int dataLength)
+	{
+		const int Length = 2;
+		var enumerable = Enumerable.Range(0, dataLength);
+
+		var result = enumerable.ToList(Length);
+
+		Assert.Equal(enumerable, result);
+		Assert.True(result.Capacity > Length);
+	}
+}


### PR DESCRIPTION
Simple overload for `ToArray()` and `ToList()` with `lenght` parameter. With `lenght` we can avoid multiple creations of array/list when rewriting IEnumerable to these collections.