### PR TITLE
Restore `Batch` operator

### DIFF
--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -1,11 +1,95 @@
-﻿using System.Globalization;
-
-namespace Test;
+﻿namespace Test;
 
 public class BatchTest
 {
 	[Fact]
 	public void BatchIsLazy()
+	{
+		_ = new BreakingSequence<int>().Batch(1);
+	}
+
+	[Fact]
+	public void BatchValidatesSize()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("size",
+			() => new BreakingSequence<int>()
+				.Batch(0));
+	}
+
+	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
+		seq
+			.ArrangeCollectionInlineDatas()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetSequences), new int[] { })]
+	public void BatchWithEmptySource(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+			Assert.Empty(seq.Batch(1));
+	}
+
+	[Fact]
+	public void BatchEvenlyDivisibleSequence()
+	{
+		using var seq = Enumerable.Range(1, 9).AsTestingSequence();
+
+		var result = seq.Batch(3);
+		using var reader = result.Read();
+		reader.Read().AssertSequenceEqual(1, 2, 3);
+		reader.Read().AssertSequenceEqual(4, 5, 6);
+		reader.Read().AssertSequenceEqual(7, 8, 9);
+		reader.ReadEnd();
+	}
+
+	[Fact]
+	public void BatchUnevenlyDivisibleSequence()
+	{
+		using var seq = Enumerable.Range(1, 9).AsTestingSequence();
+
+		var result = seq.Batch(4);
+		using var reader = result.Read();
+		reader.Read().AssertSequenceEqual(1, 2, 3, 4);
+		reader.Read().AssertSequenceEqual(5, 6, 7, 8);
+		reader.Read().AssertSequenceEqual(9);
+		reader.ReadEnd();
+	}
+
+	[Fact]
+	public void BatchWithCollectionSmallerThanBatchSize()
+	{
+		using var seq = new BreakingCollection<int>(Enumerable.Range(1, 9));
+		seq.Batch(10).Consume();
+	}
+
+	[Fact]
+	public void BatchCollectionSizeNotEvaluatedEarly()
+	{
+		var list = new List<int>(Enumerable.Range(1, 3));
+		var result = list.Batch(3);
+		list.Add(4);
+		result.AssertCount(2).Consume();
+	}
+
+	[Fact]
+	public void BatchUsesCollectionCountAtIterationTime()
+	{
+		var list = new List<int>(Enumerable.Range(1, 3));
+		using var ts = new BreakingCollection<int>(list);
+		var result = ts.Batch(3);
+
+		// should use `CopyTo`
+		result.AssertCount(1).Consume();
+
+		list.Add(4);
+
+		// should fail trying to enumerate
+		_ = Assert.Throws<TestException>(
+			() => result.AssertCount(2).Consume());
+	}
+
+	[Fact]
+	public void BatchBufferedIsLazy()
 	{
 		_ = new BreakingSequence<int>()
 			.Batch(1, BreakingFunc.Of<IReadOnlyList<int>, int>());
@@ -16,7 +100,7 @@ public class BatchTest
 	}
 
 	[Fact]
-	public void BatchValidatesSize()
+	public void BatchBufferedValidatesSize()
 	{
 		_ = Assert.Throws<ArgumentOutOfRangeException>("size",
 			() => new BreakingSequence<int>()
@@ -30,15 +114,14 @@ public class BatchTest
 	}
 
 	[Fact]
-	public void BatchWithEmptySource()
+	public void BatchBufferedWithEmptySource()
 	{
 		using var xs = TestingSequence.Of<int>();
 		Assert.Empty(xs.Batch(1, BreakingFunc.Of<IReadOnlyList<int>, int>()));
 	}
 
-
 	[Fact]
-	public void BatchEvenlyDivisibleSequence()
+	public void BatchBufferedEvenlyDivisibleSequence()
 	{
 		using var seq = Enumerable.Range(1, 9).AsTestingSequence();
 
@@ -51,7 +134,7 @@ public class BatchTest
 	}
 
 	[Fact]
-	public void BatchUnevenlyDivisibleSequence()
+	public void BatchBufferedUnevenlyDivisibleSequence()
 	{
 		using var seq = Enumerable.Range(1, 9).AsTestingSequence();
 
@@ -64,18 +147,32 @@ public class BatchTest
 	}
 
 	[Fact]
-	public void BatchWithCollectionSmallerThanBatchSize()
+	public void BatchBufferedWithCollectionSmallerThanBatchSize()
 	{
 		using var seq = new BreakingCollection<int>(Enumerable.Range(1, 9));
 		seq.Batch(10, i => i.Sum()).Consume();
 	}
 
+	public static IEnumerable<object[]> GetCollection(IEnumerable<int> seq) =>
+		seq
+			.ArrangeCollectionInlineDatas()
+			.Where(x => x is not TestingSequence<int>)
+			.Select(x => new object[] { x });
+
 	[Fact]
-	public void BatchCollectionSizeNotEvaluatedEarly()
+	public void BatchBufferedUsesCollectionCountAtIterationTime()
 	{
-		var stack = new Stack<int>(Enumerable.Range(1, 3));
-		var result = stack.Batch(3);
-		stack.Push(4);
-		result.AssertCount(2).Consume();
+		var list = new List<int>(Enumerable.Range(1, 3));
+		using var ts = new BreakingCollection<int>(list);
+		var result = ts.Batch(3, w => w[0]);
+
+		// should use `CopyTo`
+		result.AssertCount(1).Consume();
+
+		list.Add(4);
+
+		// should fail trying to enumerate
+		_ = Assert.Throws<TestException>(
+			() => result.AssertCount(2).Consume());
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -5,7 +5,6 @@ namespace Test;
 public enum SourceKind
 {
 	Sequence,
-	BreakingList,
 	BreakingCollection,
 }
 
@@ -53,4 +52,12 @@ internal static partial class TestExtensions
 		yield return input.AsTestingSequence(maxEnumerations: 2);
 		yield return new BreakingCollection<T>(input);
 	}
+
+	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
+		sourceKind switch
+		{
+			SourceKind.Sequence => input.AsTestingSequence(),
+			SourceKind.BreakingCollection => new BreakingCollection<T>(input),
+			_ => ThrowHelper.ThrowArgumentException<IDisposableEnumerable<T>>(nameof(sourceKind)),
+		};
 }


### PR DESCRIPTION
This PR restores and improves the non-collection version `Batch` operator. 

Other fixes:
* Remove unnecessary `SourceKind`
* Fix bug in collection version of `Batch`

Fixes #206
