### PR TITLE
Update `CopyTo` Return Value

### DIFF
--- a/Source/SuperLinq.Async/CopyTo.cs
+++ b/Source/SuperLinq.Async/CopyTo.cs
@@ -11,6 +11,7 @@ public static partial class AsyncSuperEnumerable
 	/// <param name="list">The list that is the destination of the elements copied from <paramref
 	/// name="source"/>.</param>
 	/// <param name="cancellationToken">The <see cref="CancellationToken"/> in use.</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -21,7 +22,7 @@ public static partial class AsyncSuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static ValueTask CopyTo<TSource>(this IAsyncEnumerable<TSource> source, IList<TSource> list, CancellationToken cancellationToken = default)
+	public static ValueTask<int> CopyTo<TSource>(this IAsyncEnumerable<TSource> source, IList<TSource> list, CancellationToken cancellationToken = default)
 	{
 		return source.CopyTo(list, 0, cancellationToken);
 	}
@@ -36,6 +37,7 @@ public static partial class AsyncSuperEnumerable
 	/// name="source"/>.</param>
 	/// <param name="index">The position in <paramref name="list"/> at which to start copying data</param>
 	/// <param name="cancellationToken">The <see cref="CancellationToken"/> in use.</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -47,7 +49,7 @@ public static partial class AsyncSuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static async ValueTask CopyTo<TSource>(this IAsyncEnumerable<TSource> source, IList<TSource> list, int index, CancellationToken cancellationToken = default)
+	public static async ValueTask<int> CopyTo<TSource>(this IAsyncEnumerable<TSource> source, IList<TSource> list, int index, CancellationToken cancellationToken = default)
 	{
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(list);
@@ -58,6 +60,8 @@ public static partial class AsyncSuperEnumerable
 			var i = index;
 			await foreach (var el in source.WithCancellation(cancellationToken).ConfigureAwait(false))
 				array[i++] = el;
+
+			return i - index;
 		}
 		else
 		{
@@ -70,6 +74,8 @@ public static partial class AsyncSuperEnumerable
 					list.Add(el);
 				i++;
 			}
+
+			return i - index;
 		}
 	}
 }

--- a/Source/SuperLinq/CopyTo.cs
+++ b/Source/SuperLinq/CopyTo.cs
@@ -12,6 +12,7 @@ public static partial class SuperEnumerable
 	/// <param name="source">The source sequence.</param>
 	/// <param name="span">The span that is the destination of the elements copied from <paramref
 	/// name="source"/>.</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentException"><paramref name="span"/> is not long enough to hold the data from
 	/// sequence.</exception>
@@ -25,13 +26,14 @@ public static partial class SuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static void CopyTo<TSource>(this IEnumerable<TSource> source, Span<TSource> span)
+	public static int CopyTo<TSource>(this IEnumerable<TSource> source, Span<TSource> span)
 	{
 		Guard.IsNotNull(source);
 
 		if (source is TSource[] arr)
 		{
 			arr.AsSpan().CopyTo(span);
+			return arr.Length;
 		}
 		else if (TryGetCollectionCount(source, out var n))
 		{
@@ -40,9 +42,9 @@ public static partial class SuperEnumerable
 
 			var i = 0;
 			foreach (var el in source)
-			{
 				span[i++] = el;
-			}
+
+			return i;
 		}
 		else
 		{
@@ -54,6 +56,8 @@ public static partial class SuperEnumerable
 
 				span[i++] = el;
 			}
+
+			return i;
 		}
 	}
 
@@ -65,6 +69,7 @@ public static partial class SuperEnumerable
 	/// <param name="source">The source sequence.</param>
 	/// <param name="array">The span that is the destination of the elements copied from <paramref
 	/// name="source"/>.</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentException"><paramref name="array"/> is not long enough to hold the data from
 	/// sequence.</exception>
@@ -78,23 +83,25 @@ public static partial class SuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static void CopyTo<TSource>(this IEnumerable<TSource> source, TSource[] array)
+	public static int CopyTo<TSource>(this IEnumerable<TSource> source, TSource[] array)
 	{
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(array);
 
-		CopyTo(source, array, 0);
+		return CopyTo(source, array, 0);
 	}
 
