### PR TITLE
Add `int` form of `Replace` operator

### DIFF
--- a/Source/SuperLinq.Async/Replace.cs
+++ b/Source/SuperLinq.Async/Replace.cs
@@ -3,17 +3,49 @@
 public static partial class AsyncSuperEnumerable
 {
 	/// <summary>
-	/// Replaces a single value in a sequence at a specified index
-	/// with the given replacement value.
+	/// Replaces a single value in a sequence at a specified index with the given replacement value.
 	/// </summary>
 	/// <typeparam name="TSource">Type of item in the sequence</typeparam>
 	/// <param name="source">The source sequence.</param>
 	/// <param name="index">The index of the value to replace.</param>
 	/// <param name="value">The replacement value to use at <paramref name="index"/>.</param>
 	/// <returns>
-	/// A sequence with the original values from <paramref name="source"/>,
-	/// except for position <paramref name="index"/> which has the value
-	/// <paramref name="value"/>.
+	/// A sequence with the original values from <paramref name="source"/>, except for position <paramref name="index"/>
+	/// which has the value <paramref name="value"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This operator evaluates in a deferred and streaming manner.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Replace<TSource>(
+		this IAsyncEnumerable<TSource> source,
+		int index,
+		TSource value)
+	{
+		Guard.IsNotNull(source);
+
+		return _(source, value, index);
+
+		static async IAsyncEnumerable<TSource> _(
+			IAsyncEnumerable<TSource> source, TSource value, int index,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			var i = 0;
+			await foreach (var e in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return i++ == index ? value : e;
+		}
+	}
+
+	/// <summary>
+	/// Replaces a single value in a sequence at a specified index with the given replacement value.
+	/// </summary>
+	/// <typeparam name="TSource">Type of item in the sequence</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="index">The index of the value to replace.</param>
+	/// <param name="value">The replacement value to use at <paramref name="index"/>.</param>
+	/// <returns>
+	/// A sequence with the original values from <paramref name="source"/>, except for position <paramref name="index"/>
+	/// which has the value <paramref name="value"/>.
 	/// </returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <remarks>

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -3,17 +3,50 @@
 public static partial class SuperEnumerable
 {
 	/// <summary>
-	/// Replaces a single value in a sequence at a specified index
-	/// with the given replacement value.
+	/// Replaces a single value in a sequence at a specified index with the given replacement value.
 	/// </summary>
 	/// <typeparam name="TSource">Type of item in the sequence</typeparam>
 	/// <param name="source">The source sequence.</param>
 	/// <param name="index">The index of the value to replace.</param>
 	/// <param name="value">The replacement value to use at <paramref name="index"/>.</param>
 	/// <returns>
-	/// A sequence with the original values from <paramref name="source"/>,
-	/// except for position <paramref name="index"/> which has the value
-	/// <paramref name="value"/>.
+	/// A sequence with the original values from <paramref name="source"/>, except for position <paramref name="index"/>
+	/// which has the value <paramref name="value"/>.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This operator evaluates in a deferred and streaming manner.
+	/// </remarks>
+	public static IEnumerable<TSource> Replace<TSource>(
+		this IEnumerable<TSource> source,
+		int index,
+		TSource value)
+	{
+		Guard.IsNotNull(source);
+
+		return _(source, index, value);
+
+		static IEnumerable<TSource> _(
+			IEnumerable<TSource> source,
+			int index,
+			TSource value)
+		{
+			var i = 0;
+			foreach (var e in source)
+				yield return i++ == index ? value : e;
+		}
+	}
+
+	/// <summary>
+	/// Replaces a single value in a sequence at a specified index with the given replacement value.
+	/// </summary>
+	/// <typeparam name="TSource">Type of item in the sequence</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="index">The index of the value to replace.</param>
+	/// <param name="value">The replacement value to use at <paramref name="index"/>.</param>
+	/// <returns>
+	/// A sequence with the original values from <paramref name="source"/>, except for position <paramref name="index"/>
+	/// which has the value <paramref name="value"/>.
 	/// </returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -30,6 +63,12 @@ public static partial class SuperEnumerable
 
 		static IEnumerable<TSource> _(IEnumerable<TSource> source, TSource value, Index index)
 		{
+			if (index.IsFromEnd
+				&& source.TryGetCollectionCount(out var count))
+			{
+				index = index.GetOffset(count);
+			}
+
 			if (!index.IsFromEnd)
 			{
 				var cnt = index.Value;

--- a/Tests/SuperLinq.Async.Test/ReplaceTest.cs
+++ b/Tests/SuperLinq.Async.Test/ReplaceTest.cs
@@ -6,15 +6,18 @@ public class ReplaceTest
 	public void ReplaceIsLazy()
 	{
 		new AsyncBreakingSequence<int>().Replace(0, 10);
+		new AsyncBreakingSequence<int>().Replace(new Index(0), 10);
 		new AsyncBreakingSequence<int>().Replace(^0, 10);
 	}
 
 	[Fact]
 	public async Task ReplaceEmptySequence()
 	{
-		await using var seq = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 4);
+		await using var seq = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 6);
 		await seq.Replace(0, 10).AssertSequenceEqual();
 		await seq.Replace(10, 10).AssertSequenceEqual();
+		await seq.Replace(new Index(0), 10).AssertSequenceEqual();
+		await seq.Replace(new Index(10), 10).AssertSequenceEqual();
 		await seq.Replace(^0, 10).AssertSequenceEqual();
 		await seq.Replace(^10, 10).AssertSequenceEqual();
 	}
@@ -23,11 +26,23 @@ public class ReplaceTest
 		Enumerable.Range(0, 10).Select(i => new object[] { i, });
 
 	[Theory, MemberData(nameof(Indices))]
-	public async Task ReplaceStartIndex(int index)
+	public async Task ReplaceIntIndex(int index)
 	{
 		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
 
 		var result = seq.Replace(index, 30);
+		await result.AssertSequenceEqual(
+			Enumerable.Range(1, index)
+				.Append(30)
+				.Concat(Enumerable.Range(index + 2, 9 - index)));
+	}
+
+	[Theory, MemberData(nameof(Indices))]
+	public async Task ReplaceStartIndex(int index)
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Replace(new Index(index), 30);
 		await result.AssertSequenceEqual(
 			Enumerable.Range(1, index)
 				.Append(30)
@@ -47,11 +62,20 @@ public class ReplaceTest
 	}
 
 	[Fact]
-	public async Task ReplaceStartIndexPastSequenceLength()
+	public async Task ReplaceIntIndexPastSequenceLength()
 	{
 		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
 
 		var result = seq.Replace(10, 30);
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public async Task ReplaceStartIndexPastSequenceLength()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Replace(new Index(10), 30);
 		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
 	}
 

--- a/Tests/SuperLinq.Test/ReplaceTest.cs
+++ b/Tests/SuperLinq.Test/ReplaceTest.cs
@@ -6,15 +6,18 @@ public class ReplaceTest
 	public void ReplaceIsLazy()
 	{
 		new BreakingSequence<int>().Replace(0, 10);
+		new BreakingSequence<int>().Replace(new Index(10), 10);
 		new BreakingSequence<int>().Replace(^0, 10);
 	}
 
 	[Fact]
 	public void ReplaceEmptySequence()
 	{
-		using var seq = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 4);
+		using var seq = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 6);
 		seq.Replace(0, 10).AssertSequenceEqual();
 		seq.Replace(10, 10).AssertSequenceEqual();
+		seq.Replace(new Index(0), 10).AssertSequenceEqual();
+		seq.Replace(new Index(10), 10).AssertSequenceEqual();
 		seq.Replace(^0, 10).AssertSequenceEqual();
 		seq.Replace(^10, 10).AssertSequenceEqual();
 	}
