### PR TITLE
Address `Window` Issues

### DIFF
--- a/Tests/SuperLinq.Test/WindowLeftTest.cs
+++ b/Tests/SuperLinq.Test/WindowLeftTest.cs
@@ -80,14 +80,14 @@ public class WindowLeftTest
 	{
 		using var sequence = Seq<int>().AsTestingSequence();
 
-		var result = sequence.WindowLeft(5);
+		var result = sequence.WindowLeft(5).ToList();
 		Assert.Empty(result);
 	}
 
 	[Fact]
 	public void WindowLeftBufferEmptySequence()
 	{
-		using var sequence = Seq<int>().AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Seq<int>().AsTestingSequence();
 
 		var result = sequence.WindowLeft(5, SuperEnumerable.Identity);
 		Assert.Empty(result);
@@ -128,7 +128,7 @@ public class WindowLeftTest
 	[Fact]
 	public void WindowLeftWithWindowSizeLargerThanSequence()
 	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
 
 		using var reader = sequence.WindowLeft(10).Read();
 		reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
@@ -142,7 +142,7 @@ public class WindowLeftTest
 	[Fact]
 	public void WindowLeftBufferWithWindowSizeLargerThanSequence()
 	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
 
 		using var reader = sequence.WindowLeft(10, a => string.Join("", a)).Read();
 		Assert.Equal("12345", reader.Read());

--- a/Tests/SuperLinq.Test/WindowRightTest.cs
+++ b/Tests/SuperLinq.Test/WindowRightTest.cs
@@ -87,7 +87,7 @@ public class WindowRightTest
 	[Fact]
 	public void WindowRightBufferEmptySequence()
 	{
-		using var sequence = Seq<int>().AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Seq<int>().AsTestingSequence();
 
 		var result = sequence.WindowRight(5, SuperEnumerable.Identity);
 		Assert.Empty(result);
@@ -128,7 +128,7 @@ public class WindowRightTest
 	[Fact]
 	public void WindowRightWithWindowSizeLargerThanSequence()
 	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
 
 		using var reader = sequence.WindowRight(10).Read();
 		reader.Read().AssertSequenceEqual(1);
@@ -142,7 +142,7 @@ public class WindowRightTest
 	[Fact]
 	public void WindowRightBufferWithWindowSizeLargerThanSequence()
 	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
 
 		using var reader = sequence.WindowRight(10, a => string.Join("", a)).Read();
 		Assert.Equal("1", reader.Read());

--- a/Tests/SuperLinq.Test/WindowTest.cs
+++ b/Tests/SuperLinq.Test/WindowTest.cs
@@ -96,7 +96,7 @@ public class WindowTests
 	[Fact]
 	public void TestWindowBufferEmptySequence()
 	{
-		using var sequence = Seq<int>().AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var sequence = Seq<int>().AsTestingSequence();
 
 		var result = sequence.Window(5, SuperEnumerable.Identity);
 		Assert.Empty(result);
@@ -142,7 +142,7 @@ public class WindowTests
 	public void TestWindowLargerThanSequence()
 	{
 		var sequence = Enumerable.Range(1, 10);
-		using var xs = sequence.AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var xs = sequence.AsTestingSequence();
 		var result = xs.Window(11).ToList();
 
 		// there should only be one window whose contents is the same
@@ -154,7 +154,7 @@ public class WindowTests
 	public void TestWindowBufferLargerThanSequence()
 	{
 		var sequence = Enumerable.Range(1, 10);
-		using var xs = sequence.AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
+		using var xs = sequence.AsTestingSequence();
 		var result = xs.Window(11, l => l.Sum());
 
 		// there should only be one window whose contents is the same


### PR DESCRIPTION
This PR addresses issues with the core `WindowImpl` functionality that caused it to rely on calling `MoveNext` after the enumeration was complete. These issues were realized with the fixes introduced in #156 for using `TestingSequence`. 

Fixes #158 