### PR TITLE
Update Local Function Name

### DIFF
--- a/Generators/SuperLinq.Async.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/EquiZip.sbntxt
@@ -47,13 +47,13 @@ public static partial class AsyncSuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(
+		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IAsyncEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Async.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/ZipLongest.sbntxt
@@ -43,13 +43,13 @@ public static partial class AsyncSuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(
+		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IAsyncEnumerable<T{{ $j }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Async.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/ZipShortest.sbntxt
@@ -41,13 +41,13 @@ public static partial class AsyncSuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(
+		static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IAsyncEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Generator/Cartesian.sbntxt
+++ b/Generators/SuperLinq.Generator/Cartesian.sbntxt
@@ -46,13 +46,13 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static global::System.Collections.Generic.IEnumerable<TResult> _(
+		static global::System.Collections.Generic.IEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IEnumerable<T{{$j}}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Generator/EquiZip.sbntxt
@@ -47,13 +47,13 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static global::System.Collections.Generic.IEnumerable<TResult> _(
+		static global::System.Collections.Generic.IEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipLongest.sbntxt
@@ -55,13 +55,13 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static global::System.Collections.Generic.IEnumerable<TResult> _(
+		static global::System.Collections.Generic.IEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IEnumerable<T{{ $j }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Generators/SuperLinq.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipShortest.sbntxt
@@ -41,13 +41,13 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
-		return _(
+		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
 			{{~ end ~}}
 			resultSelector);
 
-		static global::System.Collections.Generic.IEnumerable<TResult> _(
+		static global::System.Collections.Generic.IEnumerable<TResult> Core(
 			{{~ for $j in 1..$i ~}}
 			global::System.Collections.Generic.IEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }},
 			{{~ end ~}}

--- a/Source/SuperLinq.Async/AssertCount.cs
+++ b/Source/SuperLinq.Async/AssertCount.cs
@@ -24,9 +24,12 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
-		return _(source, count);
+		return Core(source, count);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(
+			IAsyncEnumerable<TSource> source,
+			int count,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var c = 0;
 			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))

--- a/Source/SuperLinq.Async/BindByIndex.cs
+++ b/Source/SuperLinq.Async/BindByIndex.cs
@@ -56,9 +56,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsNotNull(missingSelector);
 
-		return _(source, indices, resultSelector, missingSelector);
+		return Core(source, indices, resultSelector, missingSelector);
 
-		static async IAsyncEnumerable<TResult> _(
+		static async IAsyncEnumerable<TResult> Core(
 			IAsyncEnumerable<TSource> source, IAsyncEnumerable<int> indices, Func<TSource, int, TResult> resultSelector, Func<int, TResult> missingSelector,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{

--- a/Source/SuperLinq.Async/Choose.cs
+++ b/Source/SuperLinq.Async/Choose.cs
@@ -110,9 +110,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(chooser);
 
-		return _(source, chooser);
+		return Core(source, chooser);
 
-		static async IAsyncEnumerable<TResult> _(IAsyncEnumerable<T> source, Func<T, CancellationToken, ValueTask<(bool, TResult)>> chooser, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<T> source, Func<T, CancellationToken, ValueTask<(bool, TResult)>> chooser, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{

--- a/Source/SuperLinq.Async/ConcurrentMerge.cs
+++ b/Source/SuperLinq.Async/ConcurrentMerge.cs
@@ -79,9 +79,9 @@ public static partial class AsyncSuperEnumerable
 		foreach (var s in sources)
 			Guard.IsNotNull(s, nameof(sources));
 
-		return _(sources, maxConcurrency);
+		return Core(sources, maxConcurrency);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IEnumerable<IAsyncEnumerable<TSource>> sources,
 			int maxConcurrency,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq.Async/Consume.cs
+++ b/Source/SuperLinq.Async/Consume.cs
@@ -12,9 +12,9 @@ public static partial class AsyncSuperEnumerable
 	public static ValueTask Consume<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
 	{
 		Guard.IsNotNull(source);
-		return _(source, cancellationToken);
+		return Core(source, cancellationToken);
 
-		static async ValueTask _(IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+		static async ValueTask Core(IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			await foreach (var _ in source.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{

--- a/Source/SuperLinq.Async/CountBy.cs
+++ b/Source/SuperLinq.Async/CountBy.cs
@@ -35,9 +35,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		return _(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 
-		static async IAsyncEnumerable<(TKey key, int count)> _(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<(TKey key, int count)> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// Avoid the temptation to inline the Loop method, which
 			// exists solely to separate the scope & lifetimes of the

--- a/Source/SuperLinq.Async/CountDown.cs
+++ b/Source/SuperLinq.Async/CountDown.cs
@@ -77,9 +77,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
-		return _(source, count, resultSelector);
+		return Core(source, count, resultSelector);
 
-		static async IAsyncEnumerable<TResult> _(IAsyncEnumerable<TSource> source, int count, Func<TSource, int?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<TSource> source, int count, Func<TSource, int?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var queue = new Queue<TSource>(Math.Max(1, count + 1));
 

--- a/Source/SuperLinq.Async/DensePartialSort.cs
+++ b/Source/SuperLinq.Async/DensePartialSort.cs
@@ -244,9 +244,9 @@ public static partial class AsyncSuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<TKey>(comparer);
 
-		return _(source, count, keySelector, comparer);
+		return Core(source, count, keySelector, comparer);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var top = new SortedSet<TKey>(comparer);
 			var dic = new Dictionary<(TKey Key, int Index), List<TSource>>(count);

--- a/Source/SuperLinq.Async/DistinctBy.cs
+++ b/Source/SuperLinq.Async/DistinctBy.cs
@@ -53,9 +53,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		return _(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var knownKeys = new HashSet<TKey>(comparer);
 			await foreach (var element in source.WithCancellation(cancellationToken).ConfigureAwait(false))

--- a/Source/SuperLinq.Async/ExceptBy.cs
+++ b/Source/SuperLinq.Async/ExceptBy.cs
@@ -63,9 +63,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(second);
 		Guard.IsNotNull(keySelector);
 
-		return _(first, second, keySelector, keyComparer);
+		return Core(first, second, keySelector, keyComparer);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second,
 			Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq.Async/FallbackIfEmpty.cs
+++ b/Source/SuperLinq.Async/FallbackIfEmpty.cs
@@ -62,9 +62,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(fallback);
 
-		return _(source, fallback);
+		return Core(source, fallback);
 
-		static async IAsyncEnumerable<T> _(IAsyncEnumerable<T> source, IAsyncEnumerable<T> fallback, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<T> source, IAsyncEnumerable<T> fallback, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken))
 			{

--- a/Source/SuperLinq.Async/From.cs
+++ b/Source/SuperLinq.Async/From.cs
@@ -17,9 +17,9 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<T> From<T>(Func<Task<T>> function)
 	{
 		Guard.IsNotNull(function);
-		return _(function);
+		return Core(function);
 
-		static async IAsyncEnumerable<T> _(Func<Task<T>> function, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(Func<Task<T>> function, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			yield return await function().ConfigureAwait(false);
@@ -43,9 +43,9 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(function1);
 		Guard.IsNotNull(function2);
-		return _(function1, function2);
+		return Core(function1, function2);
 
-		static async IAsyncEnumerable<T> _(Func<Task<T>> function1, Func<Task<T>> function2, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(Func<Task<T>> function1, Func<Task<T>> function2, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			yield return await function1().ConfigureAwait(false);
@@ -73,9 +73,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(function1);
 		Guard.IsNotNull(function2);
 		Guard.IsNotNull(function3);
-		return _(function1, function2, function3);
+		return Core(function1, function2, function3);
 
-		static async IAsyncEnumerable<T> _(Func<Task<T>> function1, Func<Task<T>> function2, Func<Task<T>> function3, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(Func<Task<T>> function1, Func<Task<T>> function2, Func<Task<T>> function3, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			yield return await function1().ConfigureAwait(false);
@@ -118,9 +118,9 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<T> Evaluate<T>(this IEnumerable<Func<Task<T>>> functions)
 	{
 		Guard.IsNotNull(functions);
-		return _(functions);
+		return Core(functions);
 
-		static async IAsyncEnumerable<T> _(IEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			foreach (var f in functions)
 			{
@@ -146,9 +146,9 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<T> Evaluate<T>(this IAsyncEnumerable<Func<Task<T>>> functions)
 	{
 		Guard.IsNotNull(functions);
-		return _(functions);
+		return Core(functions);
 
-		static async IAsyncEnumerable<T> _(IAsyncEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await foreach (var f in functions.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{

--- a/Source/SuperLinq.Async/Generate.cs
+++ b/Source/SuperLinq.Async/Generate.cs
@@ -50,9 +50,9 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(generator);
 
-		return _(initial, generator);
+		return Core(initial, generator);
 
-		static async IAsyncEnumerable<TResult> _(TResult current, Func<TResult, CancellationToken, ValueTask<TResult>> generator, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(TResult current, Func<TResult, CancellationToken, ValueTask<TResult>> generator, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			while (true)
 			{

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/EquiZip.g.cs
@@ -31,8 +31,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
@@ -106,8 +106,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
@@ -189,8 +189,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, fourth, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/ZipLongest.g.cs
@@ -27,8 +27,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             var f1 = true;
@@ -92,8 +92,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             var f1 = true;
@@ -165,8 +165,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Collections.Generic.IAsyncEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, fourth, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Collections.Generic.IAsyncEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             var f1 = true;

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Generator/ZipShortest.g.cs
@@ -25,8 +25,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
@@ -82,8 +82,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
@@ -145,8 +145,8 @@ public static partial class AsyncSuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> _(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        return Core(first, second, third, fourth, resultSelector);
+        static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await using var e1 = first.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
             await using var e2 = second.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();

--- a/Source/SuperLinq.Async/Insert.cs
+++ b/Source/SuperLinq.Async/Insert.cs
@@ -34,9 +34,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(second);
 		Guard.IsGreaterThanOrEqualTo(index, 0);
 
-		return _(first, second, index);
+		return Core(first, second, index);
 
-		static async IAsyncEnumerable<T> _(IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, int index, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, int index, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var i = -1;
 
@@ -91,9 +91,9 @@ public static partial class AsyncSuperEnumerable
 
 		return !index.IsFromEnd ? Insert(first, second, index) :
 			index.Value == 0 ? first.Concat(second) :
-			_(first, second, index.Value);
+			Core(first, second, index.Value);
 
-		static async IAsyncEnumerable<T> _(IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, int index, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, int index, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await using var e = first.CountDown(index, ValueTuple.Create).GetConfiguredAsyncEnumerator(cancellationToken);
 

--- a/Source/SuperLinq.Async/Interleave.cs
+++ b/Source/SuperLinq.Async/Interleave.cs
@@ -58,9 +58,9 @@ public static partial class AsyncSuperEnumerable
 		foreach (var s in sources)
 			Guard.IsNotNull(s, nameof(sources));
 
-		return _(sources);
+		return Core(sources);
 
-		static async IAsyncEnumerable<T> _(IEnumerable<IAsyncEnumerable<T>> sources, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IEnumerable<IAsyncEnumerable<T>> sources, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var list = await EnumeratorList<T>.Create(sources, cancellationToken).ConfigureAwait(false);
 			await using var ignored_ = list.ConfigureAwait(false);

--- a/Source/SuperLinq.Async/Lag.cs
+++ b/Source/SuperLinq.Async/Lag.cs
@@ -84,9 +84,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
-		return _(source, offset, defaultLagValue, resultSelector);
+		return Core(source, offset, defaultLagValue, resultSelector);
 
-		static async IAsyncEnumerable<TResult> _(IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var lagQueue = new Queue<TSource>(offset + 1);
 			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))

--- a/Source/SuperLinq.Async/Lead.cs
+++ b/Source/SuperLinq.Async/Lead.cs
@@ -85,9 +85,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
-		return _(source, offset, defaultLeadValue, resultSelector);
+		return Core(source, offset, defaultLeadValue, resultSelector);
 
-		static async IAsyncEnumerable<TResult> _(IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var queue = new Queue<TSource>(offset + 1);
 

--- a/Source/SuperLinq.Async/Pad.cs
+++ b/Source/SuperLinq.Async/Pad.cs
@@ -93,9 +93,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
-		return _(source, width, paddingSelector);
+		return Core(source, width, paddingSelector);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> source, int width,
 			Func<int, TSource> paddingSelector,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq.Async/PartialSort.cs
+++ b/Source/SuperLinq.Async/PartialSort.cs
@@ -115,9 +115,9 @@ public static partial class AsyncSuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<T>(comparer);
 
-		return _(source, count, comparer);
+		return Core(source, count, comparer);
 
-		static async IAsyncEnumerable<T> _(IAsyncEnumerable<T> source, int count, IComparer<T> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<T> source, int count, IComparer<T> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var top = new SortedSet<(T item, int index)>(
 				ValueTupleComparer.Create<T, int>(comparer, default));
@@ -278,9 +278,9 @@ public static partial class AsyncSuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<TKey>(comparer);
 
-		return _(source, count, keySelector, comparer);
+		return Core(source, count, keySelector, comparer);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var top = new SortedSet<(TKey Key, int Index)>(
 				ValueTupleComparer.Create<TKey, int>(comparer, default));

--- a/Source/SuperLinq.Async/PreScan.cs
+++ b/Source/SuperLinq.Async/PreScan.cs
@@ -45,9 +45,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, transformation, identity);
+		return Core(source, transformation, identity);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> source,
 			Func<TSource, TSource, TSource> transformation,
 			TSource identity,

--- a/Source/SuperLinq.Async/Replace.cs
+++ b/Source/SuperLinq.Async/Replace.cs
@@ -24,9 +24,9 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
-		return _(source, value, index);
+		return Core(source, value, index);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> source, TSource value, int index,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
@@ -58,9 +58,9 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
-		return _(source, value, index);
+		return Core(source, value, index);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> source, TSource value, Index index,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{

--- a/Source/SuperLinq.Async/RunLengthEncode.cs
+++ b/Source/SuperLinq.Async/RunLengthEncode.cs
@@ -29,9 +29,9 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(sequence);
 
-		return _(sequence, comparer ?? EqualityComparer<T>.Default);
+		return Core(sequence, comparer ?? EqualityComparer<T>.Default);
 
-		static async IAsyncEnumerable<(T value, int count)> _(IAsyncEnumerable<T> sequence, IEqualityComparer<T> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<(T value, int count)> Core(IAsyncEnumerable<T> sequence, IEqualityComparer<T> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// This implementation could also have been written using a foreach loop,
 			// but it proved to be easier to deal with edge certain cases that occur

--- a/Source/SuperLinq.Async/ScanBy.cs
+++ b/Source/SuperLinq.Async/ScanBy.cs
@@ -222,9 +222,9 @@ public static partial class AsyncSuperEnumerable
 
 		comparer ??= EqualityComparer<TKey>.Default;
 
-		return _(source, keySelector, seedSelector, accumulator, comparer);
+		return Core(source, keySelector, seedSelector, accumulator, comparer);
 
-		static async IAsyncEnumerable<(TKey key, TState state)> _(
+		static async IAsyncEnumerable<(TKey key, TState state)> Core(
 			IAsyncEnumerable<TSource> source,
 			Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
 			Func<TKey, CancellationToken, ValueTask<TState>> seedSelector,

--- a/Source/SuperLinq.Async/ScanEx.cs
+++ b/Source/SuperLinq.Async/ScanEx.cs
@@ -30,9 +30,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, transformation);
+		return Core(source, transformation);
 
-		static async IAsyncEnumerable<TSource> _(
+		static async IAsyncEnumerable<TSource> Core(
 			IAsyncEnumerable<TSource> source,
 			Func<TSource, TSource, TSource> transformation,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -78,9 +78,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, seed, transformation);
+		return Core(source, seed, transformation);
 
-		static async IAsyncEnumerable<TState> _(
+		static async IAsyncEnumerable<TState> Core(
 			IAsyncEnumerable<TSource> source,
 			TState state,
 			Func<TState, TSource, TState> transformation,

--- a/Source/SuperLinq.Async/ScanRight.cs
+++ b/Source/SuperLinq.Async/ScanRight.cs
@@ -89,9 +89,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return _(source, func);
+		return Core(source, func);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, ValueTask<TSource>> func, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, ValueTask<TSource>> func, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var list = await source.ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -203,9 +203,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return _(source, seed, func);
+		return Core(source, seed, func);
 
-		static async IAsyncEnumerable<TAccumulate> _(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, CancellationToken, ValueTask<TAccumulate>> func, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, CancellationToken, ValueTask<TAccumulate>> func, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var list = await source.ToListAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Source/SuperLinq.Async/Segment.cs
+++ b/Source/SuperLinq.Async/Segment.cs
@@ -106,9 +106,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(newSegmentPredicate);
 
-		return _(source, newSegmentPredicate);
+		return Core(source, newSegmentPredicate);
 
-		static async IAsyncEnumerable<IEnumerable<T>> _(IAsyncEnumerable<T> source, Func<T, T, int, ValueTask<bool>> newSegmentPredicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<IEnumerable<T>> Core(IAsyncEnumerable<T> source, Func<T, T, int, ValueTask<bool>> newSegmentPredicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
 

--- a/Source/SuperLinq.Async/Sequence.cs
+++ b/Source/SuperLinq.Async/Sequence.cs
@@ -19,10 +19,10 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 		var max = start + (count - 1) * (long)step;
 		Guard.IsBetweenOrEqualTo(max, int.MinValue, int.MaxValue, name: nameof(count));
-		return _(start, count, step);
+		return Core(start, count, step);
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-		static async IAsyncEnumerable<int> _(int start, int count, int step)
+		static async IAsyncEnumerable<int> Core(int start, int count, int step)
 		{
 			var value = start;
 			for (var i = 0; i < count; i++)

--- a/Source/SuperLinq.Async/SkipUntil.cs
+++ b/Source/SuperLinq.Async/SkipUntil.cs
@@ -37,9 +37,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(predicate);
 
-		return _(source, predicate);
+		return Core(source, predicate);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await using var enumerator = source.GetConfiguredAsyncEnumerator(cancellationToken);
 

--- a/Source/SuperLinq.Async/Split.cs
+++ b/Source/SuperLinq.Async/Split.cs
@@ -274,9 +274,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 		Guard.IsNotNull(resultSelector);
 
-		return _(source, separatorFunc, count, resultSelector);
+		return Core(source, separatorFunc, count, resultSelector);
 
-		static async IAsyncEnumerable<TResult> _(
+		static async IAsyncEnumerable<TResult> Core(
 			IAsyncEnumerable<TSource> source,
 			Func<TSource, bool> separatorFunc, int count,
 			Func<IEnumerable<TSource>, TResult> resultSelector,

--- a/Source/SuperLinq.Async/TagFirstLast.cs
+++ b/Source/SuperLinq.Async/TagFirstLast.cs
@@ -66,9 +66,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(resultSelector);
 
-		return _(source, resultSelector);
+		return Core(source, resultSelector);
 
-		static async IAsyncEnumerable<TResult> _(IAsyncEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await using var iter = source.GetConfiguredAsyncEnumerator(cancellationToken);
 

--- a/Source/SuperLinq.Async/TakeUntil.cs
+++ b/Source/SuperLinq.Async/TakeUntil.cs
@@ -37,9 +37,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(predicate);
 
-		return _(source, predicate);
+		return Core(source, predicate);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{

--- a/Source/SuperLinq.Async/Traverse.cs
+++ b/Source/SuperLinq.Async/Traverse.cs
@@ -27,9 +27,9 @@ public partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(childrenSelector);
 
-		return _(root, childrenSelector);
+		return Core(root, childrenSelector);
 
-		static async IAsyncEnumerable<T> _(
+		static async IAsyncEnumerable<T> Core(
 			T root,
 			Func<T, IAsyncEnumerable<T>> childrenSelector,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -74,9 +74,9 @@ public partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(childrenSelector);
 
-		return _(root, childrenSelector);
+		return Core(root, childrenSelector);
 
-		static async IAsyncEnumerable<T> _(
+		static async IAsyncEnumerable<T> Core(
 			T root,
 			Func<T, IAsyncEnumerable<T>> childrenSelector,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq.Async/Where.cs
+++ b/Source/SuperLinq.Async/Where.cs
@@ -19,9 +19,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(filter);
 
-		return _(source, filter);
+		return Core(source, filter);
 
-		static async IAsyncEnumerable<TSource> _(IAsyncEnumerable<TSource> source, IAsyncEnumerable<bool> filter, [EnumeratorCancellation] CancellationToken cancellation = default)
+		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, IAsyncEnumerable<bool> filter, [EnumeratorCancellation] CancellationToken cancellation = default)
 		{
 			await using var sIter = source.GetConfiguredAsyncEnumerator(cancellation);
 			await using var fIter = filter.GetConfiguredAsyncEnumerator(cancellation);

--- a/Source/SuperLinq.Async/ZipMap.cs
+++ b/Source/SuperLinq.Async/ZipMap.cs
@@ -68,9 +68,9 @@ public static partial class AsyncSuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(selector);
 
-		return _(source, selector);
+		return Core(source, selector);
 
-		static async IAsyncEnumerable<(TSource, TResult)> _(
+		static async IAsyncEnumerable<(TSource, TResult)> Core(
 			IAsyncEnumerable<TSource> source,
 			Func<TSource, CancellationToken, ValueTask<TResult>> selector,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -24,9 +24,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
-		return _(source, count);
+		return Core(source, count);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, int count)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count)
 		{
 			if (source.TryGetCollectionCount(out var c))
 			{

--- a/Source/SuperLinq/BindByIndex.cs
+++ b/Source/SuperLinq/BindByIndex.cs
@@ -56,9 +56,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsNotNull(missingSelector);
 
-		return _(source, indices, resultSelector, missingSelector);
+		return Core(source, indices, resultSelector, missingSelector);
 
-		static IEnumerable<TResult> _(IEnumerable<TSource> source, IEnumerable<int> indices, Func<TSource, int, TResult> resultSelector, Func<int, TResult> missingSelector)
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, IEnumerable<int> indices, Func<TSource, int, TResult> resultSelector, Func<int, TResult> missingSelector)
 		{
 			// keeps track of the order of indices to know what order items should be output in
 			var lookup = indices.Index().ToDictionary(x => { Guard.IsGreaterThanOrEqualTo(x.item, 0, nameof(indices)); return x.item; }, x => x.index);

--- a/Source/SuperLinq/Choose.cs
+++ b/Source/SuperLinq/Choose.cs
@@ -36,9 +36,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(chooser);
 
-		return _(source, chooser);
+		return Core(source, chooser);
 
-		static IEnumerable<TResult> _(IEnumerable<T> source, Func<T, (bool, TResult)> chooser)
+		static IEnumerable<TResult> Core(IEnumerable<T> source, Func<T, (bool, TResult)> chooser)
 		{
 			foreach (var item in source)
 			{

--- a/Source/SuperLinq/CountBy.cs
+++ b/Source/SuperLinq/CountBy.cs
@@ -35,9 +35,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		return _(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 
-		static IEnumerable<(TKey key, int count)> _(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+		static IEnumerable<(TKey key, int count)> Core(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
 		{
 			// Avoid the temptation to inline the Loop method, which
 			// exists solely to separate the scope & lifetimes of the

--- a/Source/SuperLinq/DensePartialSort.cs
+++ b/Source/SuperLinq/DensePartialSort.cs
@@ -244,9 +244,9 @@ public static partial class SuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<TKey>(comparer);
 
-		return _(source, count, keySelector, comparer);
+		return Core(source, count, keySelector, comparer);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
 		{
 			var top = new SortedSet<TKey>(comparer);
 			var dic = new Dictionary<(TKey Key, int Index), List<TSource>>(count);

--- a/Source/SuperLinq/DistinctBy.cs
+++ b/Source/SuperLinq/DistinctBy.cs
@@ -67,9 +67,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		return _(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
 		{
 			var knownKeys = new HashSet<TKey>(comparer);
 			foreach (var element in source)

--- a/Source/SuperLinq/ExceptBy.cs
+++ b/Source/SuperLinq/ExceptBy.cs
@@ -80,9 +80,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(second);
 		Guard.IsNotNull(keySelector);
 
-		return _(first, second, keySelector, keyComparer);
+		return Core(first, second, keySelector, keyComparer);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> first, IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> first, IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer)
 		{
 			var keys = second.Select(keySelector).ToHashSet(keyComparer);
 			foreach (var element in first)

--- a/Source/SuperLinq/Exclude.cs
+++ b/Source/SuperLinq/Exclude.cs
@@ -23,9 +23,9 @@ public static partial class SuperEnumerable
 		if (count == 0)
 			return sequence;
 
-		return _(sequence, startIndex, count);
+		return Core(sequence, startIndex, count);
 
-		static IEnumerable<T> _(IEnumerable<T> sequence, int startIndex, int count)
+		static IEnumerable<T> Core(IEnumerable<T> sequence, int startIndex, int count)
 		{
 			var index = 0;
 			var endIndex = startIndex + count;

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -40,9 +40,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(fallback);
 
-		return _(source, fallback);
+		return Core(source, fallback);
 
-		static IEnumerable<T> _(IEnumerable<T> source, IEnumerable<T> fallback)
+		static IEnumerable<T> Core(IEnumerable<T> source, IEnumerable<T> fallback)
 		{
 			using (var e = source.GetEnumerator())
 			{

--- a/Source/SuperLinq/Flatten.cs
+++ b/Source/SuperLinq/Flatten.cs
@@ -73,7 +73,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(selector);
 
-		return _(); IEnumerable<object?> _()
+		return Core(); IEnumerable<object?> Core()
 		{
 			var e = source.GetEnumerator();
 			var stack = new Stack<IEnumerator>();

--- a/Source/SuperLinq/From.cs
+++ b/Source/SuperLinq/From.cs
@@ -17,9 +17,9 @@ partial class SuperEnumerable
 	public static IEnumerable<T> From<T>(Func<T> function)
 	{
 		Guard.IsNotNull(function);
-		return _(function);
+		return Core(function);
 
-		static IEnumerable<T> _(Func<T> function)
+		static IEnumerable<T> Core(Func<T> function)
 		{
 			yield return function();
 		}
@@ -42,9 +42,9 @@ partial class SuperEnumerable
 	{
 		Guard.IsNotNull(function1);
 		Guard.IsNotNull(function2);
-		return _(function1, function2);
+		return Core(function1, function2);
 
-		static IEnumerable<T> _(Func<T> function1, Func<T> function2)
+		static IEnumerable<T> Core(Func<T> function1, Func<T> function2)
 		{
 			yield return function1();
 			yield return function2();
@@ -70,9 +70,9 @@ partial class SuperEnumerable
 		Guard.IsNotNull(function1);
 		Guard.IsNotNull(function2);
 		Guard.IsNotNull(function3);
-		return _(function1, function2, function3);
+		return Core(function1, function2, function3);
 
-		static IEnumerable<T> _(Func<T> function1, Func<T> function2, Func<T> function3)
+		static IEnumerable<T> Core(Func<T> function1, Func<T> function2, Func<T> function3)
 		{
 			yield return function1();
 			yield return function2();

--- a/Source/SuperLinq/FullGroupJoin.cs
+++ b/Source/SuperLinq/FullGroupJoin.cs
@@ -126,9 +126,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(secondKeySelector);
 		Guard.IsNotNull(resultSelector);
 
-		return _(comparer ?? EqualityComparer<TKey>.Default);
+		return Core(comparer ?? EqualityComparer<TKey>.Default);
 
-		IEnumerable<TResult> _(IEqualityComparer<TKey> comparer)
+		IEnumerable<TResult> Core(IEqualityComparer<TKey> comparer)
 		{
 			var alookup = Lookup<TKey, TFirst>.CreateForJoin(first, firstKeySelector, comparer);
 			var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);

--- a/Source/SuperLinq/Generate.cs
+++ b/Source/SuperLinq/Generate.cs
@@ -26,9 +26,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(generator);
 
-		return _(initial, generator);
+		return Core(initial, generator);
 
-		static IEnumerable<TResult> _(TResult current, Func<TResult, TResult> generator)
+		static IEnumerable<TResult> Core(TResult current, Func<TResult, TResult> generator)
 		{
 			while (true)
 			{

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/Cartesian.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/Cartesian.g.cs
@@ -31,8 +31,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
+        return Core(first, second, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -95,8 +95,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
+        return Core(first, second, third, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -166,8 +166,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
+        return Core(first, second, third, fourth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -244,8 +244,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, fifth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Func<T1, T2, T3, T4, T5, TResult> resultSelector)
+        return Core(first, second, third, fourth, fifth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Func<T1, T2, T3, T4, T5, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -329,8 +329,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(sixth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, fifth, sixth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
+        return Core(first, second, third, fourth, fifth, sixth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -421,8 +421,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(sixth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(seventh);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, fifth, sixth, seventh, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
+        return Core(first, second, third, fourth, fifth, sixth, seventh, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();
@@ -520,8 +520,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(seventh);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(eighth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, fifth, sixth, seventh, eighth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Collections.Generic.IEnumerable<T8> eighth, global::System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
+        return Core(first, second, third, fourth, fifth, sixth, seventh, eighth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Collections.Generic.IEnumerable<T8> eighth, global::System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
         {
             using var firstMemo = first.Memoize();
             using var secondMemo = second.Memoize();

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/EquiZip.g.cs
@@ -31,8 +31,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
+        return Core(first, second, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();
@@ -106,8 +106,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
+        return Core(first, second, third, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();
@@ -189,8 +189,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
+        return Core(first, second, third, fourth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/ZipLongest.g.cs
@@ -39,8 +39,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
+        return Core(first, second, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             var f1 = true;
@@ -100,8 +100,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
+        return Core(first, second, third, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             var f1 = true;
@@ -168,8 +168,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
+        return Core(first, second, third, fourth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             var f1 = true;

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator/ZipShortest.g.cs
@@ -25,8 +25,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
+        return Core(first, second, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();
@@ -82,8 +82,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
+        return Core(first, second, third, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();
@@ -145,8 +145,8 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
-        return _(first, second, third, fourth, resultSelector);
-        static global::System.Collections.Generic.IEnumerable<TResult> _(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
+        return Core(first, second, third, fourth, resultSelector);
+        static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
         {
             using var e1 = first.GetEnumerator();
             using var e2 = second.GetEnumerator();

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -34,9 +34,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(second);
 		Guard.IsGreaterThanOrEqualTo(index, 0);
 
-		return _(first, second, index);
+		return Core(first, second, index);
 
-		static IEnumerable<T> _(IEnumerable<T> first, IEnumerable<T> second, int index)
+		static IEnumerable<T> Core(IEnumerable<T> first, IEnumerable<T> second, int index)
 		{
 			var i = -1;
 
@@ -91,9 +91,9 @@ public static partial class SuperEnumerable
 
 		return !index.IsFromEnd ? Insert(first, second, index.Value) :
 			index.Value == 0 ? first.Concat(second) :
-			_(first, second, index.Value);
+			Core(first, second, index.Value);
 
-		static IEnumerable<T> _(IEnumerable<T> first, IEnumerable<T> second, int index)
+		static IEnumerable<T> Core(IEnumerable<T> first, IEnumerable<T> second, int index)
 		{
 			using var e = first.CountDown(index, ValueTuple.Create).GetEnumerator();
 

--- a/Source/SuperLinq/Interleave.cs
+++ b/Source/SuperLinq/Interleave.cs
@@ -58,9 +58,9 @@ public static partial class SuperEnumerable
 		if (sources.Any(s => s == null))
 			throw new ArgumentNullException(nameof(sources), "One or more sequences passed to Interleave was null.");
 
-		return _(sources);
+		return Core(sources);
 
-		static IEnumerable<T> _(IEnumerable<IEnumerable<T>> sources)
+		static IEnumerable<T> Core(IEnumerable<IEnumerable<T>> sources)
 		{
 			using var list = new EnumeratorList<T>(sources);
 

--- a/Source/SuperLinq/Lag.cs
+++ b/Source/SuperLinq/Lag.cs
@@ -70,9 +70,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
-		return _(source, offset, defaultLagValue, resultSelector);
+		return Core(source, offset, defaultLagValue, resultSelector);
 
-		static IEnumerable<TResult> _(IEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
 		{
 			var lagQueue = new Queue<TSource>(offset + 1);
 			foreach (var item in source)

--- a/Source/SuperLinq/Lead.cs
+++ b/Source/SuperLinq/Lead.cs
@@ -75,9 +75,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
-		return _(source, offset, defaultLeadValue, resultSelector);
+		return Core(source, offset, defaultLeadValue, resultSelector);
 
-		static IEnumerable<TResult> _(IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
 		{
 			var queue = new Queue<TSource>(offset + 1);
 

--- a/Source/SuperLinq/Move.cs
+++ b/Source/SuperLinq/Move.cs
@@ -38,10 +38,10 @@ public static partial class SuperEnumerable
 			return source;
 
 		return toIndex < fromIndex
-			 ? _(source, toIndex, fromIndex - toIndex, count)
-			 : _(source, fromIndex, count, toIndex - fromIndex);
+			 ? Core(source, toIndex, fromIndex - toIndex, count)
+			 : Core(source, fromIndex, count, toIndex - fromIndex);
 
-		static IEnumerable<T> _(IEnumerable<T> source, int bufferStartIndex, int bufferSize, int bufferYieldIndex)
+		static IEnumerable<T> Core(IEnumerable<T> source, int bufferStartIndex, int bufferSize, int bufferYieldIndex)
 		{
 			bool hasMore = true;
 			bool MoveNext(IEnumerator<T> e) => hasMore && (hasMore = e.MoveNext());

--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -93,9 +93,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
-		return _(source, width, paddingSelector);
+		return Core(source, width, paddingSelector);
 
-		static IEnumerable<TSource> _(
+		static IEnumerable<TSource> Core(
 			IEnumerable<TSource> source, int width,
 			Func<int, TSource> paddingSelector)
 		{

--- a/Source/SuperLinq/PartialSort.cs
+++ b/Source/SuperLinq/PartialSort.cs
@@ -115,9 +115,9 @@ public static partial class SuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<T>(comparer);
 
-		return _(source, count, comparer);
+		return Core(source, count, comparer);
 
-		static IEnumerable<T> _(IEnumerable<T> source, int count, IComparer<T> comparer)
+		static IEnumerable<T> Core(IEnumerable<T> source, int count, IComparer<T> comparer)
 		{
 			var top = new SortedSet<(T Item, int Index)>(
 				ValueTupleComparer.Create<T, int>(comparer, default));
@@ -278,9 +278,9 @@ public static partial class SuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<TKey>(comparer);
 
-		return _(source, count, keySelector, comparer);
+		return Core(source, count, keySelector, comparer);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
 		{
 			var top = new SortedSet<(TKey Key, int Index)>(
 				ValueTupleComparer.Create<TKey, int>(comparer, default));

--- a/Source/SuperLinq/Permutations.cs
+++ b/Source/SuperLinq/Permutations.cs
@@ -183,9 +183,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(sequence);
 
-		return _(sequence);
+		return Core(sequence);
 
-		static IEnumerable<IList<T>> _(IEnumerable<T> sequence)
+		static IEnumerable<IList<T>> Core(IEnumerable<T> sequence)
 		{
 			using var iter = new PermutationEnumerator<T>(sequence);
 

--- a/Source/SuperLinq/PreScan.cs
+++ b/Source/SuperLinq/PreScan.cs
@@ -45,9 +45,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, transformation, identity);
+		return Core(source, transformation, identity);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, TSource, TSource> transformation, TSource identity)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TSource, TSource> transformation, TSource identity)
 		{
 			var aggregator = identity;
 			using var e = source.GetEnumerator();

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -24,9 +24,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
-		return _(source, index, value);
+		return Core(source, index, value);
 
-		static IEnumerable<TSource> _(
+		static IEnumerable<TSource> Core(
 			IEnumerable<TSource> source,
 			int index,
 			TSource value)
@@ -59,9 +59,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
-		return _(source, value, index);
+		return Core(source, value, index);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, TSource value, Index index)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, TSource value, Index index)
 		{
 			if (index.IsFromEnd
 				&& source.TryGetCollectionCount(out var count))

--- a/Source/SuperLinq/RunLengthEncode.cs
+++ b/Source/SuperLinq/RunLengthEncode.cs
@@ -29,9 +29,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(sequence);
 
-		return _(sequence, comparer ?? EqualityComparer<T>.Default);
+		return Core(sequence, comparer ?? EqualityComparer<T>.Default);
 
-		static IEnumerable<(T value, int count)> _(IEnumerable<T> sequence, IEqualityComparer<T> comparer)
+		static IEnumerable<(T value, int count)> Core(IEnumerable<T> sequence, IEqualityComparer<T> comparer)
 		{
 			// This implementation could also have been written using a foreach loop,
 			// but it proved to be easier to deal with edge certain cases that occur

--- a/Source/SuperLinq/ScanBy.cs
+++ b/Source/SuperLinq/ScanBy.cs
@@ -73,9 +73,9 @@ public static partial class SuperEnumerable
 
 		comparer ??= EqualityComparer<TKey>.Default;
 
-		return _(source, keySelector, seedSelector, accumulator, comparer);
+		return Core(source, keySelector, seedSelector, accumulator, comparer);
 
-		static IEnumerable<(TKey key, TState state)> _(
+		static IEnumerable<(TKey key, TState state)> Core(
 			IEnumerable<TSource> source,
 			Func<TSource, TKey> keySelector,
 			Func<TKey, TState> seedSelector,

--- a/Source/SuperLinq/ScanEx.cs
+++ b/Source/SuperLinq/ScanEx.cs
@@ -30,9 +30,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, transformation);
+		return Core(source, transformation);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, TSource, TSource> transformation)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TSource, TSource> transformation)
 		{
 			using var e = source.GetEnumerator();
 
@@ -75,9 +75,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(transformation);
 
-		return _(source, seed, transformation);
+		return Core(source, seed, transformation);
 
-		static IEnumerable<TState> _(
+		static IEnumerable<TState> Core(
 			IEnumerable<TSource> source,
 			TState state,
 			Func<TState, TSource, TState> transformation)

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -32,9 +32,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return _(source, func);
+		return Core(source, func);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
 		{
 			var list = source is IList<TSource> l ? l : source.ToList();
 
@@ -87,9 +87,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return _(source, seed, func);
+		return Core(source, seed, func);
 
-		static IEnumerable<TAccumulate> _(IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
+		static IEnumerable<TAccumulate> Core(IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
 		{
 			var list = source is IList<TSource> l ? l : source.ToList();
 			var stack = new Stack<TAccumulate>(list.Count + 1);

--- a/Source/SuperLinq/Segment.cs
+++ b/Source/SuperLinq/Segment.cs
@@ -54,9 +54,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(newSegmentPredicate);
 
-		return _(source, newSegmentPredicate);
+		return Core(source, newSegmentPredicate);
 
-		static IEnumerable<IEnumerable<T>> _(IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
+		static IEnumerable<IEnumerable<T>> Core(IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
 		{
 			using var e = source.GetEnumerator();
 

--- a/Source/SuperLinq/Sequence.cs
+++ b/Source/SuperLinq/Sequence.cs
@@ -19,9 +19,9 @@ public static partial class SuperEnumerable
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 		var max = start + (count - 1) * (long)step;
 		Guard.IsBetweenOrEqualTo(max, int.MinValue, int.MaxValue, name: nameof(count));
-		return _(start, count, step);
+		return Core(start, count, step);
 
-		static IEnumerable<int> _(int start, int count, int step)
+		static IEnumerable<int> Core(int start, int count, int step)
 		{
 			var value = start;
 			for (var i = 0; i < count; i++)

--- a/Source/SuperLinq/SkipUntil.cs
+++ b/Source/SuperLinq/SkipUntil.cs
@@ -37,9 +37,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(predicate);
 
-		return _(source, predicate);
+		return Core(source, predicate);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, bool> predicate)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, bool> predicate)
 		{
 			using var enumerator = source.GetEnumerator();
 

--- a/Source/SuperLinq/Split.cs
+++ b/Source/SuperLinq/Split.cs
@@ -274,9 +274,9 @@ public static partial class SuperEnumerable
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 		Guard.IsNotNull(resultSelector);
 
-		return _(source, separatorFunc, count, resultSelector);
+		return Core(source, separatorFunc, count, resultSelector);
 
-		static IEnumerable<TResult> _(IEnumerable<TSource> source, Func<TSource, bool> separatorFunc, int count, Func<IEnumerable<TSource>, TResult> resultSelector)
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, Func<TSource, bool> separatorFunc, int count, Func<IEnumerable<TSource>, TResult> resultSelector)
 		{
 			var items = new List<TSource>();
 

--- a/Source/SuperLinq/Subsets.cs
+++ b/Source/SuperLinq/Subsets.cs
@@ -26,9 +26,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(sequence);
 
-		return _(sequence);
+		return Core(sequence);
 
-		static IEnumerable<IList<T>> _(IEnumerable<T> sequence)
+		static IEnumerable<IList<T>> Core(IEnumerable<T> sequence)
 		{
 			var sequenceAsList = sequence.ToList();
 			var sequenceLength = sequenceAsList.Count;

--- a/Source/SuperLinq/TagFirstLast.cs
+++ b/Source/SuperLinq/TagFirstLast.cs
@@ -66,9 +66,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(resultSelector);
 
-		return _(source, resultSelector);
+		return Core(source, resultSelector);
 
-		static IEnumerable<TResult> _(IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
 		{
 			using var iter = source.GetEnumerator();
 

--- a/Source/SuperLinq/TakeUntil.cs
+++ b/Source/SuperLinq/TakeUntil.cs
@@ -37,9 +37,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(predicate);
 
-		return _(source, predicate);
+		return Core(source, predicate);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, bool> predicate)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, bool> predicate)
 		{
 			foreach (var item in source)
 			{

--- a/Source/SuperLinq/Transpose.cs
+++ b/Source/SuperLinq/Transpose.cs
@@ -35,9 +35,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
-		return _(source);
+		return Core(source);
 
-		static IEnumerable<IEnumerable<T>> _(IEnumerable<IEnumerable<T>> source)
+		static IEnumerable<IEnumerable<T>> Core(IEnumerable<IEnumerable<T>> source)
 		{
 			using var list = new EnumeratorList<T>(source);
 

--- a/Source/SuperLinq/Traverse.cs
+++ b/Source/SuperLinq/Traverse.cs
@@ -27,9 +27,9 @@ public partial class SuperEnumerable
 	{
 		Guard.IsNotNull(childrenSelector);
 
-		return _(root, childrenSelector);
+		return Core(root, childrenSelector);
 
-		static IEnumerable<T> _(T root, Func<T, IEnumerable<T>> childrenSelector)
+		static IEnumerable<T> Core(T root, Func<T, IEnumerable<T>> childrenSelector)
 		{
 			var queue = new Queue<T>();
 			queue.Enqueue(root);
@@ -69,9 +69,9 @@ public partial class SuperEnumerable
 	{
 		Guard.IsNotNull(childrenSelector);
 
-		return _(root, childrenSelector);
+		return Core(root, childrenSelector);
 
-		static IEnumerable<T> _(T root, Func<T, IEnumerable<T>> childrenSelector)
+		static IEnumerable<T> Core(T root, Func<T, IEnumerable<T>> childrenSelector)
 		{
 			var stack = new Stack<T>();
 			stack.Push(root);

--- a/Source/SuperLinq/Unfold.cs
+++ b/Source/SuperLinq/Unfold.cs
@@ -41,7 +41,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(stateSelector);
 		Guard.IsNotNull(resultSelector);
 
-		return _(); IEnumerable<TResult> _()
+		return Core(); IEnumerable<TResult> Core()
 		{
 			while (true)
 			{

--- a/Source/SuperLinq/Where.cs
+++ b/Source/SuperLinq/Where.cs
@@ -19,9 +19,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(filter);
 
-		return _(source, filter);
+		return Core(source, filter);
 
-		static IEnumerable<TSource> _(IEnumerable<TSource> source, IEnumerable<bool> filter)
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, IEnumerable<bool> filter)
 		{
 			using var sIter = source.GetEnumerator();
 			using var fIter = filter.GetEnumerator();

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -22,9 +22,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(selector);
 
-		return _(source, selector);
+		return Core(source, selector);
 
-		static IEnumerable<(TSource, TResult)> _(IEnumerable<TSource> source, Func<TSource, TResult> selector)
+		static IEnumerable<(TSource, TResult)> Core(IEnumerable<TSource> source, Func<TSource, TResult> selector)
 		{
 			foreach (var item in source)
 				yield return (item, selector(item));

--- a/Tests/SuperLinq.Test/TraceTest.cs
+++ b/Tests/SuperLinq.Test/TraceTest.cs
@@ -81,7 +81,7 @@ public class TraceTest
 
 	private static IEnumerable<string> Lines(string str)
 	{
-		using (var e = _(string.IsNullOrEmpty(str)
+		using (var e = Core(string.IsNullOrEmpty(str)
 					 ? TextReader.Null
 					 : new StringReader(str)))
 		{
@@ -89,7 +89,7 @@ public class TraceTest
 				yield return e.Current;
 		}
 
-		static IEnumerator<string> _(TextReader reader)
+		static IEnumerator<string> Core(TextReader reader)
 		{
 			Debug.Assert(reader != null);
 			string? line;


### PR DESCRIPTION
This PR updates local implementation functions to use `Core` instead of `_` to improve a) readability, and b) ability to use discards as needed.