### PR TITLE
Migrate Source Generators to Scriban

### DIFF
--- a/Generators/SuperLinq.Async.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/Fold.sbntxt
@@ -1,0 +1,42 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	{{~ for $i in 1..16 ~}}
+    /// <summary>
+    /// Returns the result of applying a function to a sequence of {{$i}} element{{if $i != 1}}s{{end}}.
+    /// </summary>
+    /// <remarks>
+    /// This operator uses immediate execution and buffers as many items of the source sequence as necessary.
+    /// </remarks>
+    /// <typeparam name="T">Type of element in the source sequence</typeparam>
+    /// <typeparam name="TResult">Type of the result</typeparam>
+    /// <param name="source">The sequence of items to fold.</param>
+    /// <param name="folder">Function to apply to the elements in the sequence.</param>
+    /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="source"/> or <paramref name="folder"/> is null.</exception>
+    /// <exception cref="global::System.InvalidOperationException">
+	/// <paramref name="source"/> does not contain exactly {{$i}} element{{if $i != 1}}s{{end}}.
+	/// </exception>
+    public static async global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<
+		{{~ for $j in 1..$i ~}}
+		T,
+		{{~ end ~}}
+		TResult> folder)
+    {
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+
+		var elements = await source.Take({{$i}} + 1).ToListAsync();
+		if (elements.Count != {{$i}})
+			global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
+				$"Sequence contained an incorrect number of elements. (Expected: {{$i}}, Actual: {elements.Count})");
+
+		return folder(
+			{{~ for $j in 1..$i ~}}
+			elements[{{$j-1}}]{{ if !for.last }},{{ end }}
+			{{~ end ~}}
+		);
+	}
+	{{ end ~}}
+}

--- a/Generators/SuperLinq.Async.Generator/Properties/launchSettings.json
+++ b/Generators/SuperLinq.Async.Generator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SuperLinq.Async.Generator": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\Source\\SuperLinq.Async\\SuperLinq.Async.csproj"
+    }
+  }
+}

--- a/Generators/SuperLinq.Async.Generator/SuperLinq.Async.Generator.csproj
+++ b/Generators/SuperLinq.Async.Generator/SuperLinq.Async.Generator.csproj
@@ -1,15 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<IsPackable>false</IsPackable>
 		<IsRoslynComponent>true</IsRoslynComponent>
+
+		<!-- Avoid figuring out an actual dependency on Scriban -->
+		<PackageScribanIncludeSource>true</PackageScribanIncludeSource>
+
+		<!-- Scriban fails a lot of things in latest-all... -->
+		<AnalysisLevel>latest-default</AnalysisLevel>
+
+		<!-- Analyzer checks-->
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+		<!-- Other things to turn off -->
+		<NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+		<PackageReference Include="Scriban" Version="5.5.2" IncludeAssets="build" />
+		<PackageReference Include="ThisAssembly.Resources" Version="1.2.0-rc" PrivateAssets="all" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="*.sbntxt" Kind="Text" />
+	</ItemGroup>
+
 </Project>

--- a/Generators/SuperLinq.Generator/.editorconfig
+++ b/Generators/SuperLinq.Generator/.editorconfig
@@ -1,5 +1,0 @@
-[*.cs]
-
-dotnet_diagnostic.MA0028.severity = none			# MA0028: Optimize StringBuilder usage
-dotnet_diagnostic.MA0076.severity = none			# MA0076: Do not use implicit culture-sensitive ToString in interpolated strings
-dotnet_diagnostic.MA0101.severity = none			# MA0101: String contains an implicit end of line character

