### PR TITLE
Update `Fold` to use `AssertCount`

### DIFF
--- a/Generators/SuperLinq.Async.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/Fold.sbntxt
@@ -29,10 +29,7 @@ public static partial class AsyncSuperEnumerable
 		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
 		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
 
-		var elements = await source.Take({{$i}} + 1).ToListAsync().ConfigureAwait(false);
-		if (elements.Count != {{$i}})
-			global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
-				$"Sequence contained an incorrect number of elements. (Expected: {{$i}}, Actual: {elements.Count})");
+		var elements = await source.AssertCount({{$i}}).ToListAsync().ConfigureAwait(false);
 
 		return folder(
 			{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Generator/Fold.sbntxt
@@ -29,10 +29,7 @@ public static partial class SuperEnumerable
 		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
 		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
 
-		var elements = source.Take({{$i}} + 1).ToList();
-		if (elements.Count != {{$i}})
-			global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
-				$"Sequence contained an incorrect number of elements. (Expected: {{$i}}, Actual: {elements.Count})");
+		var elements = source.AssertCount({{$i}}).ToList();
 
 		return folder(
 			{{~ for $j in 1..$i ~}}

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/Fold.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/Fold.g.cs
@@ -21,9 +21,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(1 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 1)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 1, Actual: {elements.Count})");
+        var elements = await source.AssertCount(1).ToListAsync().ConfigureAwait(false);
         return folder(elements[0]);
     }
 
@@ -46,9 +44,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(2 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 2)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 2, Actual: {elements.Count})");
+        var elements = await source.AssertCount(2).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1]);
     }
 
@@ -71,9 +67,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(3 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 3)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 3, Actual: {elements.Count})");
+        var elements = await source.AssertCount(3).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2]);
     }
 
@@ -96,9 +90,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(4 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 4)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 4, Actual: {elements.Count})");
+        var elements = await source.AssertCount(4).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3]);
     }
 
@@ -121,9 +113,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(5 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 5)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 5, Actual: {elements.Count})");
+        var elements = await source.AssertCount(5).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4]);
     }
 
@@ -146,9 +136,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(6 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 6)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 6, Actual: {elements.Count})");
+        var elements = await source.AssertCount(6).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
     }
 
@@ -171,9 +159,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(7 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 7)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 7, Actual: {elements.Count})");
+        var elements = await source.AssertCount(7).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
     }
 
@@ -196,9 +182,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(8 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 8)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 8, Actual: {elements.Count})");
+        var elements = await source.AssertCount(8).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
     }
 
@@ -221,9 +205,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(9 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 9)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 9, Actual: {elements.Count})");
+        var elements = await source.AssertCount(9).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
     }
 
@@ -246,9 +228,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(10 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 10)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 10, Actual: {elements.Count})");
+        var elements = await source.AssertCount(10).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
     }
 
@@ -271,9 +251,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(11 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 11)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 11, Actual: {elements.Count})");
+        var elements = await source.AssertCount(11).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
     }
 
@@ -296,9 +274,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(12 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 12)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 12, Actual: {elements.Count})");
+        var elements = await source.AssertCount(12).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
     }
 
@@ -321,9 +297,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(13 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 13)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 13, Actual: {elements.Count})");
+        var elements = await source.AssertCount(13).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
     }
 
@@ -346,9 +320,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(14 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 14)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 14, Actual: {elements.Count})");
+        var elements = await source.AssertCount(14).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
     }
 
@@ -371,9 +343,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(15 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 15)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 15, Actual: {elements.Count})");
+        var elements = await source.AssertCount(15).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
     }
 
@@ -396,9 +366,7 @@ public static partial class AsyncSuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = await source.Take(16 + 1).ToListAsync().ConfigureAwait(false);
-        if (elements.Count != 16)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 16, Actual: {elements.Count})");
+        var elements = await source.AssertCount(16).ToListAsync().ConfigureAwait(false);
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
     }
 }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/Fold.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/Fold.g.cs
@@ -21,9 +21,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(1 + 1).ToList();
-        if (elements.Count != 1)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 1, Actual: {elements.Count})");
+        var elements = source.AssertCount(1).ToList();
         return folder(elements[0]);
     }
 
@@ -46,9 +44,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(2 + 1).ToList();
-        if (elements.Count != 2)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 2, Actual: {elements.Count})");
+        var elements = source.AssertCount(2).ToList();
         return folder(elements[0], elements[1]);
     }
 
@@ -71,9 +67,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(3 + 1).ToList();
-        if (elements.Count != 3)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 3, Actual: {elements.Count})");
+        var elements = source.AssertCount(3).ToList();
         return folder(elements[0], elements[1], elements[2]);
     }
 
@@ -96,9 +90,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(4 + 1).ToList();
-        if (elements.Count != 4)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 4, Actual: {elements.Count})");
+        var elements = source.AssertCount(4).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3]);
     }
 
