### PR TITLE
Add reduced allocation overloads of `Window`

### DIFF
--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -3,6 +3,15 @@
 namespace SuperLinq;
 
 /// <summary>
+/// A delegate that projects a <see cref="ReadOnlySpan{T}" /> of items into a <typeparamref name="TResult"/>.
+/// </summary>
+/// <typeparam name="TSource">The type of the elements of the source.</typeparam>
+/// <typeparam name="TResult">The type of the value returned by selector.</typeparam>
+/// <param name="source">A sequence of values to transform.</param>
+/// <returns>The transformed value produced by this delegate.</returns>
+public delegate TResult ReadOnlySpanProjector<TSource, out TResult>(ReadOnlySpan<TSource> source);
+
+/// <summary>
 /// Provides a set of static methods for querying objects that
 /// implement <see cref="IEnumerable{T}" />.
 /// </summary>

--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -20,4 +20,99 @@ public static partial class SuperEnumerable
 
 		return WindowImpl(source, size, WindowType.Normal);
 	}
+
+	/// <summary>
+	/// Processes a sequence into a series of subsequences representing a windowed subset of the original, and then
+	/// projecting them into a new form.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="selector"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="selector"/>.</typeparam>
+	/// <param name="source">The sequence to evaluate a sliding window over.</param>
+	/// <param name="size">The size (number of elements) in each window.</param>
+	/// <param name="selector">A transform function to apply to each window.</param>
+	/// <returns>An <see cref="IEnumerable{T}"/> whose elements are the result of invoking the transform function on
+	/// each window of <paramref name="source"/>.</returns>
+	/// <remarks>
+	/// <para>
+	/// The number of sequences returned is: <c>Max(0, <paramref name="source"/>.Count() - <paramref name="size"/> +
+	/// 1)</c><br/> Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Window</c>, a single array of length <paramref name="size"/> is allocated as a buffer for
+	/// all subsequences.</para>
+	/// </remarks>
+	public static IEnumerable<TResult> Window<TSource, TResult>(this IEnumerable<TSource> source, int size, ReadOnlySpanProjector<TSource, TResult> selector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(size, 1);
+		Guard.IsNotNull(selector);
+
+		return WindowImpl(source, new TSource[size], size, WindowType.Normal, selector);
+	}
+
+	/// <summary>
+	/// Processes a sequence into a series of subsequences representing a windowed subset of the original, and then
+	/// projecting them into a new form.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="selector"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="selector"/>.</typeparam>
+	/// <param name="source">The sequence to evaluate a sliding window over.</param>
+	/// <param name="array">An array to use as a buffer for each subsequence.</param>
+	/// <param name="selector">A transform function to apply to each window.</param>
+	/// <returns>An <see cref="IEnumerable{T}"/> whose elements are the result of invoking the transform function on
+	/// each window of <paramref name="source"/>.</returns>
+	/// <remarks>
+	/// <para>
+	/// The number of sequences returned is: <c>Max(0, <paramref name="source"/>.Count() - <paramref
+	/// name="array"/>.Length + 1)</c><br/> Returned subsequences are buffered, but the overall operation is
+	/// streamed.<br/>
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Window</c>, <paramref name="array"/> is used as a common buffer for all
+	/// subsequences.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TResult> Window<TSource, TResult>(this IEnumerable<TSource> source, TSource[] array, ReadOnlySpanProjector<TSource, TResult> selector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(array);
+		Guard.IsNotNull(selector);
+
+		return WindowImpl(source, array, array.Length, WindowType.Normal, selector);
+	}
+
+	/// <summary>
+	/// Processes a sequence into a series of subsequences representing a windowed subset of the original, and then
+	/// projecting them into a new form.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="selector"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="selector"/>.</typeparam>
+	/// <param name="source">The sequence to evaluate a sliding window over.</param>
+	/// <param name="array">An array to use as a buffer for each subsequence.</param>
+	/// <param name="size">The size (number of elements) in each window.</param>
+	/// <param name="selector">A transform function to apply to each window.</param>
+	/// <returns>An <see cref="IEnumerable{T}"/> whose elements are the result of invoking the transform function on
+	/// each window of <paramref name="source"/>.</returns>
+	/// <remarks>
+	/// <para>
+	/// The number of sequences returned is: <c>Max(0, <paramref name="source"/>.Count() - <paramref name="size" /> +
+	/// 1)</c><br/> Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Window</c>, <paramref name="array"/> is used as a common buffer for all subsequences.
+	/// </para>
+	/// <para>
+	/// This overload is provided to ease usage of common buffers, such as those rented from <see
+	/// cref="System.Buffers.ArrayPool{T}"/>, which may return an array larger than requested.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TResult> Window<TSource, TResult>(this IEnumerable<TSource> source, TSource[] array, int size, ReadOnlySpanProjector<TSource, TResult> selector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(array);
+		Guard.IsLessThanOrEqualTo(size, array.Length);
+		Guard.IsNotNull(selector);
+
+		return WindowImpl(source, array, size, WindowType.Normal, selector);
+	}
 }

--- a/Source/SuperLinq/WindowImpl.cs
+++ b/Source/SuperLinq/WindowImpl.cs
@@ -48,4 +48,43 @@ public static partial class SuperEnumerable
 			window = newWindow;
 		}
 	}
+
+	private static IEnumerable<TResult> WindowImpl<TSource, TResult>(
+		IEnumerable<TSource> source,
+		TSource[] array,
+		int size,
+		WindowType type,
+		ReadOnlySpanProjector<TSource, TResult> projector)
+	{
+		using var iter = source.GetEnumerator();
+
+		var n = 0;
+		while (n < size && iter.MoveNext())
+		{
+			array[n] = iter.Current;
+			if (type == WindowType.Right)
+				yield return projector(((ReadOnlySpan<TSource>)array)[..n]);
+
+			n++;
+		}
+
+		if (type != WindowType.Right && n == size)
+			yield return projector((ReadOnlySpan<TSource>)array);
+
+		while (iter.MoveNext())
+		{
+			array.AsSpan()[1..].CopyTo(array);
+			array[^1] = iter.Current;
+
+			yield return projector((ReadOnlySpan<TSource>)array);
+		}
+
+		if (type != WindowType.Left)
+			yield break;
+
+		for (var j = 0; j < n; j++)
+		{
+			yield return projector(((ReadOnlySpan<TSource>)array)[j..]);
+		}
+	}
 }


### PR DESCRIPTION
@Arithmomaniac tagged for initial review. This PR will likely be closed and a new one issued once work is completed with: `Window(Left|Right)`, and additional unit tests.

What are your thoughts on the updated API/implementation for new overloads of `Window`? 

NB: Initial benchmarking shows 50% (N=2) to 80% (N=32) improvement in performance.