--- a/Generators/SuperLinq.Generator/Aggregate.cs
+++ b/Generators/SuperLinq.Generator/Aggregate.cs
@@ -10,33 +10,7 @@ internal static class Aggregate
 	public static SourceText Generate()
 	{
 		var template = Template.Parse(ThisAssembly.Resources.Aggregate.Text);
-		var output = template.Render(new
-		{
-			Ordinals = new[]
-			{
-				"zeroth" ,
-				"first"  ,
-				"second" ,
-				"third"  ,
-				"fourth" ,
-				"fifth"  ,
-				"sixth"  ,
-				"seventh",
-				"eighth" ,
-			},
-			Arity = new[]
-			{
-				"zero" ,
-				"one"  ,
-				"two"  ,
-				"three",
-				"four" ,
-				"five" ,
-				"six"  ,
-				"seven",
-				"eight",
-			},
-		});
+		var output = template.Render(ArgumentNames.Instance);
 
 		// Apply formatting since indenting isn't that nice in Scriban when rendering nested 
 		// structures via functions.

--- a/Generators/SuperLinq.Generator/Aggregate.cs
+++ b/Generators/SuperLinq.Generator/Aggregate.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Scriban;
 
 namespace SuperLinq;
 
@@ -7,93 +9,42 @@ internal static class Aggregate
 {
 	public static SourceText Generate()
 	{
-		var sb = new StringBuilder();
-		sb.Append(@"
-namespace SuperLinq;
-
-public static partial class SuperEnumerable
-{");
-
-		var args = new[]
+		var template = Template.Parse(ThisAssembly.Resources.Aggregate.Text);
+		var output = template.Render(new
 		{
-			(ordinal: "first"  , arity: "one"   ),
-			(ordinal: "second" , arity: "two"   ),
-			(ordinal: "third"  , arity: "three" ),
-			(ordinal: "fourth" , arity: "four"  ),
-			(ordinal: "fifth"  , arity: "five"  ),
-			(ordinal: "sixth"  , arity: "six"   ),
-			(ordinal: "seventh", arity: "seven" ),
-			(ordinal: "eighth" , arity: "eight" ),
-		};
+			Ordinals = new[]
+			{
+				"zeroth" ,
+				"first"  ,
+				"second" ,
+				"third"  ,
+				"fourth" ,
+				"fifth"  ,
+				"sixth"  ,
+				"seventh",
+				"eighth" ,
+			},
+			Arity = new[]
+			{
+				"zero" ,
+				"one"  ,
+				"two"  ,
+				"three",
+				"four" ,
+				"five" ,
+				"six"  ,
+				"seven",
+				"eight",
+			},
+		});
 
-		void ForEachArgument(int i, Func<int, string, string> builder)
-		{
-			for (var j = 0; j < i; j++)
-				sb.Append(builder(j + 1, args[j].ordinal));
-		}
+		// Apply formatting since indenting isn't that nice in Scriban when rendering nested 
+		// structures via functions.
+		output = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseCompilationUnit(output)
+			.NormalizeWhitespace()
+			.GetText()
+			.ToString();
 
-		static string BuildArgumentString(int i, Func<int, string> builder) =>
-			string.Join(", ", Enumerable.Range(0, i).Select(j => builder(j + 1)));
-
-		for (var i = 2; i <= args.Length; i++)
-		{
-			var (ordinal, arity) = args[i - 1];
-
-			sb.Append($@"
-    /// <summary>
-    /// Applies {arity} accumulators sequentially in a single pass over a
-    /// sequence.
-    /// </summary>
-    /// <typeparam name=""T"">The type of elements in <paramref name=""source""/>.</typeparam>
-    /// <typeparam name=""TResult"">The type of the accumulated result.</typeparam>
-    /// <param name=""source"">The source sequence</param>
-    /// <param name=""resultSelector"">
-    /// A function that projects a single result given the result of each
-    /// accumulator.</param>
-    /// <returns>The value returned by <paramref name=""resultSelector""/>.</returns>
-    /// <remarks>
-    /// This operator executes immediately.
-    /// </remarks>");
-
-			ForEachArgument(i, (j, ordinal) => $@"
-    /// <typeparam name=""TAccumulate{j}"">The type of the {ordinal} accumulator value.</typeparam>
-	/// <param name=""seed{j}"">The seed value for the {ordinal} accumulator.</param>
-	/// <param name=""accumulator{j}"">The {ordinal} accumulator.</param>");
-
-			sb.Append($@"
-    public static TResult Aggregate<T, {BuildArgumentString(i, j => $"TAccumulate{j}")}, TResult>(
-        this IEnumerable<T> source,");
-
-			ForEachArgument(i, (j, ordinal) => $@"
-        TAccumulate{j} seed{j}, Func<TAccumulate{j}, T, TAccumulate{j}> accumulator{j},");
-
-			sb.Append($@"
-        Func<{BuildArgumentString(i, j => $"TAccumulate{j}")}, TResult> resultSelector)
-	{{
-		Guard.IsNotNull(source);");
-
-			ForEachArgument(i, (j, ordinal) => $@"
-        Guard.IsNotNull(accumulator{j});");
-
-			sb.Append($@"
-        Guard.IsNotNull(resultSelector);
-
-		foreach (var item in source)
-		{{");
-
-			ForEachArgument(i, (j, ordinal) => $@"
-			seed{j} = accumulator{j}(seed{j}, item);");
-
-			sb.Append($@"
-		}}
-
-		return resultSelector({BuildArgumentString(i, j => $"seed{j}")});
-	}}");
-		}
-
-		sb.Append($@"
-}}");
-
-		return SourceText.From(sb.ToString(), Encoding.UTF8);
+		return SourceText.From(output, Encoding.UTF8);
 	}
 }

--- a/Generators/SuperLinq.Generator/Aggregate.sbntxt
+++ b/Generators/SuperLinq.Generator/Aggregate.sbntxt
@@ -1,0 +1,59 @@
+﻿{{ 
+    $arity = arity
+    $ordinals = ordinals
+}}
+
+namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	{{~ for $i in 2..($arity.size - 1) ~}}
+    /// <summary>
+    /// Applies {{ $arity[$i] }} accumulators sequentially in a single pass over a
+    /// sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the accumulated result.</typeparam>
+    /// <param name="source">The source sequence</param>
+    /// <param name="resultSelector">
+    /// A function that projects a single result given the result of each
+    /// accumulator.</param>
+    /// <returns>The value returned by <paramref name="resultSelector"/>.</returns>
+    /// <remarks>
+    /// This operator executes immediately.
+    /// </remarks>
+	{{~ for $j in 1..$i ~}}
+    /// <typeparam name="TAccumulate{{$j}}">The type of the {{ $ordinals[$j] }} accumulator value.</typeparam>
+	/// <param name="seed{{$j}}">The seed value for the {{ $ordinals[$j] }} accumulator.</param>
+	/// <param name="accumulator{{$j}}">The {{ $ordinals[$j] }} accumulator.</param>
+	{{~ end ~}}
+    public static TResult Aggregate<T, {{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult>(
+        this IEnumerable<T> source,
+		{{~ for $j in 1..$i ~}}
+        TAccumulate{{$j}} seed{{$j}}, Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}},
+		{{~ end ~}}
+        Func<{{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult> resultSelector)
+	{
+		Guard.IsNotNull(source);
+
+		{{~ for $j in 1..$i ~}}
+        Guard.IsNotNull(accumulator{{$j}});
+		{{~ end ~}}
+
+        Guard.IsNotNull(resultSelector);
+
+		foreach (var item in source)
+		{
+			{{~ for $j in 1..$i ~}}
+		    seed{{$j}} = accumulator{{$j}}(seed{{$j}}, item);
+		    {{~ end ~}}
+		}
+
+		return resultSelector(
+			{{~ for $j in 1..$i ~}}
+		    seed{{$j}}{{ if !for.last }},{{ end }}
+		    {{~ end ~}}
+        );
+	}
+	{{ end ~}}
+}

--- a/Generators/SuperLinq.Generator/Aggregate.sbntxt
+++ b/Generators/SuperLinq.Generator/Aggregate.sbntxt
@@ -22,6 +22,9 @@ public static partial class SuperEnumerable
     /// <remarks>
     /// This operator executes immediately.
     /// </remarks>
+    /// <exception cref="global::System.ArgumentNullException">
+	/// <paramref name="source"/>, <paramref name="resultSelector"/> or any of the accumulator functions is null.
+	/// </exception>
 	{{~ for $j in 1..$i ~}}
     /// <typeparam name="TAccumulate{{$j}}">The type of the {{ $ordinals[$j] }} accumulator value.</typeparam>
 	/// <param name="seed{{$j}}">The seed value for the {{ $ordinals[$j] }} accumulator.</param>

--- a/Generators/SuperLinq.Generator/Aggregate.sbntxt
+++ b/Generators/SuperLinq.Generator/Aggregate.sbntxt
@@ -16,8 +16,8 @@ public static partial class SuperEnumerable
     /// <typeparam name="TResult">The type of the accumulated result.</typeparam>
     /// <param name="source">The source sequence</param>
     /// <param name="resultSelector">
-    /// A function that projects a single result given the result of each
-    /// accumulator.</param>
+    /// A function that projects a single result given the result of each accumulator.
+	/// </param>
     /// <returns>The value returned by <paramref name="resultSelector"/>.</returns>
     /// <remarks>
     /// This operator executes immediately.
@@ -28,19 +28,19 @@ public static partial class SuperEnumerable
 	/// <param name="accumulator{{$j}}">The {{ $ordinals[$j] }} accumulator.</param>
 	{{~ end ~}}
     public static TResult Aggregate<T, {{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult>(
-        this IEnumerable<T> source,
+        this global::System.Collections.Generic.IEnumerable<T> source,
 		{{~ for $j in 1..$i ~}}
-        TAccumulate{{$j}} seed{{$j}}, Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}},
+        TAccumulate{{$j}} seed{{$j}}, global::System.Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}},
 		{{~ end ~}}
-        Func<{{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult> resultSelector)
+        global::System.Func<{{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
 
 		{{~ for $j in 1..$i ~}}
-        Guard.IsNotNull(accumulator{{$j}});
+        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator{{$j}});
 		{{~ end ~}}
 
-        Guard.IsNotNull(resultSelector);
+        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
 		foreach (var item in source)
 		{
@@ -63,7 +63,7 @@ public static partial class SuperEnumerable
     /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
     /// <param name="source">The source sequence</param>
     /// <returns>A 
-	/// <see cref="ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
+	/// <see cref="global::System.ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
     /// containing the result of each accumulator.</returns>
     /// <remarks>
     /// This operator executes immediately.
@@ -74,11 +74,11 @@ public static partial class SuperEnumerable
 	/// <param name="accumulator{{$j}}">The {{ $ordinals[$j] }} accumulator.</param>
 	{{~ end ~}}
     public static ({{~ for $j in 1..$i ~}}TAccumulate{{$j}}{{ if !for.last }},{{ end }}{{ end }}) Aggregate<T, {{ for $j in 1..$i }}TAccumulate{{$j}}{{ if !for.last }}, {{ end }}{{ end }}>(
-        this IEnumerable<T> source,
+        this global::System.Collections.Generic.IEnumerable<T> source,
 		{{~ for $j in 1..$i ~}}
-        TAccumulate{{$j}} seed{{$j}}, Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}}{{ if !for.last }},{{ end }}
+        TAccumulate{{$j}} seed{{$j}}, global::System.Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}}{{ if !for.last }},{{ end }}
 		{{~ end ~}}) =>
-		Aggregate(source, {{~ for $j in 1..$i ~}}seed{{$j}}, accumulator{{$j}}, {{ end }}ValueTuple.Create);
+		Aggregate(source, {{~ for $j in 1..$i ~}}seed{{$j}}, accumulator{{$j}}, {{ end }}global::System.ValueTuple.Create);
 
 	{{ end ~}}
 }

--- a/Generators/SuperLinq.Generator/Aggregate.sbntxt
+++ b/Generators/SuperLinq.Generator/Aggregate.sbntxt
@@ -55,5 +55,30 @@ public static partial class SuperEnumerable
 		    {{~ end ~}}
         );
 	}
+
+    /// <summary>
+    /// Applies {{ $arity[$i] }} accumulators sequentially in a single pass over a
+    /// sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
+    /// <param name="source">The source sequence</param>
+    /// <returns>A 
+	/// <see cref="ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
+    /// containing the result of each accumulator.</returns>
+    /// <remarks>
+    /// This operator executes immediately.
+    /// </remarks>
+	{{~ for $j in 1..$i ~}}
+    /// <typeparam name="TAccumulate{{$j}}">The type of the {{ $ordinals[$j] }} accumulator value.</typeparam>
+	/// <param name="seed{{$j}}">The seed value for the {{ $ordinals[$j] }} accumulator.</param>
+	/// <param name="accumulator{{$j}}">The {{ $ordinals[$j] }} accumulator.</param>
+	{{~ end ~}}
+    public static ({{~ for $j in 1..$i ~}}TAccumulate{{$j}}{{ if !for.last }},{{ end }}{{ end }}) Aggregate<T, {{ for $j in 1..$i }}TAccumulate{{$j}}{{ if !for.last }}, {{ end }}{{ end }}>(
+        this IEnumerable<T> source,
+		{{~ for $j in 1..$i ~}}
+        TAccumulate{{$j}} seed{{$j}}, Func<TAccumulate{{$j}}, T, TAccumulate{{$j}}> accumulator{{$j}}{{ if !for.last }},{{ end }}
+		{{~ end ~}}) =>
+		Aggregate(source, {{~ for $j in 1..$i ~}}seed{{$j}}, accumulator{{$j}}, {{ end }}ValueTuple.Create);
+
 	{{ end ~}}
 }

--- a/Generators/SuperLinq.Generator/ArgumentNames.cs
+++ b/Generators/SuperLinq.Generator/ArgumentNames.cs
@@ -1,0 +1,31 @@
+﻿namespace SuperLinq;
+
+public record ArgumentNames(string[] Arity, string[] Ordinals)
+{
+	public static ArgumentNames Instance { get; } = new(
+		Arity: new[]
+		{
+			"zero" ,
+			"one"  ,
+			"two"  ,
+			"three",
+			"four" ,
+			"five" ,
+			"six"  ,
+			"seven",
+			"eight",
+		},
+		Ordinals: new[]
+		{
+			"zeroth" ,
+			"first"  ,
+			"second" ,
+			"third"  ,
+			"fourth" ,
+			"fifth"  ,
+			"sixth"  ,
+			"seventh",
+			"eighth" ,
+		});
+}
+

--- a/Generators/SuperLinq.Generator/Cartesian.cs
+++ b/Generators/SuperLinq.Generator/Cartesian.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Scriban;
 
 namespace SuperLinq;
 
@@ -7,135 +9,16 @@ internal static class Cartesian
 {
 	public static SourceText Generate()
 	{
-		var sb = new StringBuilder();
-		sb.Append(@"
-namespace SuperLinq;
+		var template = Template.Parse(ThisAssembly.Resources.Cartesian.Text);
+		var output = template.Render(ArgumentNames.Instance);
 
-public static partial class SuperEnumerable
-{");
+		// Apply formatting since indenting isn't that nice in Scriban when rendering nested 
+		// structures via functions.
+		output = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseCompilationUnit(output)
+			.NormalizeWhitespace()
+			.GetText()
+			.ToString();
 
-		var args = new[]
-		{
-			(ordinal: "first"  , arity: "one"   ),
-			(ordinal: "second" , arity: "two"   ),
-			(ordinal: "third"  , arity: "three" ),
-			(ordinal: "fourth" , arity: "four"  ),
-			(ordinal: "fifth"  , arity: "five"  ),
-			(ordinal: "sixth"  , arity: "six"   ),
-			(ordinal: "seventh", arity: "seven" ),
-			(ordinal: "eighth" , arity: "eight" ),
-		};
-
-		for (var i = 2; i <= args.Length; i++)
-		{
-			void ForEachArgument(Func<int, string, string> builder)
-			{
-				for (var j = 0; j < i; j++)
-					sb.Append(builder(j + 1, args[j].ordinal));
-			}
-
-			string BuildArgumentString(Func<int, string, string> builder) =>
-				string.Join(", ", Enumerable.Range(0, i).Select(j => builder(j + 1, args[j].ordinal)));
-
-			var (ordinal, arity) = args[i - 1];
-
-			sb.Append($@"
-    /// <summary>
-    /// Returns the Cartesian product of {arity} sequences by enumerating all
-    /// possible combinations of one item from each sequence, and applying
-    /// a user-defined projection to the items in a given combination.
-    /// </summary>
-    /// <typeparam name=""TResult"">
-    /// The type of the elements of the result sequence.</typeparam>
-    /// <param name=""resultSelector"">A projection function that combines
-    /// elements from all of the sequences.</param>
-    /// <returns>A sequence of elements returned by
-    /// <paramref name=""resultSelector""/>.</returns>
-    /// <remarks>
-    /// <para>
-    /// The method returns items in the same order as a nested foreach
-    /// loop, but all sequences except for <paramref name=""first""/> are
-    /// cached when iterated over. The cache is then re-used for any
-    /// subsequent iterations.</para>
-    /// <para>
-    /// This method uses deferred execution and stream its results.</para>
-    /// </remarks>");
-
-			ForEachArgument((j, o) => $@"
-    /// <typeparam name=""T{j}"">
-    /// The type of the elements of <paramref name=""{o}""/>.</typeparam>
-    /// <param name=""{o}"">The {o} sequence of elements.</param>");
-
-			sb.Append($@"
-    public static IEnumerable<TResult> Cartesian<{BuildArgumentString((j, _) => $"T{j}")}, TResult>(this ");
-
-			ForEachArgument((j, o) => $@"
-		IEnumerable<T{j}> {o},");
-
-			sb.Append($@"
-		Func<{BuildArgumentString((j, _) => $"T{j}")}, TResult> resultSelector)
-    {{");
-
-			ForEachArgument((j, o) => $@"
-        Guard.IsNotNull({o});");
-
-			sb.Append($@"
-		Guard.IsNotNull(resultSelector);
-
-        return _({BuildArgumentString((_, o) => o)}, resultSelector);
-
-		static IEnumerable<TResult> _(");
-
-			ForEachArgument((j, o) => $@"
-			IEnumerable<T{j}> {o},");
-
-			sb.Append($@"
-			Func<{BuildArgumentString((j, _) => $"T{j}")}, TResult> resultSelector)
-		{{");
-
-			ForEachArgument((j, o) => $@"
-            using var {o}Memo = {o}.Memoize();");
-
-			ForEachArgument((j, o) => $@"
-            foreach (var item{j} in {o}Memo)");
-
-			sb.Append($@"
-                yield return resultSelector({BuildArgumentString((j, _) => $"item{j}")});
-		}}
-    }}");
-
-			sb.Append($@"
-
-    /// <summary>
-    /// Returns the Cartesian product of {arity} sequences by enumerating all
-    /// possible combinations of one item from each sequence.
-    /// </summary>
-    /// <returns>A sequence of <see cref=""ValueTuple{{{BuildArgumentString((j, _) => $"T{j}")}}}"" /> 
-    /// containing elements from each of the sequences.</returns>
-    /// <remarks>
-    /// <para>
-    /// The method returns items in the same order as a nested foreach
-    /// loop, but all sequences except for <paramref name=""first""/> are
-    /// cached when iterated over. The cache is then re-used for any
-    /// subsequent iterations.</para>
-    /// <para>
-    /// This method uses deferred execution and stream its results.</para>
-    /// </remarks>");
-
-			ForEachArgument((j, o) => $@"
-    /// <typeparam name=""T{j}"">
-    /// The type of the elements of <paramref name=""{o}""/>.</typeparam>
-    /// <param name=""{o}"">The {o} sequence of elements.</param>");
-			sb.Append($@"
-    public static IEnumerable<({BuildArgumentString((j, _) => $"T{j}")})> Cartesian<{BuildArgumentString((j, _) => $"T{j}")}>(
-		this {BuildArgumentString((j, k) => $"IEnumerable<T{j}> {k}")}) =>
-		Cartesian({BuildArgumentString((j, k) => k)}, ValueTuple.Create);
-");
-		}
-
-		sb.Append($@"
-}}");
-
-		return SourceText.From(sb.ToString(), Encoding.UTF8);
+		return SourceText.From(output, Encoding.UTF8);
 	}
 }

--- a/Generators/SuperLinq.Generator/Cartesian.sbntxt
+++ b/Generators/SuperLinq.Generator/Cartesian.sbntxt
@@ -27,6 +27,7 @@ public static partial class SuperEnumerable
     /// <para>
     /// This method uses deferred execution and stream its results.</para>
     /// </remarks>
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="resultSelector"/> or any of the input sequences is null.</exception>
 	{{~ for $j in 1..$i ~}}
     /// <typeparam name="T{{$j}}">The type of the elements of <paramref name="{{ $ordinals[$j] }}" />.</typeparam>
 	/// <param name="{{ $ordinals[$j] }}">The {{ $ordinals[$j] }} sequence of elements.</param>

--- a/Generators/SuperLinq.Generator/Cartesian.sbntxt
+++ b/Generators/SuperLinq.Generator/Cartesian.sbntxt
@@ -31,17 +31,17 @@ public static partial class SuperEnumerable
     /// <typeparam name="T{{$j}}">The type of the elements of <paramref name="{{ $ordinals[$j] }}" />.</typeparam>
 	/// <param name="{{ $ordinals[$j] }}">The {{ $ordinals[$j] }} sequence of elements.</param>
 	{{~ end ~}}
-    public static IEnumerable<TResult> Cartesian<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult>(this 
+    public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult>(this 
 		{{~ for $j in 1..$i ~}}
-        IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
+        global::System.Collections.Generic.IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
 		{{~ end ~}}
-        Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
+        global::System.Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        Guard.IsNotNull({{ $ordinals[$j] }});
+        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        Guard.IsNotNull(resultSelector);
+        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
 		return _(
 			{{~ for $j in 1..$i ~}}
@@ -49,11 +49,11 @@ public static partial class SuperEnumerable
 			{{~ end ~}}
 			resultSelector);
 
-		static IEnumerable<TResult> _(
+		static global::System.Collections.Generic.IEnumerable<TResult> _(
 			{{~ for $j in 1..$i ~}}
-			IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
+			global::System.Collections.Generic.IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
 			{{~ end ~}}
-			Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
+			global::System.Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
 		{
 			{{~ for $j in 1..$i ~}}
 			using var {{ $ordinals[$j] }}Memo = {{ $ordinals[$j] }}.Memoize();
@@ -75,7 +75,7 @@ public static partial class SuperEnumerable
     /// possible combinations of one item from each sequence.
     /// </summary>
     /// <returns>A sequence of 
-	/// <see cref="ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
+	/// <see cref="global::System.ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
     /// containing elements from each of the sequences.</returns>
     /// <remarks>
     /// <para>
@@ -89,11 +89,11 @@ public static partial class SuperEnumerable
     /// <typeparam name="T{{$j}}">The type of the elements of <paramref name="{{ $ordinals[$j] }}" />.</typeparam>
 	/// <param name="{{ $ordinals[$j] }}">The {{ $ordinals[$j] }} sequence of elements.</param>
 	{{~ end ~}}
-    public static IEnumerable<({{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }})> 
+    public static global::System.Collections.Generic.IEnumerable<({{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }})> 
 		Cartesian<{{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }}>(this
 			{{~ for $j in 1..$i ~}}
-			IEnumerable<T{{$j}}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
+			global::System.Collections.Generic.IEnumerable<T{{$j}}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
 			{{~ end ~}}) =>
-		Cartesian({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}ValueTuple.Create);
+		Cartesian({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
 	{{ end ~}}
 }

--- a/Generators/SuperLinq.Generator/Cartesian.sbntxt
+++ b/Generators/SuperLinq.Generator/Cartesian.sbntxt
@@ -1,0 +1,99 @@
+﻿{{ 
+    $arity = arity
+    $ordinals = ordinals
+}}
+
+namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	{{~ for $i in 2..($arity.size - 1) ~}}
+    /// <summary>
+    /// Returns the Cartesian product of {{ $arity[$i] }} sequences by enumerating all
+    /// possible combinations of one item from each sequence, and applying
+    /// a user-defined projection to the items in a given combination.
+    /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the elements of the result sequence.</typeparam>
+    /// <param name="resultSelector">A projection function that combines
+    /// elements from all of the sequences.</param>
+    /// <returns>A sequence of elements returned by
+    /// <paramref name="resultSelector"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The method returns items in the same order as a nested foreach
+    /// loop, but all sequences cached when iterated over. The cache is 
+	/// then re-used for any subsequent iterations.</para>
+    /// <para>
+    /// This method uses deferred execution and stream its results.</para>
+    /// </remarks>
+	{{~ for $j in 1..$i ~}}
+    /// <typeparam name="T{{$j}}">The type of the elements of <paramref name="{{ $ordinals[$j] }}" />.</typeparam>
+	/// <param name="{{ $ordinals[$j] }}">The {{ $ordinals[$j] }} sequence of elements.</param>
+	{{~ end ~}}
+    public static IEnumerable<TResult> Cartesian<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult>(this 
+		{{~ for $j in 1..$i ~}}
+        IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
+		{{~ end ~}}
+        Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
+	{
+		{{~ for $j in 1..$i ~}}
+        Guard.IsNotNull({{ $ordinals[$j] }});
+		{{~ end ~}}
+
+        Guard.IsNotNull(resultSelector);
+
+		return _(
+			{{~ for $j in 1..$i ~}}
+			{{ $ordinals[$j] }},
+			{{~ end ~}}
+			resultSelector);
+
+		static IEnumerable<TResult> _(
+			{{~ for $j in 1..$i ~}}
+			IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
+			{{~ end ~}}
+			Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
+		{
+			{{~ for $j in 1..$i ~}}
+			using var {{ $ordinals[$j] }}Memo = {{ $ordinals[$j] }}.Memoize();
+			{{~ end ~}}
+
+			{{~ for $j in 1..$i ~}}
+			foreach (var item{{$j}} in {{ $ordinals[$j] }}Memo)
+			{{~ end ~}}
+				yield return resultSelector(
+					{{~ for $j in 1..$i ~}}
+					item{{$j}}{{ if !for.last }},{{ end }}
+					{{~ end ~}}
+				);
+		}
+	}
+
+	/// <summary>
+    /// Returns the Cartesian product of {{ $arity[$i] }} sequences by enumerating all
+    /// possible combinations of one item from each sequence.
+    /// </summary>
+    /// <returns>A sequence of 
+	/// <see cref="ValueTuple{ {{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }} }" /> 
+    /// containing elements from each of the sequences.</returns>
+    /// <remarks>
+    /// <para>
+    /// The method returns items in the same order as a nested foreach
+    /// loop, but all sequences are cached when iterated over. The cache 
+	/// is then re-used for any subsequent iterations.</para>
+    /// <para>
+    /// This method uses deferred execution and stream its results.</para>
+    /// </remarks>
+	{{~ for $j in 1..$i ~}}
+    /// <typeparam name="T{{$j}}">The type of the elements of <paramref name="{{ $ordinals[$j] }}" />.</typeparam>
+	/// <param name="{{ $ordinals[$j] }}">The {{ $ordinals[$j] }} sequence of elements.</param>
+	{{~ end ~}}
+    public static IEnumerable<({{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }})> 
+		Cartesian<{{~ for $j in 1..$i ~}}T{{$j}}{{ if !for.last }},{{ end }}{{ end }}>(this
+			{{~ for $j in 1..$i ~}}
+			IEnumerable<T{{$j}}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
+			{{~ end ~}}) =>
+		Cartesian({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}ValueTuple.Create);
+	{{ end ~}}
+}

--- a/Generators/SuperLinq.Generator/Fold.cs
+++ b/Generators/SuperLinq.Generator/Fold.cs
@@ -1,6 +1,7 @@
-﻿using System.Globalization;
-using System.Text;
+﻿using System.Text;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Scriban;
 
 namespace SuperLinq;
 
@@ -8,67 +9,16 @@ internal static class Fold
 {
 	public static SourceText Generate()
 	{
-		var sb = new StringBuilder();
-		sb.Append(@"
-namespace SuperLinq;
+		var template = Template.Parse(ThisAssembly.Resources.Fold.Text);
+		var output = template.Render(ArgumentNames.Instance);
 
-public static partial class SuperEnumerable
-{");
+		// Apply formatting since indenting isn't that nice in Scriban when rendering nested 
+		// structures via functions.
+		output = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseCompilationUnit(output)
+			.NormalizeWhitespace()
+			.GetText()
+			.ToString();
 
-		var overloads =
-			from i in Enumerable.Range(1, 16)
-			let istr = i.ToString(CultureInfo.InvariantCulture)
-			select new
-			{
-				Ts = string.Join(", ", Enumerable.Repeat("T", i)),
-				Count = i,
-				CountElements = istr + " " + (i == 1 ? "element" : "elements"),
-				CountArg = istr,
-				FolderArgs = "folder" + istr + ": folder",
-			};
-
-		foreach (var e in overloads)
-		{
-			sb.Append($@"
-    /// <summary>
-    /// Returns the result of applying a function to a sequence of {e.CountElements}.
-    /// </summary>
-    /// <remarks>
-    /// This operator uses immediate execution and effectively buffers
-    /// as many items of the source sequence as necessary.
-    /// </remarks>
-    /// <typeparam name=""T"">Type of element in the source sequence</typeparam>
-    /// <typeparam name=""TResult"">Type of the result</typeparam>
-    /// <param name=""source"">The sequence of items to fold.</param>
-    /// <param name=""folder"">Function to apply to the elements in the sequence.</param>
-    /// <returns>The folded value returned by <paramref name=""folder""/>.</returns>
-    /// <exception cref=""ArgumentNullException""><paramref name=""source""/> is null</exception>
-    /// <exception cref=""ArgumentNullException""><paramref name=""folder""/> is null</exception>
-    /// <exception cref=""InvalidOperationException""><paramref name=""source""/> does not contain exactly {e.CountElements}.</exception>
-    public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<{e.Ts}, TResult> folder)
-    {{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(folder);
-
-		var elements = source.Take({e.CountArg} + 1).ToList();
-		if (elements.Count != {e.CountArg})
-			ThrowHelper.ThrowInvalidOperationException(
-				$""Sequence contained an incorrect number of elements. (Expected: {e.CountArg}, Actual: {{elements.Count}})"");
-
-		return folder(");
-
-			for (var i = 0; i < e.Count; i++)
-				sb.Append($@"
-			elements[{i}]{(i == e.Count - 1 ? "" : ",")}");
-
-			sb.Append(@"
-		);
-	}");
-		}
-
-		sb.Append(@"
-}");
-
-		return SourceText.From(sb.ToString(), Encoding.UTF8);
+		return SourceText.From(output, Encoding.UTF8);
 	}
 }

--- a/Generators/SuperLinq.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Generator/Fold.sbntxt
@@ -14,22 +14,22 @@ public static partial class SuperEnumerable
     /// <param name="source">The sequence of items to fold.</param>
     /// <param name="folder">Function to apply to the elements in the sequence.</param>
     /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="folder"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="global::System.ArgumentNullException"><paramref name="source"/> or <paramref name="folder"/> is null.</exception>
+    /// <exception cref="global::System.InvalidOperationException">
 	/// <paramref name="source"/> does not contain exactly {{$i}} element{{if $i != 1}}s{{end}}.
 	/// </exception>
-    public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<
+    public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<
 		{{~ for $j in 1..$i ~}}
 		T,
 		{{~ end ~}}
 		TResult> folder)
     {
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(folder);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
 
 		var elements = source.Take({{$i}} + 1).ToList();
 		if (elements.Count != {{$i}})
-			ThrowHelper.ThrowInvalidOperationException(
+			global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
 				$"Sequence contained an incorrect number of elements. (Expected: {{$i}}, Actual: {elements.Count})");
 
 		return folder(

--- a/Generators/SuperLinq.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Generator/Fold.sbntxt
@@ -34,7 +34,7 @@ public static partial class SuperEnumerable
 
 		return folder(
 			{{~ for $j in 1..$i ~}}
-			elements[{{$j}}]{{ if !for.last }},{{ end }}
+			elements[{{$j-1}}]{{ if !for.last }},{{ end }}
 			{{~ end ~}}
 		);
 	}

--- a/Generators/SuperLinq.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Generator/Fold.sbntxt
@@ -1,0 +1,42 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	{{~ for $i in 1..16 ~}}
+    /// <summary>
+    /// Returns the result of applying a function to a sequence of {{$i}} element{{if $i != 1}}s{{end}}.
+    /// </summary>
+    /// <remarks>
+    /// This operator uses immediate execution and buffers as many items of the source sequence as necessary.
+    /// </remarks>
+    /// <typeparam name="T">Type of element in the source sequence</typeparam>
+    /// <typeparam name="TResult">Type of the result</typeparam>
+    /// <param name="source">The sequence of items to fold.</param>
+    /// <param name="folder">Function to apply to the elements in the sequence.</param>
+    /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="folder"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+	/// <paramref name="source"/> does not contain exactly {{$i}} element{{if $i != 1}}s{{end}}.
+	/// </exception>
+    public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<
+		{{~ for $j in 1..$i ~}}
+		T,
+		{{~ end ~}}
+		TResult> folder)
+    {
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(folder);
+
+		var elements = source.Take({{$i}} + 1).ToList();
+		if (elements.Count != {{$i}})
+			ThrowHelper.ThrowInvalidOperationException(
+				$"Sequence contained an incorrect number of elements. (Expected: {{$i}}, Actual: {elements.Count})");
+
+		return folder(
+			{{~ for $j in 1..$i ~}}
+			elements[{{$j}}]{{ if !for.last }},{{ end }}
+			{{~ end ~}}
+		);
+	}
+	{{ end ~}}
+}

--- a/Generators/SuperLinq.Generator/SuperLinq.Generator.csproj
+++ b/Generators/SuperLinq.Generator/SuperLinq.Generator.csproj
@@ -5,12 +5,30 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<IsPackable>false</IsPackable>
 		<IsRoslynComponent>true</IsRoslynComponent>
+
+		<!-- Avoid figuring out an actual dependency on Scriban -->
+		<PackageScribanIncludeSource>true</PackageScribanIncludeSource>
+
+		<!-- Scriban fails a lot of things in latest-all... -->
+		<AnalysisLevel>latest-default</AnalysisLevel>
+
+		<!-- Analyzer checks-->
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+		<!-- Other things to turn off -->
+		<NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+		<PackageReference Include="Scriban" Version="5.5.2" IncludeAssets="build" />
+		<PackageReference Include="ThisAssembly.Resources" Version="1.2.0-rc" PrivateAssets="all" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="*.sbntxt" Kind="Text" />
+	</ItemGroup>
+
 </Project>
 

--- a/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
+++ b/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
@@ -8,23 +8,23 @@ public static partial class SuperEnumerable
 	/// a given delimiter.
 	/// </summary>
 	/// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-	/// simple ToString() conversion.</param>
+	/// simple <c>ToString()</c> conversion.</param>
 	/// <param name="delimiter">The delimiter to inject between elements.</param>
 	/// <returns>
 	/// A string that consists of the elements in <paramref name="source"/>
 	/// delimited by <paramref name="delimiter"/>. If the source sequence
 	/// is empty, the method returns an empty string.
 	/// </returns>
-	/// <exception cref="ArgumentNullException">
+	/// <exception cref="global::System.ArgumentNullException">
 	/// <paramref name="source"/> or <paramref name="delimiter"/> is <see langword="null"/>.
 	/// </exception>
 	/// <remarks>
 	/// This operator uses immediate execution and effectively buffers the sequence.
 	/// </remarks>
-	public static global::System.String ToDelimitedString(this IEnumerable<{{t}}> source, global::System.String delimiter)
+	public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<{{t}}> source, global::System.String delimiter)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(delimiter);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
+		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
 		return ToDelimitedStringImpl(source, delimiter, Builder);
 
 		static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, {{t}} e) => sb.Append(e);

--- a/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
+++ b/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
@@ -1,0 +1,33 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	{{~ for t in types ~}}
+	/// <summary>
+	/// Creates a delimited string from a sequence of values and
+	/// a given delimiter.
+	/// </summary>
+	/// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+	/// simple ToString() conversion.</param>
+	/// <param name="delimiter">The delimiter to inject between elements.</param>
+	/// <returns>
+	/// A string that consists of the elements in <paramref name="source"/>
+	/// delimited by <paramref name="delimiter"/>. If the source sequence
+	/// is empty, the method returns an empty string.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="source"/> or <paramref name="delimiter"/> is <see langword="null"/>.
+	/// </exception>
+	/// <remarks>
+	/// This operator uses immediate execution and effectively buffers the sequence.
+	/// </remarks>
+	public static global::System.String ToDelimitedString(this IEnumerable<{{t}}> source, global::System.String delimiter)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(delimiter);
+		return ToDelimitedStringImpl(source, delimiter, Builder);
+
+		static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, {{t}} e) => sb.Append(e);
+    }
+	{{ end ~}}
+}

--- a/Tests/SuperLinq.Test/AggregateTest.cs
+++ b/Tests/SuperLinq.Test/AggregateTest.cs
@@ -23,6 +23,7 @@ public class AggregateTest
 		from m in typeof(SuperEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
 		where m.Name == nameof(SuperEnumerable.Aggregate)
 		   && m.IsGenericMethodDefinition
+		where !m.ReturnType.Name.Contains(nameof(ValueTuple))
 		select new
 		{
 			Source = source,


### PR DESCRIPTION
This PR updates the source generators to use Scriban text templating instead of string interpolation. It should be easier to read the underlying code and update as necessary as text templates.

This PR also:
* Adds a `ValueTuple` version of the `Aggregate` operator
* Adds exception documentation to some of the operators.

Fixes #152