### PR TITLE
Add `Memoize` operator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -206,6 +206,8 @@ csharp_preserve_single_line_statements = true:silent
 # Style Analytics
 dotnet_analyzer_diagnostic.category-Style.severity = warning
 
+dotnet_diagnostic.IDE0046.severity = silent				# IDE0046: Convert to conditional expression
+
 # For ScanEx()
 dotnet_code_quality.ca1711.allowed_suffixes = Ex
 

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -1,4 +1,8 @@
-﻿namespace SuperLinq;
+﻿using System.Collections;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -38,6 +42,355 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IBuffer<TSource> Memoize<TSource>(this IEnumerable<TSource> source, bool forceCache = true)
 	{
-		throw new NotImplementedException();
+		Guard.IsNotNull(source);
+
+		return (source, forceCache) switch
+		{
+			(ICollection<TSource> coll, true) => new CollectionMemoizedBuffer<TSource>(coll),
+			(ICollection<TSource> coll, false) => new CollectionProxyBuffer<TSource>(coll),
+			_ => new EnumerableMemoizedBuffer<TSource>(source),
+		};
+	}
+
+	private sealed class EnumerableMemoizedBuffer<T> : IBuffer<T>
+	{
+		private readonly object _lock = new();
+
+		private readonly IEnumerable<T> _source;
+
+		private IEnumerator<T>? _enumerator;
+		private List<T> _buffer = new();
+		private bool _initialized;
+
+		private ExceptionDispatchInfo? _exception;
+		private int? _exceptionIndex;
+
+		private bool _disposed;
+
+		public EnumerableMemoizedBuffer(IEnumerable<T> source)
+		{
+			_source = source;
+		}
+
+		public int Count => _buffer.Count;
+
+		public void Reset()
+		{
+			lock (_lock)
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+
+				if (_exceptionIndex == -1)
+					return;
+
+				_buffer = new();
+				_initialized = false;
+				_enumerator?.Dispose();
+				_enumerator = null;
+				_exceptionIndex = null;
+				_exception = null;
+			}
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			InitializeEnumerator();
+			return GetEnumeratorImpl();
+		}
+
+		private void InitializeEnumerator()
+		{
+			lock (_lock)
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+
+				if (_exceptionIndex == -1)
+				{
+					Guard.IsNotNull(_exception);
+					_exception.Throw();
+				}
+
+				if (_initialized)
+					return;
+
+				try
+				{
+					_enumerator = _source.GetEnumerator();
+					_initialized = true;
+				}
+				catch (Exception ex)
+				{
+					_exception = ExceptionDispatchInfo.Capture(ex);
+					_exceptionIndex = -1;
+					throw;
+				}
+			}
+		}
+
+		private IEnumerator<T> GetEnumeratorImpl()
+		{
+			var buffer = _buffer;
+			var index = 0;
+			while (true)
+			{
+				T? element;
+				lock (_lock)
+				{
+					if (_disposed)
+						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					if (!_initialized
+						|| buffer != _buffer)
+					{
+						ThrowHelper.ThrowInvalidOperationException("Buffer reset during iteration.");
+					}
+
+					if (index >= _buffer.Count)
+					{
+						if (index == _exceptionIndex)
+						{
+							if (_exception == null)
+								ThrowHelper.ThrowInvalidOperationException();
+							_exception.Throw();
+						}
+
+						if (_enumerator == null)
+							break;
+
+						var moved = false;
+						try
+						{
+							moved = _enumerator.MoveNext();
+						}
+						catch (Exception ex)
+						{
+							_exception = ExceptionDispatchInfo.Capture(ex);
+							_exceptionIndex = index;
+							_enumerator.Dispose();
+							_enumerator = null;
+							throw;
+						}
+
+						if (!moved)
+						{
+							_enumerator.Dispose();
+							_enumerator = null;
+							break;
+						}
+
+						_buffer.Add(_enumerator.Current);
+
+						if (index >= _buffer.Count)
+							ThrowHelper.ThrowInvalidOperationException();
+					}
+
+					element = _buffer[index];
+				}
+
+				yield return element;
+				index++;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public void Dispose()
+		{
+			lock (_lock)
+			{
+				_disposed = true;
+				_buffer.Clear();
+				_enumerator?.Dispose();
+				_enumerator = null;
+			}
+		}
+	}
+
+	private sealed class CollectionMemoizedBuffer<T> : IBuffer<T>
+	{
+		private enum State
+		{
+			Uninitialized,
+			Initializing,
+			Initialized,
+			Disposed,
+			Error,
+	}
+
+		private sealed record CmbHelper(State State, T[]? Buffer = null, ExceptionDispatchInfo? Exception = null);
+
+		private ICollection<T>? _source;
+
+		private volatile CmbHelper _state;
+
+		public CollectionMemoizedBuffer(ICollection<T> source)
+		{
+			_source = source;
+			_state = new(State.Uninitialized, null);
+}
+
+		public int Count
+		{
+			get
+			{
+				var h = _state;
+				if (h.State != State.Initialized)
+					return 0;
+				return h.Buffer!.Length;
+			}
+		}
+
+		public void Reset()
+		{
+			while (true)
+			{
+				var h = _state;
+				switch (h.State)
+				{
+					case State.Uninitialized:
+						return;
+
+					case State.Initializing:
+						break;
+
+					case State.Initialized:
+					case State.Error:
+					{
+						var res = Interlocked.CompareExchange(ref _state, new(State.Uninitialized), h);
+						if (res != h)
+							continue;
+						return;
+					}
+
+					case State.Disposed:
+						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						break;
+
+					default:
+						throw new UnreachableException();
+				}
+			}
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			var buffer = InitializeBuffer();
+			return GetEnumeratorImpl(buffer);
+		}
+
+		private T[] InitializeBuffer()
+		{
+			var source = _source;
+
+			while (true)
+			{
+				var h = _state;
+				switch (h.State)
+				{
+					case State.Uninitialized:
+					{
+						var tmp = new CmbHelper(State.Initializing);
+						// are we first?
+						var res = Interlocked.CompareExchange(ref _state, tmp, h);
+						if (res != h) continue;
+						h = tmp;
+
+						// we should be only ones inside here
+						if (source == null)
+							ThrowHelper.ThrowInvalidOperationException();
+
+						T[]? array;
+						try
+						{
+							// try to get the array
+							array = source.ToArray();
+						}
+						catch (Exception ex)
+						{
+							var edi = ExceptionDispatchInfo.Capture(ex);
+							// if it doesn't get set, then we're disposed, so don't worry about it
+							_ = Interlocked.CompareExchange(ref _state, new(State.Error, Exception: edi), h);
+							throw;
+						}
+
+						// we've got an array, set it
+						res = Interlocked.CompareExchange(ref _state, new(State.Initialized, Buffer: array), tmp);
+						// only way this could happen is dispose, so loop again to trigger dispose handling
+						if (res != tmp) continue;
+
+						// we've got the array, hand it out.
+						return array;
+					}
+
+					case State.Initializing:
+						continue;
+
+					case State.Initialized:
+						if (h.Buffer == null)
+							ThrowHelper.ThrowInvalidOperationException();
+						return h.Buffer;
+
+					case State.Disposed:
+						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						break;
+
+					case State.Error:
+						h.Exception!.Throw();
+						break;
+
+					default:
+						throw new UnreachableException();
+				}
+			}
+		}
+
+		private IEnumerator<T> GetEnumeratorImpl(T[] buffer)
+		{
+			foreach (var i in buffer)
+			{
+				if (_state.State == State.Disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+
+				if (_state.State != State.Initialized
+					|| _state.Buffer != buffer)
+				{
+					ThrowHelper.ThrowInvalidOperationException("Buffer reset during iteration.");
+				}
+
+				yield return i;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public void Dispose()
+		{
+			// don't care what current state is, force everyone out
+			_ = Interlocked.Exchange(ref _state, new(State.Disposed));
+			_source = null;
+		}
+	}
+
+	private sealed class CollectionProxyBuffer<T> : IBuffer<T>
+	{
+		public CollectionProxyBuffer(ICollection<T> source)
+		{
+			_source = source;
+		}
+
+		private ICollection<T>? _source;
+		private ICollection<T> Source =>
+			_source ?? ThrowHelper.ThrowObjectDisposedException<ICollection<T>>(nameof(IBuffer<T>));
+
+		// nothing to do here
+		public void Reset() { }
+
+		public int Count => Source.Count;
+
+		public IEnumerator<T> GetEnumerator() => Source.GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => Source.GetEnumerator();
+
+		public void Dispose() => _source = null;
 	}
 }

--- a/Tests/SuperLinq.Test/BreakingCollection.cs
+++ b/Tests/SuperLinq.Test/BreakingCollection.cs
@@ -13,9 +13,15 @@ internal class BreakingCollection<T> : BreakingSequence<T>, ICollection<T>, IDis
 	public void Add(T item) => Assert.Fail("LINQ Operators should not be calling this method.");
 	public void Clear() => Assert.Fail("LINQ Operators should not be calling this method.");
 	public bool Contains(T item) => List.Contains(item);
-	public void CopyTo(T[] array, int arrayIndex) => List.CopyTo(array, arrayIndex);
 	public bool Remove(T item) { Assert.Fail("LINQ Operators should not be calling this method."); return false; }
 	public bool IsReadOnly => true;
+
+	public int CopyCount { get; private set; }
+	public virtual void CopyTo(T[] array, int arrayIndex)
+	{
+		List.CopyTo(array, arrayIndex);
+		CopyCount++;
+	}
 
 	public void Dispose() { }
 }

--- a/Tests/SuperLinq.Test/MemoizeTest.cs
+++ b/Tests/SuperLinq.Test/MemoizeTest.cs
@@ -1,0 +1,435 @@
+﻿using System.Collections;
+using CommunityToolkit.Diagnostics;
+
+namespace Test;
+
+public class MemoizeTest
+{
+	[Fact]
+	public void MemoizeIsLazy()
+	{
+		_ = new BreakingSequence<int>().Memoize();
+	}
+
+	public static IEnumerable<object[]> GetSequences() =>
+		Enumerable.Range(1, 10)
+			.ArrangeCollectionInlineDatas()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void MemoizeSimpleUse(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var buffer = seq.Memoize();
+
+			buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+			Assert.Equal(10, buffer.Count);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void MemoizeReturningExpectedElementsWhenUsedAtInnerForEach(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var buffer = seq.Memoize();
+
+			var flowArray = InnerForEach(Enumerable.Range(1, 10));
+			var flowBuffer = InnerForEach(buffer);
+
+			flowArray.AssertSequenceEqual(flowBuffer);
+
+			static IEnumerable<object> InnerForEach(IEnumerable<int> source)
+			{
+				var firstVisitAtInnerLoopDone = false;
+
+				//add 1-3 to cache (so enter inner loop)
+				//consume 4-5 already cached
+				//add 6-7 to cache (so enter inner loop)
+				//consume 8-10 already cached
+
+				yield return "enter outer loop";
+				foreach (var i in source)
+				{
+					yield return i;
+
+					if (i is 3 or 7)
+					{
+						//consume 1-3 already cached
+						//add 4-5 to cache (so go to outer loop)
+						//consume 1-7 already cached
+						//add 8-10 to cache (so go to outer loop)
+
+						yield return "enter inner loop";
+						foreach (var j in source)
+						{
+							yield return j;
+
+							if (!firstVisitAtInnerLoopDone && j == 5)
+							{
+								firstVisitAtInnerLoopDone = true;
+								break;
+							}
+						}
+						yield return "exit inner loop";
+					}
+				}
+				yield return "exit outer loop";
+
+				yield return "enter last loop";
+				//consume 1-10 (all item were already cached)
+				foreach (var k in source)
+				{
+					yield return k;
+				}
+				yield return "exit last loop";
+			}
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public static void MemoizeThrowsWhenCacheDisposedDuringIteration(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var buffer = seq.Memoize();
+
+			using var reader = buffer.Read();
+			Assert.Equal(1, reader.Read());
+
+			buffer.Dispose();
+
+			_ = Assert.Throws<ObjectDisposedException>(
+				() => reader.Read());
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public static void MemoizeThrowsWhenGettingIteratorAfterDispose(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var buffer = seq.Memoize();
+
+			buffer.Consume();
+			buffer.Dispose();
+
+			_ = Assert.Throws<ObjectDisposedException>(
+				() => buffer.Consume());
+		}
+	}
+
+	[Fact]
+	public void MemoizeIteratorWithPartialIterationBeforeCompleteIteration()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = seq.Memoize();
+
+		buffer.Take(5).AssertSequenceEqual(Enumerable.Range(0, 5));
+		Assert.Equal(5, buffer.Count);
+
+		buffer.AssertSequenceEqual(Enumerable.Range(0, 10));
+		Assert.Equal(10, buffer.Count);
+	}
+
+	[Fact]
+	public void MemoizeIteratorWithDisposeOnEarlyExitTrue()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = seq.Memoize();
+
+		using (buffer)
+			buffer.Take(1).Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public void MemoizeIteratorDisposesAfterSourceIsIteratedEntirely()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = seq.Memoize();
+		buffer.Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public void MemoizeIteratorEnumeratesOnlyOnce()
+	{
+		using var ts = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = ts.Memoize();
+
+		buffer.AssertSequenceEqual(Enumerable.Range(0, 10));
+		buffer.AssertSequenceEqual(Enumerable.Range(0, 10));
+	}
+
+	[Fact]
+	public static void MemoizeIteratorRestartsAfterReset()
+	{
+		var starts = 0;
+
+		IEnumerable<int> TestSequence()
+		{
+			starts++;
+			yield return 1;
+			yield return 2;
+		}
+
+		using var seq = TestSequence().AsTestingSequence(maxEnumerations: 2);
+		using var memoized = seq.Memoize();
+
+		memoized.Take(1).Consume();
+		Assert.Equal(1, starts);
+
+		memoized.Reset();
+		memoized.Take(1).Consume();
+		Assert.Equal(2, starts);
+	}
+
+	[Fact]
+	public void MemoizeIteratorRethrowsErrorDuringIterationToAllIteratorsUntilReset()
+	{
+		using var xs = SeqExceptionAt(2).AsTestingSequence(maxEnumerations: 2);
+
+		using var memoized = xs.Memoize();
+
+		using (var r1 = memoized.Read())
+		using (var r2 = memoized.Read())
+		{
+			Guard.IsTrue(r1.Read() == r2.Read());
+			_ = Assert.Throws<TestException>(() => r1.Read());
+
+			Guard.IsTrue(xs.IsDisposed);
+
+			_ = Assert.Throws<TestException>(() => r2.Read());
+		}
+
+		memoized.Reset();
+
+		using (var r1 = memoized.Read())
+			Assert.Equal(1, r1.Read());
+	}
+
+	[Fact]
+	public void MemoizeIteratorRethrowsErrorDuringIterationStartToAllIteratorsUntilReset()
+	{
+		var i = 0;
+		using var xs = SuperEnumerable
+			.From(() => i++ == 0 ? throw new TestException() : 42)
+			.AsTestingSequence(maxEnumerations: 2);
+
+		using var memoized = xs.Memoize();
+
+		using (var r1 = memoized.Read())
+		using (var r2 = memoized.Read())
+		{
+			_ = Assert.Throws<TestException>(() => r1.Read());
+			Guard.IsTrue(xs.IsDisposed);
+			_ = Assert.Throws<TestException>(() => r2.Read());
+		}
+
+		memoized.Reset();
+		using (var r1 = memoized.Read())
+		using (var r2 = memoized.Read())
+			Guard.IsTrue(r1.Read() == r2.Read());
+	}
+
+	[Fact]
+	public void MemoizeIteratorRethrowsErrorDuringFirstIterationStartToAllIterationsUntilReset()
+	{
+		using var seq = new FailingEnumerable().AsTestingSequence(maxEnumerations: 2);
+		using var memo = seq.Memoize();
+
+		for (var i = 0; i < 2; i++)
+			_ = Assert.Throws<TestException>(() => memo.First());
+
+		memo.Reset();
+		memo.AssertSequenceEqual(1);
+	}
+
+	private class FailingEnumerable : IEnumerable<int>
+	{
+		private bool _started;
+		public IEnumerator<int> GetEnumerator()
+		{
+			if (!_started)
+			{
+				_started = true;
+				throw new TestException();
+			}
+			yield return 1;
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	[Fact]
+	public void MemoizeCollectionsUseCopyTo()
+	{
+		using var list = new BreakingCollection<int>(Enumerable.Range(0, 10));
+
+		using var buffer = list.Memoize();
+
+		buffer.Take(1).Consume();
+		Assert.Equal(10, buffer.Count);
+	}
+
+	[Fact]
+	public void MemoizeCollectionEnumeratesOnlyOnce()
+	{
+		using var ts = new BreakingCollection<int>(Enumerable.Range(0, 10));
+
+		using var buffer = ts.Memoize();
+
+		buffer.AssertSequenceEqual(Enumerable.Range(0, 10));
+		buffer.AssertSequenceEqual(Enumerable.Range(0, 10));
+		Assert.Equal(1, ts.CopyCount);
+	}
+
+	[Fact]
+	public static void MemoizeCollectionRestartsAfterReset()
+	{
+		using var ts = new BreakingCollection<int>(Enumerable.Range(0, 10));
+		using var memoized = ts.Memoize();
+
+		memoized.Take(1).Consume();
+		Assert.Equal(1, ts.CopyCount);
+		Assert.Equal(10, memoized.Count);
+
+		memoized.Reset();
+		memoized.Take(1).Consume();
+		Assert.Equal(2, ts.CopyCount);
+		Assert.Equal(10, memoized.Count);
+	}
+
+	[Fact]
+	public void MemoizeCollectionRethrowsErrorDuringFirstIterationStartToAllIterationsUntilReset()
+	{
+		using var ts = new FailingCollection();
+		using var memo = ts.Memoize();
+
+		for (var i = 0; i < 2; i++)
+			_ = Assert.Throws<TestException>(() => memo.First());
+
+		memo.Reset();
+		memo.AssertSequenceEqual(1);
+		Assert.Equal(1, ts.CopyCount);
+	}
+
+	private class FailingCollection : BreakingCollection<int>
+	{
+		public FailingCollection() : base(1) { }
+
+		private bool _started;
+		public override void CopyTo(int[] array, int arrayIndex)
+		{
+			if (!_started)
+			{
+				_started = true;
+				throw new TestException();
+			}
+			base.CopyTo(array, arrayIndex);
+		}
+	}
+
+	[Fact]
+	public void MemoizeProxySimpleUse()
+	{
+		var ts = Enumerable.Range(1, 10).ToArray();
+		using var buffer = ts.Memoize(forceCache: false);
+
+		buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+		Assert.Equal(10, buffer.Count);
+	}
+
+	[Fact]
+	public void MemoizeProxyThrowsExceptionAfterDisposal()
+	{
+		var ts = Enumerable.Range(1, 10).ToArray();
+		var buffer = ts.Memoize(forceCache: false);
+
+		buffer.Consume();
+		buffer.Dispose();
+
+		_ = Assert.Throws<ObjectDisposedException>(buffer.Consume);
+	}
+
+	[Fact]
+	public void MemoizeProxyReturnsCollectionIteratorDirectly()
+	{
+		var iterator = Enumerable.Empty<int>().GetEnumerator();
+		var coll = new ProxyCollection(() => iterator, () => 42);
+		var memo = coll.Memoize(forceCache: false);
+
+		Assert.Same(iterator, memo.GetEnumerator());
+		Assert.Equal(42, memo.Count);
+	}
+
+	private class ProxyCollection : ICollection<int>
+	{
+		private readonly Func<IEnumerator<int>> _enumeratorFunc;
+		private readonly Func<int> _countFunc;
+
+		public ProxyCollection(
+			Func<IEnumerator<int>> enumeratorFunc,
+			Func<int> countFunc)
+		{
+			_enumeratorFunc = enumeratorFunc;
+			_countFunc = countFunc;
+		}
+
+		public int Count => _countFunc();
+
+		public void Add(int item) => throw new TestException();
+		public void Clear() => throw new TestException();
+		public bool Contains(int item) => throw new TestException();
+		public bool Remove(int item) => throw new TestException();
+		public bool IsReadOnly => true;
+
+		public virtual void CopyTo(int[] array, int arrayIndex) => throw new TestException();
+
+		public IEnumerator<int> GetEnumerator() => _enumeratorFunc();
+		IEnumerator IEnumerable.GetEnumerator() => _enumeratorFunc();
+	}
+
+#if false
+	[Test, Explicit]
+	public static void MemoizeIsThreadSafe()
+	{
+		var sequence = Enumerable.Range(1, 50000);
+		using var ts = sequence.AsTestingSequence();
+		var memoized = ts.Memoize();
+
+		var lists = Enumerable.Range(0, Environment.ProcessorCount * 2)
+							  .Select(_ => new List<int>())
+							  .ToArray();
+
+		using var start = new Barrier(lists.Length);
+
+		var threads =
+			from list in lists
+			select new Thread(() =>
+			{
+				start.SignalAndWait();
+				list.AddRange(memoized);
+			});
+
+		threads.Pipe(t => t.Start())
+			   .ToArray() // start all before joining
+			   .ForEach(t => t.Join());
+
+		Assert.That(sequence, Is.EqualTo(memoized));
+		lists.ForEach(list => Assert.That(list, Is.EqualTo(memoized)));
+	}
+#endif
+}


### PR DESCRIPTION
This PR adds the `Memoize` operator using an `IBuffer<T>` return type.

Fixes #208