-	private static void CopyTo<TSource>(IEnumerable<TSource> source, TSource[] array, int index)
+	private static int CopyTo<TSource>(IEnumerable<TSource> source, TSource[] array, int index)
 	{
 		if (source is TSource[] arr)
 		{
 			arr.CopyTo(array, index);
+			return arr.Length;
 		}
 		else if (source is ICollection<TSource> coll)
 		{
 			coll.CopyTo(array, index);
+			return coll.Count;
 		}
 		else if (TryGetCollectionCount(source, out var n))
 		{
@@ -103,9 +110,9 @@ public static partial class SuperEnumerable
 
 			var i = index;
 			foreach (var el in source)
-			{
 				array[i++] = el;
-			}
+
+			return i - index;
 		}
 		else
 		{
@@ -117,6 +124,8 @@ public static partial class SuperEnumerable
 
 				array[i++] = el;
 			}
+
+			return i - index;
 		}
 	}
 
@@ -128,6 +137,7 @@ public static partial class SuperEnumerable
 	/// <param name="source">The source sequence.</param>
 	/// <param name="list">The list that is the destination of the elements copied from <paramref
 	/// name="source"/>.</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -138,9 +148,9 @@ public static partial class SuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static void CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list)
+	public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list)
 	{
-		source.CopyTo(list, 0);
+		return source.CopyTo(list, 0);
 	}
 
 	/// <summary>
@@ -152,6 +162,7 @@ public static partial class SuperEnumerable
 	/// <param name="list">The list that is the destination of the elements copied from <paramref
 	/// name="source"/>.</param>
 	/// <param name="index">The position in <paramref name="list"/> at which to start copying data</param>
+	/// <returns>The number of elements actually copied.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -163,7 +174,7 @@ public static partial class SuperEnumerable
 	/// This operator executes immediately.
 	/// </para>
 	/// </remarks>
-	public static void CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list, int index)
+	public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list, int index)
 	{
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(list);
@@ -171,7 +182,7 @@ public static partial class SuperEnumerable
 
 		if (list is TSource[] array)
 		{
-			CopyTo(source, array, index);
+			return CopyTo(source, array, index);
 		}
 		else
 		{
@@ -192,6 +203,8 @@ public static partial class SuperEnumerable
 					list.Add(el);
 				i++;
 			}
+
+			return i - index;
 		}
 	}
 }

--- a/Tests/SuperLinq.Async.Test/CopyToTest.cs
+++ b/Tests/SuperLinq.Async.Test/CopyToTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace Test.Async;
 
@@ -42,11 +41,13 @@ public class CopyToTest
 	{
 		var array = new int[4];
 
-		await AsyncSeq(1).CopyTo(array);
+		var cnt = await AsyncSeq(1).CopyTo(array);
 		array.AssertSequenceEqual(1, 0, 0, 0);
+		Assert.Equal(1, cnt);
 
-		await AsyncSeq(2).CopyTo(array, 1);
+		cnt = await AsyncSeq(2).CopyTo(array, 1);
 		array.AssertSequenceEqual(1, 2, 0, 0);
+		Assert.Equal(1, cnt);
 	}
 
 	[Fact]
@@ -54,14 +55,17 @@ public class CopyToTest
 	{
 		var list = new List<int>();
 
-		await AsyncSeq(1).CopyTo(list);
+		var cnt = await AsyncSeq(1).CopyTo(list);
 		list.AssertSequenceEqual(1);
+		Assert.Equal(1, cnt);
 
-		await AsyncSeq(2).CopyTo(list, 1);
+		cnt = await AsyncSeq(2).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 2);
+		Assert.Equal(1, cnt);
 
-		await AsyncSeq(3, 4).CopyTo(list, 1);
+		cnt = await AsyncSeq(3, 4).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 3, 4);
+		Assert.Equal(2, cnt);
 	}
 
 	[Fact]
@@ -69,13 +73,16 @@ public class CopyToTest
 	{
 		var list = new Collection<int>();
 
-		await AsyncSeq(1).CopyTo(list);
+		var cnt = await AsyncSeq(1).CopyTo(list);
 		list.AssertSequenceEqual(1);
+		Assert.Equal(1, cnt);
 
-		await AsyncSeq(2).CopyTo(list, 1);
+		cnt = await AsyncSeq(2).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 2);
+		Assert.Equal(1, cnt);
 
