### PR TITLE
Restore `AssertCount` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The documentation for the SuperLinq.Async methods can be found [here](Source/Sup
 |-|:-:|:-:|
 | Acquire                         | ❌<br/>(Removed[^1]) | ❌ |
 | AggregateRight				  | ✔️ | ✔️ |
+| AssertCount					  | ✔️ | ✔️ |
 | AtLeast						  | ✔️ | ✔️ |
 | AtMost						  | ✔️ | ✔️ |
 | Backsert						  | ⚠️[^2] | ❌[^2] |

--- a/Source/SuperLinq.Async/AssertCount.cs
+++ b/Source/SuperLinq.Async/AssertCount.cs
@@ -1,0 +1,41 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Asserts that a source sequence contains a given count of elements.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Count to assert.</param>
+	/// <returns>
+	/// Returns the original sequence as long it is contains the number of elements specified by <paramref
+	/// name="count"/>. Otherwise it throws <see cref="ArgumentException" />.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than <c>0</c>.</exception>
+	/// <exception cref="ArgumentException"><paramref name="source"/> has a length different than <paramref
+	/// name="count"/>.</exception>
+	/// <remarks>
+	/// This operator uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> AssertCount<TSource>(this IAsyncEnumerable<TSource> source, int count)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(count, 0);
+
+		return _(source, count);
+
+		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			var c = 0;
+			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+			{
+				if (++c > count)
+					break;
+				yield return item;
+			}
+			Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+		}
+	}
+}

--- a/Source/SuperLinq.Async/SuperLinq.Async.csproj
+++ b/Source/SuperLinq.Async/SuperLinq.Async.csproj
@@ -28,6 +28,7 @@
 			This project enhances Async LINQ to Objects with the following methods:
 
 			- AggregateRight
+			- AssertCount
 			- AtLeast
 			- AtMost
 			- Choose

--- a/Source/SuperLinq.Async/readme.md
+++ b/Source/SuperLinq.Async/readme.md
@@ -32,6 +32,10 @@ This operator is the right-associative version of the Aggregate LINQ operator.
 
 This method has 9 overloads.
 
+### AssertCount
+
+Asserts that a source sequence contains a given count of elements.
+
 ### AtLeast
 
 Determines whether or not the number of elements in the sequence is greater

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -1,0 +1,51 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Asserts that a source sequence contains a given count of elements.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Count to assert.</param>
+	/// <returns>
+	/// Returns the original sequence as long it is contains the number of elements specified by <paramref
+	/// name="count"/>. Otherwise it throws <see cref="ArgumentException" />.
+	/// </returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than <c>0</c>.</exception>
+	/// <exception cref="ArgumentException"><paramref name="source"/> has a length different than <paramref
+	/// name="count"/>.</exception>
+	/// <remarks>
+	/// This operator uses deferred execution and streams its results.
+	/// </remarks>
+	public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source, int count)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(count, 0);
+
+		return _(source, count);
+
+		static IEnumerable<TSource> _(IEnumerable<TSource> source, int count)
+		{
+			if (source.TryGetCollectionCount(out var c))
+			{
+				Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+
+				foreach (var item in source)
+					yield return item;
+			}
+			else
+			{
+				c = 0;
+				foreach (var item in source)
+				{
+					if (++c > count)
+						break;
+					yield return item;
+				}
+				Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+			}
+		}
+	}
+}

--- a/Source/SuperLinq/SuperLinq.csproj
+++ b/Source/SuperLinq/SuperLinq.csproj
@@ -28,6 +28,7 @@
 			This project enhances LINQ to Objects with the following methods:
 
 			- AggregateRight
+			- AssertCount
 			- AtLeast
 			- AtMost
 			- Cartesian

--- a/Source/SuperLinq/readme.md
+++ b/Source/SuperLinq/readme.md
@@ -139,6 +139,10 @@ This operator is the right-associative version of the Aggregate LINQ operator.
 
 This method has 3 overloads.
 
+### AssertCount
+
+Asserts that a source sequence contains a given count of elements.
+
 ### AtLeast
 
 Determines whether or not the number of elements in the sequence is greater

--- a/Tests/SuperLinq.Async.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Async.Test/AssertCountTest.cs
@@ -1,0 +1,40 @@
+﻿namespace Test.Async;
+
+public class AssertCountTest
+{
+	[Fact]
+	public void AssertCountIsLazy()
+	{
+		_ = new AsyncBreakingSequence<object>().AssertCount(0);
+	}
+
+	[Fact]
+	public void AssertCountNegativeCount()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>("count",
+			() => new AsyncBreakingSequence<int>().AssertCount(-1));
+	}
+
+	[Fact]
+	public async Task AssertCountSequenceWithMatchingLength()
+	{
+		await using var data = TestingSequence.Of("foo", "bar", "baz");
+		await data.AssertCount(3).Consume();
+	}
+
+	[Fact]
+	public async Task AssertCountShortSequence()
+	{
+		await using var data = TestingSequence.Of("foo", "bar", "baz");
+		await Assert.ThrowsAsync<ArgumentException>("source.Count()", async () =>
+			await data.AssertCount(4).Consume());
+	}
+
+	[Fact]
+	public async Task AssertCountLongSequence()
+	{
+		await using var data = TestingSequence.Of("foo", "bar", "baz");
+		await Assert.ThrowsAsync<ArgumentException>("source.Count()", async () =>
+			await data.AssertCount(2).Consume());
+	}
+}

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -1,0 +1,61 @@
+﻿namespace Test;
+
+public class AssertCountTest
+{
+	[Fact]
+	public void AssertCountIsLazy()
+	{
+		_ = new BreakingSequence<object>().AssertCount(0);
+	}
+
+	[Fact]
+	public void AssertCountNegativeCount()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>("count",
+			() => new BreakingSequence<int>().AssertCount(-1));
+	}
+
+	[Fact]
+	public void AssertCountSequenceWithMatchingLength()
+	{
+		var data = new[] { "foo", "bar", "baz" };
+		data.AssertCount(3).Consume();
+		using (var xs = data.AsTestingSequence())
+			xs.AssertCount(3).Consume();
+		using (var xs = new BreakingCollection<string>(data))
+			// expect a `TestException` as we try to enumerate the list
+			// but should _not_ get an `ArgumentException` as the 
+			// count is correct for the sequence
+			Assert.Throws<TestException>(
+				() => xs.AssertCount(3).Consume());
+	}
+
+	[Fact]
+	public void AssertCountShortSequence()
+	{
+		var data = new[] { "foo", "bar", "baz" };
+		foreach (var xs in data.ArrangeCollectionInlineDatas())
+			using (xs)
+				Assert.Throws<ArgumentException>("source.Count()",
+					() => xs.AssertCount(4).Consume());
+	}
+
+	[Fact]
+	public void AssertCountLongSequence()
+	{
+		var data = new[] { "foo", "bar", "baz" };
+		foreach (var xs in data.ArrangeCollectionInlineDatas())
+			using (xs)
+				Assert.Throws<ArgumentException>("source.Count()",
+					() => xs.AssertCount(2).Consume());
+	}
+
+	[Fact]
+	public void AssertCountUsesCollectionCountAtIterationTime()
+	{
+		var stack = new Stack<int>(Enumerable.Range(1, 3));
+		var result = stack.AssertCount(4);
+		stack.Push(4);
+		result.Consume();
+	}
+}


### PR DESCRIPTION
This PR restores the `AssertCount` operator, as originally written in MoreLinq. Two differences: a) it only restores the simple version of the operator; and b) it throws `ArgumentException` instead of `SequenceException`.