### PR TITLE
Add `GetShortestPath` overload

### DIFF
--- a/Source/SuperLinq.Async/GetShortestPath.cs
+++ b/Source/SuperLinq.Async/GetShortestPath.cs
@@ -131,7 +131,7 @@ public partial class AsyncSuperEnumerable
 	///  This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static async ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+	public static ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
 		TState start,
 		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
 		TState end,
@@ -146,6 +146,131 @@ public partial class AsyncSuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPathCost(
+			start, getNeighbors, s => new ValueTask<bool>(stateComparer.Equals(s, end)),
+			stateComparer, costComparer,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+		Func<TState, ValueTask<bool>> predicate,
+		CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPathCost(
+			start, getNeighbors, predicate,
+			stateComparer: null,
+			costComparer: null,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static async ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+		Func<TState, ValueTask<bool>> predicate,
+		IEqualityComparer<TState>? stateComparer,
+		IComparer<TCost>? costComparer,
+		CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, TCost?>(stateComparer);
@@ -158,7 +283,7 @@ public partial class AsyncSuperEnumerable
 			cancellationToken.ThrowIfCancellationRequested();
 
 			totalCost[current] = cost;
-			if (stateComparer.Equals(current, end))
+			if (await predicate(current).ConfigureAwait(false))
 				break;
 
 			var newStates = getNeighbors(current, cost);
@@ -303,7 +428,7 @@ public partial class AsyncSuperEnumerable
 	///  This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static async ValueTask<IEnumerable<(TState state, TCost? cost)>>
+	public static ValueTask<IEnumerable<(TState state, TCost? cost)>>
 		GetShortestPath<TState, TCost>(
 			TState start,
 			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
@@ -319,6 +444,135 @@ public partial class AsyncSuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPath(
+			start, getNeighbors, s => new ValueTask<bool>(stateComparer.Equals(s, end)),
+			stateComparer, costComparer,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static ValueTask<IEnumerable<(TState nextState, TCost? cost)>>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+			Func<TState, ValueTask<bool>> predicate,
+			CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPath(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static async ValueTask<IEnumerable<(TState state, TCost? cost)>>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+			Func<TState, ValueTask<bool>> predicate,
+			IEqualityComparer<TState>? stateComparer,
+			IComparer<TCost>? costComparer,
+			CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, (TState? parent, TCost? cost)>(stateComparer);
@@ -329,14 +583,18 @@ public partial class AsyncSuperEnumerable
 			stateComparer);
 
 		TState? current = start;
+		TState? end = default;
 		(TState? parent, TCost cost) from = default;
 		do
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 
 			totalCost[current] = from;
-			if (stateComparer.Equals(current, end))
+			if (await predicate(current).ConfigureAwait(false))
+			{
+				end = current;
 				break;
+			}
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
@@ -677,7 +935,7 @@ public partial class AsyncSuperEnumerable
 	///  This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static async ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+	public static ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
 		TState start,
 		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
 		TState end,
@@ -690,6 +948,137 @@ public partial class AsyncSuperEnumerable
 		Guard.IsNotNull(start);
 		Guard.IsNotNull(getNeighbors);
 		Guard.IsNotNull(end);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPathCost(
+			start, getNeighbors, s => new ValueTask<bool>(stateComparer.Equals(s, end)),
+			stateComparer, costComparer,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+		Func<TState, ValueTask<bool>> predicate,
+		CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPathCost(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static async ValueTask<TCost?> GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+		Func<TState, ValueTask<bool>> predicate,
+		IEqualityComparer<TState>? stateComparer,
+		IComparer<TCost>? costComparer,
+		CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -715,7 +1104,7 @@ public partial class AsyncSuperEnumerable
 				|| costComparer.Compare(costs.traversed, oldCost) < 0)
 			{
 				totalCost[current] = costs.traversed;
-				if (stateComparer.Equals(current, end))
+				if (await predicate(current).ConfigureAwait(false))
 					break;
 
 				var newStates = getNeighbors(current, costs.traversed);
@@ -868,7 +1257,7 @@ public partial class AsyncSuperEnumerable
 	///  This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static async ValueTask<IEnumerable<(TState nextState, TCost? cost)>>
+	public static ValueTask<IEnumerable<(TState nextState, TCost? cost)>>
 		GetShortestPath<TState, TCost>(
 			TState start,
 			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost traversed, TCost bestGuess)>> getNeighbors,
@@ -882,6 +1271,149 @@ public partial class AsyncSuperEnumerable
 		Guard.IsNotNull(start);
 		Guard.IsNotNull(getNeighbors);
 		Guard.IsNotNull(end);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPath(
+			start, getNeighbors, s => new ValueTask<bool>(stateComparer.Equals(s, end)),
+			stateComparer, costComparer,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static ValueTask<IEnumerable<(TState nextState, TCost? cost)>>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+			Func<TState, ValueTask<bool>> predicate,
+			CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPath(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null,
+			cancellationToken);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static async ValueTask<IEnumerable<(TState nextState, TCost? cost)>>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IAsyncEnumerable<(TState nextState, TCost traversed, TCost bestGuess)>> getNeighbors,
+			Func<TState, ValueTask<bool>> predicate,
+			IEqualityComparer<TState>? stateComparer,
+			IComparer<TCost>? costComparer,
+			CancellationToken cancellationToken = default)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -898,6 +1430,7 @@ public partial class AsyncSuperEnumerable
 			stateComparer);
 
 		TState? current = start;
+		TState? end = default;
 		(TState? parent, TCost bestGuess, TCost traversed) from = default;
 		do
 		{
@@ -907,8 +1440,11 @@ public partial class AsyncSuperEnumerable
 				|| costComparer.Compare(from.traversed, oldCost.traversed) < 0)
 			{
 				totalCost[current] = (from.parent, from.traversed);
-				if (stateComparer.Equals(current, end))
+				if (await predicate(current).ConfigureAwait(false))
+				{
+					end = current;
 					break;
+				}
 
 				var cost = from.traversed;
 				var newStates = getNeighbors(current, cost);

--- a/Source/SuperLinq.Async/readme.md
+++ b/Source/SuperLinq.Async/readme.md
@@ -235,7 +235,31 @@ The underlying map can be a plane, a graph, or any other state system provided
 by the consumer, since traversal from one state to the next is done by the
 consumer in the getNeighbors functor. 
 
-This method has 4 overloads.
+This method has 8 overloads.
+
+### GetShortestPathCost
+
+Finds the cost of the shortest path between two points, using either Dijkstra's 
+algorithm or the A* algorithm (depending on whether a heuristic value is provided 
+when getting state neighbors). 
+
+The underlying map can be a plane, a graph, or any other state system provided
+by the consumer, since traversal from one state to the next is done by the
+consumer in the getNeighbors functor. 
+
+This method has 8 overloads.
+
+### GetShortestPaths
+
+Finds the shortest path from a starting point to every other point in the map,
+using either Dijkstra's algorithm.
+
+The underlying map can be a plane, a graph, or any other state system provided
+by the consumer, since traversal from one state to the next is done by the
+consumer in the getNeighbors functor. The map must have a finite number of states
+in order for this method to complete.
+
+This method has 2 overloads.
 
 ### GroupAdjacent
 

--- a/Source/SuperLinq/GetShortestPath.cs
+++ b/Source/SuperLinq/GetShortestPath.cs
@@ -141,6 +141,130 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPathCost(
+			start, getNeighbors, s => stateComparer.Equals(s, end),
+			stateComparer, costComparer);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static TCost? GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+		Func<TState, bool> predicate)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPathCost(
+			start, getNeighbors, predicate,
+			stateComparer: null,
+			costComparer: null);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static TCost? GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+		Func<TState, bool> predicate,
+		IEqualityComparer<TState>? stateComparer,
+		IComparer<TCost>? costComparer)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, TCost?>(stateComparer);
@@ -151,7 +275,7 @@ public partial class SuperEnumerable
 		do
 		{
 			totalCost[current] = cost;
-			if (stateComparer.Equals(current, end))
+			if (predicate(current))
 				break;
 
 			var newStates = getNeighbors(current, cost);
@@ -307,6 +431,134 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPath(
+			start, getNeighbors, s => stateComparer.Equals(s, end),
+			stateComparer, costComparer);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<(TState nextState, TCost? cost)>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+			Func<TState, bool> predicate)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPath(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using Dijkstra's algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state and the total cost to get to that state based on the
+	/// traversal cost at the current state.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses Dijkstra's algorithm to explore a map and find the shortest path from <paramref name="start"/>
+	///  to a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  Dijkstra's algorithm assumes that all costs are positive, that is to say, that it is not possible to go a
+	///  negative distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<(TState state, TCost? cost)>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost)>> getNeighbors,
+			Func<TState, bool> predicate,
+			IEqualityComparer<TState>? stateComparer,
+			IComparer<TCost>? costComparer)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, (TState? parent, TCost? cost)>(stateComparer);
@@ -317,12 +569,16 @@ public partial class SuperEnumerable
 			stateComparer);
 
 		TState? current = start;
+		TState? end = default;
 		(TState? parent, TCost cost) from = default;
 		do
 		{
 			totalCost[current] = from;
-			if (stateComparer.Equals(current, end))
+			if (predicate(current))
+			{
+				end = current;
 				break;
+			}
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
@@ -666,6 +922,136 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPathCost(
+			start, getNeighbors, s => stateComparer.Equals(s, end),
+			stateComparer, costComparer);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static TCost? GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+		Func<TState, bool> predicate)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPathCost(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null);
+	}
+
+	/// <summary>
+	/// Calculate the cost of the shortest path from state <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <returns>
+	/// The traversal cost of the shortest path from <paramref name="start"/> to a state that satisfies the conditions
+	/// expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static TCost? GetShortestPathCost<TState, TCost>(
+		TState start,
+		Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+		Func<TState, bool> predicate,
+		IEqualityComparer<TState>? stateComparer,
+		IComparer<TCost>? costComparer)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, TCost?>(stateComparer);
@@ -687,7 +1073,7 @@ public partial class SuperEnumerable
 				|| costComparer.Compare(costs.traversed, oldCost) < 0)
 			{
 				totalCost[current] = costs.traversed;
-				if (stateComparer.Equals(current, end))
+				if (predicate(current))
 					break;
 
 				var newStates = getNeighbors(current, costs.traversed);
@@ -851,6 +1237,143 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
+
+		return GetShortestPath(
+			start, getNeighbors, s => stateComparer.Equals(s, end),
+			stateComparer, costComparer);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<(TState nextState, TCost? cost)>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IEnumerable<(TState nextState, TCost cost, TCost bestGuess)>> getNeighbors,
+			Func<TState, bool> predicate)
+		where TState : notnull
+		where TCost : notnull
+	{
+		return GetShortestPath(
+			start,
+			getNeighbors,
+			predicate,
+			stateComparer: null,
+			costComparer: null);
+	}
+
+	/// <summary>
+	/// Find the shortest path from state <paramref name="start"/> to a state that satisfies the conditions expressed by
+	/// <paramref name="predicate"/>, using the A* algorithm.
+	/// </summary>
+	/// <typeparam name="TState">The type of each state in the map</typeparam>
+	/// <typeparam name="TCost">The type of the cost to traverse between states</typeparam>
+	/// <param name="start">The starting state</param>
+	/// <param name="getNeighbors">
+	/// A function that returns the neighbors for a given state; the total cost to get to that state based on the
+	/// traversal cost at the current state; and the predicted or best-guess total (already traversed plus remaining)
+	/// cost to get to a state that satisfies the conditions expressed by <paramref name="predicate"/>.
+	/// </param>
+	/// <param name="predicate">The predicate that defines the conditions of the element to search for.</param>
+	/// <param name="stateComparer">A custom equality comparer for <typeparamref name="TState"/></param>
+	/// <param name="costComparer">A custom comparer for <typeparamref name="TCost"/></param>
+	/// <returns>
+	/// The traversal path and cost of the shortest path from <paramref name="start"/> to a state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="getNeighbors"/> is <see langword="null"/>.</exception>
+	/// <exception cref="InvalidOperationException">The map is entirely explored and no state that satisfies the
+	/// conditions expressed by <paramref name="predicate"/> is found.</exception>
+	/// <remarks>
+	/// <para>
+	///  This method uses the A* algorithm to explore a map and find the shortest path from <paramref name="start"/> to
+	///  a state that satisfies the conditions expressed by <paramref name="predicate"/>. An <see
+	///  cref="UpdatablePriorityQueue{TElement, TPriority}"/> is used to manage the list of <typeparamref
+	///  name="TState"/>s to process, to reduce the computation cost of this operator. Overall performance of this
+	///  method will depend on the reliability of the best-guess cost provided by <paramref name="getNeighbors"/>.
+	/// </para>
+	/// <para>
+	///  Loops and cycles are automatically detected and handled correctly by this operator; only the cheapest path to a
+	///  given <typeparamref name="TState"/> is used, and other paths (including loops) are discarded.
+	/// </para>
+	/// <para>
+	///  The A* algorithm assumes that all costs are positive, that is to say, that it is not possible to go a negative
+	///  distance from one state to the next. Violating this assumption will have undefined behavior.
+	/// </para>
+	/// <para>
+	///  This method will operate on an infinite map, however, performance will depend on how many states are required
+	///  to be evaluated before reaching the target point.
+	/// </para>
+	/// <para>
+	///	 This method uses <see cref="EqualityComparer{T}.Default"/> to compare <typeparamref name="TState"/>s and <see
+	///	 cref="Comparer{T}.Default"/> to compare traversal
+	///	 <typeparamref name="TCost"/>s.
+	/// </para>
+	/// <para>
+	///  This operator executes immediately.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<(TState nextState, TCost? cost)>
+		GetShortestPath<TState, TCost>(
+			TState start,
+			Func<TState, TCost?, IEnumerable<(TState nextState, TCost traversed, TCost bestGuess)>> getNeighbors,
+			Func<TState, bool> predicate,
+			IEqualityComparer<TState>? stateComparer,
+			IComparer<TCost>? costComparer)
+		where TState : notnull
+		where TCost : notnull
+	{
+		Guard.IsNotNull(start);
+		Guard.IsNotNull(getNeighbors);
+		Guard.IsNotNull(predicate);
+
+		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
 
 		var totalCost = new Dictionary<TState, (TState? parent, TCost? traversed)>(stateComparer);
@@ -865,6 +1388,7 @@ public partial class SuperEnumerable
 			stateComparer);
 
 		TState? current = start;