@@ -23,11 +26,23 @@ public class ReplaceTest
 		Enumerable.Range(0, 10).Select(i => new object[] { i, });
 
 	[Theory, MemberData(nameof(Indices))]
-	public void ReplaceStartIndex(int index)
+	public void ReplaceIntIndex(int index)
 	{
 		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
 
 		var result = seq.Replace(index, 30);
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, index)
+				.Append(30)
+				.Concat(Enumerable.Range(index + 2, 9 - index)));
+	}
+
+	[Theory, MemberData(nameof(Indices))]
+	public void ReplaceStartIndex(int index)
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Replace(new Index(index), 30);
 		result.AssertSequenceEqual(
 			Enumerable.Range(1, index)
 				.Append(30)
@@ -46,12 +61,34 @@ public class ReplaceTest
 				.Concat(Enumerable.Range(11 - index, index)));
 	}
 
+	[Theory, MemberData(nameof(Indices))]
+	public void ReplaceEndIndexWithCollection(int index)
+	{
+		var seq = Enumerable.Range(1, 10).ToArray();
+
+		// offset by one because 0..9 is less useful than 1..10
+		var result = seq.Replace(^(index + 1), 30);
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 9 - index)
+				.Append(30)
+				.Concat(Enumerable.Range(11 - index, index)));
+	}
+
+	[Fact]
+	public void ReplaceIntIndexPastSequenceLength()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Replace(10, 30);
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
 	[Fact]
 	public void ReplaceStartIndexPastSequenceLength()
 	{
 		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
 
-		var result = seq.Replace(10, 30);
+		var result = seq.Replace(new Index(10), 30);
 		result.AssertSequenceEqual(Enumerable.Range(1, 10));
 	}
 


### PR DESCRIPTION
This PR adds an `int` version of the `Replace` operator and updates the `Index` form to use `TryGetCollectionCount` for improvement when possible.

Fixes #183 
Fixes #185 