### PR TITLE
Fix `Exclude` to not call `MoveNext` past end of sequence

### DIFF
--- a/Source/SuperLinq/Exclude.cs
+++ b/Source/SuperLinq/Exclude.cs
@@ -3,15 +3,17 @@
 public static partial class SuperEnumerable
 {
 	/// <summary>
-	/// Excludes a contiguous number of elements from a sequence starting
-	/// at a given index.
+	/// Excludes a contiguous number of elements from a sequence starting at a given index.
 	/// </summary>
 	/// <typeparam name="T">The type of the elements of the sequence</typeparam>
 	/// <param name="sequence">The sequence to exclude elements from</param>
 	/// <param name="startIndex">The zero-based index at which to begin excluding elements</param>
 	/// <param name="count">The number of elements to exclude</param>
 	/// <returns>A sequence that excludes the specified portion of elements</returns>
-
+	/// <exception cref="ArgumentNullException"><paramref name="sequence"/> is null.</exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="startIndex"/> or <paramref name="count"/> is less than <c>0</c>.
+	/// </exception>
 	public static IEnumerable<T> Exclude<T>(this IEnumerable<T> sequence, int startIndex, int count)
 	{
 		Guard.IsNotNull(sequence);
@@ -25,18 +27,15 @@ public static partial class SuperEnumerable
 
 		static IEnumerable<T> _(IEnumerable<T> sequence, int startIndex, int count)
 		{
-			var index = -1;
+			var index = 0;
 			var endIndex = startIndex + count;
-			using var iter = sequence.GetEnumerator();
-			// yield the first part of the sequence
-			while (iter.MoveNext() && ++index < startIndex)
-				yield return iter.Current;
-			// skip the next part (up to count items)
-			while (++index < endIndex && iter.MoveNext())
-				continue;
-			// yield the remainder of the sequence
-			while (iter.MoveNext())
-				yield return iter.Current;
+
+			foreach (var item in sequence)
+			{
+				if (index < startIndex || index >= endIndex)
+					yield return item;
+				index++;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Based on morelinq/morelinq#692, however this PR uses simpler evaluation of the enumeration; benchmarking shows that complex code is not actually faster. 

* [`exclude-bench.txt`](https://github.com/viceroypenguin/SuperLinq/files/10476418/exclude-bench.txt)
* [`UserQuery-20230122-204407.log.txt`](https://github.com/viceroypenguin/SuperLinq/files/10476423/UserQuery-20230122-204407.log.txt)