+		TState? end = default;
 		(TState? parent, TCost bestGuess, TCost traversed) from = default;
 		do
 		{
@@ -872,8 +1396,11 @@ public partial class SuperEnumerable
 				|| costComparer.Compare(from.traversed, oldCost.traversed) < 0)
 			{
 				totalCost[current] = (from.parent, from.traversed);
-				if (stateComparer.Equals(current, end))
+				if (predicate(current))
+				{
+					end = current;
 					break;
+				}
 
 				var cost = from.traversed;
 				var newStates = getNeighbors(current, cost);

--- a/Source/SuperLinq/readme.md
+++ b/Source/SuperLinq/readme.md
@@ -387,19 +387,19 @@ The underlying map can be a plane, a graph, or any other state system provided
 by the consumer, since traversal from one state to the next is done by the
 consumer in the getNeighbors functor. 
 
-This method has 4 overloads.
+This method has 8 overloads.
 
 ### GetShortestPathCost
 
-Finds the cost of the shortest path between two points, using either Dijkstra's algorithm
-or the A* algorithm (depending on whether a heuristic value is provided when 
-getting state neighbors). 
+Finds the cost of the shortest path between two points, using either Dijkstra's 
+algorithm or the A* algorithm (depending on whether a heuristic value is provided 
+when getting state neighbors). 
 
 The underlying map can be a plane, a graph, or any other state system provided
 by the consumer, since traversal from one state to the next is done by the
 consumer in the getNeighbors functor. 
 
-This method has 4 overloads.
+This method has 8 overloads.
 
 ### GetShortestPaths
 

--- a/Tests/SuperLinq.Async.Test/GetShortestPathTest.cs
+++ b/Tests/SuperLinq.Async.Test/GetShortestPathTest.cs
@@ -42,7 +42,7 @@ public class GetShortestPathTest
 
 		[Theory]
 		[MemberData(nameof(GetStringIntCostData))]
-		public async Task GetStringIntCost(
+		public async Task GetStringIntCostByState(
 			IEqualityComparer<string>? stateComparer,
 			IComparer<int>? costComparer,
 			int expectedCost,
@@ -66,18 +66,74 @@ public class GetShortestPathTest
 			Assert.Equal(expectedCount, count);
 		}
 
+		[Theory]
+		[MemberData(nameof(GetStringIntCostData))]
+		public async Task GetStringIntCostByFunction(
+			IEqualityComparer<string> stateComparer,
+			IComparer<int>? costComparer,
+			int expectedCost,
+			int expectedCount)
+		{
+			stateComparer ??= EqualityComparer<string>.Default;
+
+			var map = BuildStringIntMap(stateComparer);
+			var count = 0;
+			var actualCost = await AsyncSuperEnumerable.GetShortestPathCost(
+				"start",
+				(x, c) =>
+				{
+					count++;
+					return map[x].Select(y => (y.to, c + y.cost))
+						.ToAsyncEnumerable();
+				},
+				s => new ValueTask<bool>(stateComparer.Equals(s[..1], "e")),
+				stateComparer,
+				costComparer);
+
+			Assert.Equal(expectedCost, actualCost);
+			Assert.Equal(expectedCount, count);
+		}
+
 		public static IEnumerable<object?[]> GetStringIntPathData { get; } =
 			new[]
 			{
 				new object?[] { null, null, Seq(("start", 0), ("a", 1), ("b", 3), ("c", 6), ("d", 10), ("end", 15)), 7, },
-				new object?[] { StringComparer.InvariantCultureIgnoreCase, null, Seq(("start", 0), ("end", 10)), 4, },
+				new object?[] { StringComparer.InvariantCultureIgnoreCase, null, Seq(("start", 0), ("END", 10)), 4, },
 				new object?[] { null, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("A", 10), ("B", 30), ("C", 60), ("D", 100), ("end", 150)), 6, },
-				new object?[] { StringComparer.InvariantCultureIgnoreCase, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("end", 1000)), 1, },
+				new object?[] { StringComparer.InvariantCultureIgnoreCase, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("END", 1000)), 1, },
 			};
 
 		[Theory]
 		[MemberData(nameof(GetStringIntPathData))]