@@ -121,9 +113,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(5 + 1).ToList();
-        if (elements.Count != 5)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 5, Actual: {elements.Count})");
+        var elements = source.AssertCount(5).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4]);
     }
 
@@ -146,9 +136,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(6 + 1).ToList();
-        if (elements.Count != 6)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 6, Actual: {elements.Count})");
+        var elements = source.AssertCount(6).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
     }
 
@@ -171,9 +159,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(7 + 1).ToList();
-        if (elements.Count != 7)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 7, Actual: {elements.Count})");
+        var elements = source.AssertCount(7).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
     }
 
@@ -196,9 +182,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(8 + 1).ToList();
-        if (elements.Count != 8)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 8, Actual: {elements.Count})");
+        var elements = source.AssertCount(8).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
     }
 
@@ -221,9 +205,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(9 + 1).ToList();
-        if (elements.Count != 9)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 9, Actual: {elements.Count})");
+        var elements = source.AssertCount(9).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
     }
 
@@ -246,9 +228,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(10 + 1).ToList();
-        if (elements.Count != 10)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 10, Actual: {elements.Count})");
+        var elements = source.AssertCount(10).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
     }
 
@@ -271,9 +251,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(11 + 1).ToList();
-        if (elements.Count != 11)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 11, Actual: {elements.Count})");
+        var elements = source.AssertCount(11).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
     }
 
@@ -296,9 +274,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(12 + 1).ToList();
-        if (elements.Count != 12)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 12, Actual: {elements.Count})");
+        var elements = source.AssertCount(12).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
     }
 
@@ -321,9 +297,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(13 + 1).ToList();
-        if (elements.Count != 13)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 13, Actual: {elements.Count})");
+        var elements = source.AssertCount(13).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
     }
 
@@ -346,9 +320,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(14 + 1).ToList();
-        if (elements.Count != 14)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 14, Actual: {elements.Count})");
+        var elements = source.AssertCount(14).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
     }
 
@@ -371,9 +343,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(15 + 1).ToList();
-        if (elements.Count != 15)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 15, Actual: {elements.Count})");
+        var elements = source.AssertCount(15).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
     }
 
@@ -396,9 +366,7 @@ public static partial class SuperEnumerable
     {
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
-        var elements = source.Take(16 + 1).ToList();
-        if (elements.Count != 16)
-            global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException($"Sequence contained an incorrect number of elements. (Expected: 16, Actual: {elements.Count})");
+        var elements = source.AssertCount(16).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
     }
 }

--- a/Tests/SuperLinq.Async.Test/FoldTest.cs
+++ b/Tests/SuperLinq.Async.Test/FoldTest.cs
@@ -5,25 +5,22 @@ public class FoldTest
 	[Fact]
 	public async Task FoldWithTooFewItems()
 	{
-		var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+		await Assert.ThrowsAsync<ArgumentException>(async () =>
 			await AsyncEnumerable.Range(1, 3).Fold(AsyncBreakingFunc.Of<int, int, int, int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 4, Actual: 3)", ex.Message);
 	}
 
 	[Fact]
 	public async Task FoldWithEmptySequence()
 	{
-		var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+		await Assert.ThrowsAsync<ArgumentException>(async () =>
 			await AsyncEnumerable.Empty<int>().Fold(AsyncBreakingFunc.Of<int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 1, Actual: 0)", ex.Message);
 	}
 
 	[Fact]
 	public async Task FoldWithTooManyItems()
 	{
-		var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+		await Assert.ThrowsAsync<ArgumentException>(async () =>
 			await AsyncEnumerable.Range(1, 3).Fold(AsyncBreakingFunc.Of<int, int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 2, Actual: 3)", ex.Message);
 	}
 
 	[Fact]

--- a/Tests/SuperLinq.Test/FoldTest.cs
+++ b/Tests/SuperLinq.Test/FoldTest.cs
@@ -5,25 +5,22 @@ public class FoldTest
 	[Fact]
 	public void FoldWithTooFewItems()
 	{
-		var ex = Assert.Throws<InvalidOperationException>(() =>
+		Assert.Throws<ArgumentException>(() =>
 			Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int, int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 4, Actual: 3)", ex.Message);
 	}
 
 	[Fact]
 	public void FoldWithEmptySequence()
 	{
-		var ex = Assert.Throws<InvalidOperationException>(() =>
+		Assert.Throws<ArgumentException>(() =>
 			Enumerable.Empty<int>().Fold(BreakingFunc.Of<int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 1, Actual: 0)", ex.Message);
 	}
 
 	[Fact]
 	public void FoldWithTooManyItems()
 	{
-		var ex = Assert.Throws<InvalidOperationException>(() =>
+		Assert.Throws<ArgumentException>(() =>
 			Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int>()));
-		Assert.Equal("Sequence contained an incorrect number of elements. (Expected: 2, Actual: 3)", ex.Message);
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR updates the `Fold` operator to use the `AssertCount` operator to ensure the proper element count, rather than creating a list of `n + 1` elements to verify the sequence length.