### PR TITLE
Add buffered overloads of `Batch`

### DIFF
--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -36,23 +36,137 @@ public static partial class SuperEnumerable
 #endif
 
 	/// <summary>
-	/// Split the elements of a sequence into chunks of size at most <paramref name="size"/>
-	/// and applies a projection to each chunk.
+	/// Split the elements of a sequence into chunks of size at most <paramref name="size"/>.
 	/// </summary>
 	/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
-	/// <typeparam name="TResult">The type of the value returned by <paramref name="resultSelector"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="resultSelector"/>.</typeparam>
 	/// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
 	/// <param name="size">The maximum size of each chunk.</param>
-	/// <param name="resultSelector">The projection that .</param>
-	/// <returns>An <see cref="IEnumerable{T}"/> that contains the elements the input sequence split into chunks of size size.</returns>
-	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-	/// <exception cref="ArgumentNullException"><paramref name="resultSelector"/> is <see langword="null"/>.</exception>
+	/// <param name="resultSelector">A transform function to apply to each chunk.</param>
+	/// <returns>A sequence of elements returned by <paramref name="resultSelector"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="resultSelector"/> is
+	/// null.</exception>
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="size"/>, specifically the final chunk of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Batch</c>, a single array of length <paramref name="size"/> is allocated as a buffer for
+	/// all subsequences.
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
 	public static IEnumerable<TResult> Batch<TSource, TResult>(
-		this IEnumerable<TSource> source, int size,
-		Func<IList<TSource>, TResult> resultSelector)
+		this IEnumerable<TSource> source,
+		int size,
+		Func<IReadOnlyList<TSource>, TResult> resultSelector)
 	{
+		Guard.IsNotNull(source);
 		Guard.IsNotNull(resultSelector);
-		return source.Batch(size).Select(resultSelector);
+		Guard.IsGreaterThanOrEqualTo(size, 1);
+
+		return BatchImpl(source, new TSource[size], size, resultSelector);
+	}
+
+	/// <summary>
+	/// Split the elements of a sequence into chunks of size at most <c><paramref name="array"/>.Length</c>.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="resultSelector"/>.</typeparam>
+	/// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
+	/// <param name="array">An array to use as a buffer for each chunk.</param>
+	/// <param name="resultSelector">A transform function to apply to each chunk.</param>
+	/// <returns>A sequence of elements returned by <paramref name="resultSelector"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="resultSelector"/>, or
+	/// <paramref name="array"/> is null.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <c><paramref name="array"/>.Length</c>, specifically the final chunk of
+	/// <paramref name="source"/>.
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Batch</c>, <paramref name="array"/> is used as a common buffer for all subsequences.
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TResult> Batch<TSource, TResult>(
+		this IEnumerable<TSource> source,
+		TSource[] array,
+		Func<IReadOnlyList<TSource>, TResult> resultSelector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(array);
+		Guard.IsNotNull(resultSelector);
+
+		return BatchImpl(source, array, array.Length, resultSelector);
+	}
+
+	/// <summary>
+	/// Split the elements of a sequence into chunks of size at most <paramref name="size"/>.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+	/// <typeparam name="TResult">The type of the value return by <paramref name="resultSelector"/>.</typeparam>
+	/// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
+	/// <param name="size">The maximum size of each chunk.</param>
+	/// <param name="array">An array to use as a buffer for each chunk.</param>
+	/// <param name="resultSelector">A transform function to apply to each chunk.</param>
+	/// <returns>A sequence of elements returned by <paramref name="resultSelector"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="resultSelector"/>, or
+	/// <paramref name="array"/> is null.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1 or above <c><paramref
+	/// name="array"/>.Length</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="size"/>, specifically the final chunk of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// In this overload of <c>Batch</c>, <paramref name="array"/> is used as a common buffer for all subsequences.<br/>
+	/// This overload is provided to ease usage of common buffers, such as those rented from <see
+	/// cref="System.Buffers.ArrayPool{T}"/>, which may return an array larger than requested.
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TResult> Batch<TSource, TResult>(
+		this IEnumerable<TSource> source,
+		TSource[] array,
+		int size,
+		Func<IReadOnlyList<TSource>, TResult> resultSelector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(array);
+		Guard.IsNotNull(resultSelector);
+		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
+
+		return BatchImpl(source, array, size, resultSelector);
+	}
+
+	private static IEnumerable<TResult> BatchImpl<TSource, TResult>(
+		IEnumerable<TSource> source,
+		TSource[] array,
+		int size,
+		Func<IReadOnlyList<TSource>, TResult> resultSelector)
+	{
+		var n = 0;
+		foreach (var item in source)
+		{
+			array[n++] = item;
+			if (n == size)
+			{
+				yield return resultSelector(new ArraySegment<TSource>(array, 0, n));
+				n = 0;
+			}
+		}
+
+		if (n != 0)
+			yield return resultSelector(new ArraySegment<TSource>(array, 0, n));
 	}
 }


### PR DESCRIPTION
This PR adds buffered overloads of `Batch`, which offer a way to use `Batch` with reduced allocation. An array may be passed in, or one can be allocated, but no other allocation will be necessary for execution of these overloads.

For #112