-		public async Task GetStringIntPath(
+		public async Task GetStringIntPathByState(
+			IEqualityComparer<string>? stateComparer,
+			IComparer<int>? costComparer,
+			IEnumerable<(string state, int cost)> expectedPath,
+			int expectedCount)
+		{
+			stateComparer ??= EqualityComparer<string>.Default;
+
+			var map = BuildStringIntMap(stateComparer);
+			var count = 0;
+			var path = await AsyncSuperEnumerable.GetShortestPath(
+				"start",
+				(x, c) =>
+				{
+					count++;
+					return map[x].Select(y => (y.to, c + y.cost))
+						.ToAsyncEnumerable();
+				},
+				s => new ValueTask<bool>(stateComparer.Equals(s[..1], "e")),
+				stateComparer,
+				costComparer);
+
+			path.AssertSequenceEqual(expectedPath);
+			Assert.Equal(expectedCount, count);
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringIntPathData))]
+		public async Task GetStringIntPathByFunction(
 			IEqualityComparer<string>? stateComparer,
 			IComparer<int>? costComparer,
 			IEnumerable<(string state, int cost)> expectedPath,
@@ -260,7 +316,7 @@ public class GetShortestPathTest
 		// Primary improvement of A* is the heuristic to reduce nodes visited.
 		[Theory]
 		[MemberData(nameof(GetStringIntCostData))]
-		public async Task GetStringIntCost(
+		public async Task GetStringIntCostByState(
 			IEqualityComparer<string>? stateComparer,
 			IComparer<int>? costComparer,
 			int expectedCost,
@@ -284,13 +340,41 @@ public class GetShortestPathTest
 			Assert.Equal(expectedCount, count);
 		}
 
+		[Theory]
+		[MemberData(nameof(GetStringIntCostData))]
+		public async Task GetStringIntCostByFunction(
+			IEqualityComparer<string>? stateComparer,
+			IComparer<int>? costComparer,
+			int expectedCost,
+			int expectedCount)
+		{
+			stateComparer ??= EqualityComparer<string>.Default;
+
+			var map = BuildStringIntMap(stateComparer);
+			var count = 0;
+			var actualCost = await AsyncSuperEnumerable.GetShortestPathCost(
+				"start",
+				(x, c) =>
+				{
+					count++;
+					return map[x].Select(y => (y.to, c + y.cost, c + y.cost))
+						.ToAsyncEnumerable();
+				},
+				s => new ValueTask<bool>(stateComparer.Equals(s[..1], "e")),
+				stateComparer,
+				costComparer);
+
+			Assert.Equal(expectedCost, actualCost);
+			Assert.Equal(expectedCount, count);
+		}
+
 		public static IEnumerable<object?[]> GetStringIntPathData { get; } =
 			new[]
 			{
 				new object?[] { null, null, Seq(("start", 0), ("a", 1), ("b", 3), ("c", 6), ("d", 10), ("end", 15)), 7, },
-				new object?[] { StringComparer.InvariantCultureIgnoreCase, null, Seq(("start", 0), ("end", 10)), 4, },
+				new object?[] { StringComparer.InvariantCultureIgnoreCase, null, Seq(("start", 0), ("END", 10)), 4, },
 				new object?[] { null, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("A", 10), ("B", 30), ("C", 60), ("D", 100), ("end", 150)), 6, },
-				new object?[] { StringComparer.InvariantCultureIgnoreCase, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("end", 1000)), 1, },
+				new object?[] { StringComparer.InvariantCultureIgnoreCase, Comparer<int>.Create((x, y) => -x.CompareTo(y)), Seq(("start", 0), ("END", 1000)), 1, },
 			};
 
 		// No heuristic means this operates the same as Dijkstra; this is