-		await AsyncSeq(3, 4).CopyTo(list, 1);
+		cnt = await AsyncSeq(3, 4).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 3, 4);
+		Assert.Equal(2, cnt);
 	}
 }

--- a/Tests/SuperLinq.Test/CopyToTest.cs
+++ b/Tests/SuperLinq.Test/CopyToTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace Test;
 
@@ -77,14 +76,17 @@ public class CopyToTest
 	{
 		Span<int> span = stackalloc int[4];
 
-		Seq(1).CopyTo(span);
+		var cnt = Seq(1).CopyTo(span);
 		span.ToArray().AssertSequenceEqual(1, 0, 0, 0);
+		Assert.Equal(1, cnt);
 
-		new List<int> { 2 }.AsEnumerable().CopyTo(span[1..]);
+		cnt = new List<int> { 2 }.AsEnumerable().CopyTo(span[1..]);
 		span.ToArray().AssertSequenceEqual(1, 2, 0, 0);
+		Assert.Equal(1, cnt);
 
-		Enumerable.Range(3, 1).CopyTo(span[2..]);
-		span.ToArray().AssertSequenceEqual(1, 2, 3, 0);
+		cnt = Enumerable.Range(3, 2).CopyTo(span[2..]);
+		span.ToArray().AssertSequenceEqual(1, 2, 3, 4);
+		Assert.Equal(2, cnt);
 	}
 
 	[Fact]
@@ -92,17 +94,21 @@ public class CopyToTest
 	{
 		var array = new int[4];
 
-		Seq(1).CopyTo(array);
+		var cnt = Seq(1).CopyTo(array);
 		array.AssertSequenceEqual(1, 0, 0, 0);
+		Assert.Equal(1, cnt);
 
-		new List<int> { 2 }.AsEnumerable().CopyTo(array, 1);
+		cnt = new List<int> { 2 }.AsEnumerable().CopyTo(array, 1);
 		array.AssertSequenceEqual(1, 2, 0, 0);
+		Assert.Equal(1, cnt);
 
-		new List<int> { 3 }.AsReadOnly().AsEnumerable().CopyTo(array, 2);
+		cnt = new List<int> { 3 }.AsReadOnly().AsEnumerable().CopyTo(array, 2);
 		array.AssertSequenceEqual(1, 2, 3, 0);
+		Assert.Equal(1, cnt);
 
-		Enumerable.Range(4, 1).CopyTo(array, 3);
+		cnt = Enumerable.Range(4, 1).CopyTo(array, 3);
 		array.AssertSequenceEqual(1, 2, 3, 4);
+		Assert.Equal(1, cnt);
 	}
 
 	[Fact]
@@ -110,14 +116,17 @@ public class CopyToTest
 	{
 		var list = new List<int>();
 
-		Seq(1).CopyTo(list);
+		var cnt = Seq(1).CopyTo(list);
 		list.AssertSequenceEqual(1);
+		Assert.Equal(1, cnt);
 
-		Seq(2).CopyTo(list, 1);
+		cnt = Seq(2).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 2);
+		Assert.Equal(1, cnt);
 
-		Seq(3, 4).CopyTo(list, 1);
+		cnt = Seq(3, 4).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 3, 4);
+		Assert.Equal(2, cnt);
 	}
 
 	[Fact]
@@ -125,13 +134,16 @@ public class CopyToTest
 	{
 		var list = new Collection<int>();
 
-		Seq(1).CopyTo(list);
+		var cnt = Seq(1).CopyTo(list);
 		list.AssertSequenceEqual(1);
+		Assert.Equal(1, cnt);
 
-		Seq(2).CopyTo(list, 1);
+		cnt = Seq(2).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 2);
+		Assert.Equal(1, cnt);
 
-		Seq(3, 4).CopyTo(list, 1);
+		cnt = Seq(3, 4).CopyTo(list, 1);
 		list.AssertSequenceEqual(1, 3, 4);
+		Assert.Equal(2, cnt);
 	}
 }


### PR DESCRIPTION
This PR updates the `CopyTo` operator to return how many items were actually copied. The `Array` and `Collection` implementations of `CopyTo` in corelib do not return this value, because the value is known from the collection size. However, when copying sequences, this value may not be known due to the nature of `IEnumerable<>`.

Fixes #172 