@@ -298,7 +382,7 @@ public class GetShortestPathTest
 		// Primary improvement of A* is the heuristic to reduce nodes visited.
 		[Theory]
 		[MemberData(nameof(GetStringIntPathData))]
-		public async Task GetStringIntPath(
+		public async Task GetStringIntPathByState(
 			IEqualityComparer<string>? stateComparer,
 			IComparer<int>? costComparer,
 			IEnumerable<(string state, int cost)> expectedPath,
@@ -315,6 +399,34 @@ public class GetShortestPathTest
 						.ToAsyncEnumerable();
 				},
 				"end",
+				stateComparer,
+				costComparer);
+
+			path.AssertSequenceEqual(expectedPath);
+			Assert.Equal(expectedCount, count);
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringIntPathData))]
+		public async Task GetStringIntPathByFunction(
+			IEqualityComparer<string>? stateComparer,
+			IComparer<int>? costComparer,
+			IEnumerable<(string state, int cost)> expectedPath,
+			int expectedCount)
+		{
+			stateComparer ??= EqualityComparer<string>.Default;
+
+			var map = BuildStringIntMap(stateComparer);
+			var count = 0;
+			var path = await AsyncSuperEnumerable.GetShortestPath(
+				"start",
+				(x, c) =>
+				{
+					count++;
+					return map[x].Select(y => (y.to, c + y.cost, c + y.cost))
+						.ToAsyncEnumerable();
+				},
+				s => new ValueTask<bool>(stateComparer.Equals(s[..1], "e")),
 				stateComparer,
 				costComparer);
 


### PR DESCRIPTION
Fixes #116. Adds new overloads for `GetShortestPath` that allows identifying the end state by condition rather than by value.