### PR TITLE
Consolidate `TryGetCollectionCount` usage

### DIFF
--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -28,7 +28,7 @@ public static partial class SuperEnumerable
 
 		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count)
 		{
-			if (source.TryGetCollectionCount(out var c))
+			if (source.TryGetCollectionCount() is int c)
 			{
 				Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
 

--- a/Source/SuperLinq/CopyTo.cs
+++ b/Source/SuperLinq/CopyTo.cs
@@ -33,7 +33,7 @@ public static partial class SuperEnumerable
 			arr.AsSpan().CopyTo(span);
 			return arr.Length;
 		}
-		else if (TryGetCollectionCount(source, out var n))
+		else if (source.TryGetCollectionCount() is int n)
 		{
 			if (n > span.Length)
 				ThrowHelper.ThrowArgumentException(nameof(span), "Destination is not long enough.");
@@ -101,7 +101,7 @@ public static partial class SuperEnumerable
 			coll.CopyTo(array, index);
 			return coll.Count;
 		}
-		else if (TryGetCollectionCount(source, out var n))
+		else if (source.TryGetCollectionCount() is int n)
 		{
 			if (n + index > array.Length)
 				ThrowHelper.ThrowArgumentException(nameof(array), "Destination is not long enough.");
@@ -186,7 +186,7 @@ public static partial class SuperEnumerable
 		{
 #if NET6_0_OR_GREATER
 			if (list is List<TSource> l
-				&& TryGetCollectionCount(source, out var n))
+				&& source.TryGetCollectionCount() is int n)
 			{
 				l.EnsureCapacity(n + index);
 			}

--- a/Source/SuperLinq/CountDown.cs
+++ b/Source/SuperLinq/CountDown.cs
@@ -77,7 +77,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
-		return source.TryGetCollectionCount(out var _)
+		return source.TryGetCollectionCount() is int
 			? IterateCollection(source, count, resultSelector)
 			: IterateSequence(source, count, resultSelector);
 
@@ -88,7 +88,7 @@ public static partial class SuperEnumerable
 			// Enumerable counts can change over time, so it is very
 			// important that this check happens at enumeration time;
 			// do not move it outside of the iterator method.
-			_ = source.TryGetCollectionCount(out var i);
+			var i = source.TryGetCollectionCount()!.Value;
 			foreach (var item in source)
 				yield return resultSelector(item, i-- <= count ? i : null);
 		}

--- a/Source/SuperLinq/CountMethods.cs
+++ b/Source/SuperLinq/CountMethods.cs
@@ -147,11 +147,11 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(first);
 		Guard.IsNotNull(second);
 
-		if (first.TryGetCollectionCount(out var firstCount))
+		if (first.TryGetCollectionCount() is int firstCount)
 		{
 			return firstCount.CompareTo(second.TryGetCollectionCount() ?? second.CountUpTo(firstCount + 1));
 		}
-		else if (second.TryGetCollectionCount(out var secondCount))
+		else if (second.TryGetCollectionCount() is int secondCount)
 		{
 			return first.CountUpTo(secondCount + 1).CompareTo(secondCount);
 		}

--- a/Source/SuperLinq/ElementAt.cs
+++ b/Source/SuperLinq/ElementAt.cs
@@ -69,7 +69,7 @@ public static partial class SuperEnumerable
 			return Enumerable.ElementAt(source, index.Value);
 		}
 
-		if (source.TryGetCollectionCount(out var count))
+		if (source.TryGetCollectionCount() is int count)
 		{
 			return Enumerable.ElementAt(source, count - index.Value);
 		}

--- a/Source/SuperLinq/EndsWith.cs
+++ b/Source/SuperLinq/EndsWith.cs
@@ -50,8 +50,8 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(first);
 		Guard.IsNotNull(second);
 
-		if (first.TryGetCollectionCount(out var firstCount) &&
-			second.TryGetCollectionCount(out var secondCount) &&
+		if (first.TryGetCollectionCount() is int firstCount &&
+			second.TryGetCollectionCount() is int secondCount &&
 			secondCount > firstCount)
 		{
 			return false;

--- a/Source/SuperLinq/FindIndex.cs
+++ b/Source/SuperLinq/FindIndex.cs
@@ -111,7 +111,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
-		if (TryGetCollectionCount(source, out var length))
+		if (source.TryGetCollectionCount() is int length)
 		{
 			index = index.GetOffset(length);
 		}

--- a/Source/SuperLinq/FindLastIndex.cs
+++ b/Source/SuperLinq/FindLastIndex.cs
@@ -115,7 +115,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
-		if (TryGetCollectionCount(source, out var length))
+		if (source.TryGetCollectionCount() is int length)
 		{
 			index = index.GetOffset(length);
 		}

--- a/Source/SuperLinq/PadStart.cs
+++ b/Source/SuperLinq/PadStart.cs
@@ -100,7 +100,7 @@ public static partial class SuperEnumerable
 			IEnumerable<TSource> source, int width,
 			Func<int, TSource> paddingSelector)
 		{
-			if (source.TryGetCollectionCount(out var collectionCount))
+			if (source.TryGetCollectionCount() is int collectionCount)
 			{
 				for (var i = 0; i < width - collectionCount; i++)
 					yield return paddingSelector(i);

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -64,7 +64,7 @@ public static partial class SuperEnumerable
 		static IEnumerable<TSource> Core(IEnumerable<TSource> source, TSource value, Index index)
 		{
 			if (index.IsFromEnd
-				&& source.TryGetCollectionCount(out var count))
+				&& source.TryGetCollectionCount() is int count)
 			{
 				index = index.GetOffset(count);
 			}

--- a/Source/SuperLinq/StartsWith.cs
+++ b/Source/SuperLinq/StartsWith.cs
@@ -52,8 +52,8 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(first);
 		Guard.IsNotNull(second);
 
-		if (first.TryGetCollectionCount(out var firstCount) &&
-			second.TryGetCollectionCount(out var secondCount) &&
+		if (first.TryGetCollectionCount() is int firstCount &&
+			second.TryGetCollectionCount() is int secondCount &&
 			secondCount > firstCount)
 		{
 			return false;

--- a/Source/SuperLinq/Subsets.cs
+++ b/Source/SuperLinq/Subsets.cs
@@ -195,7 +195,7 @@ public static partial class SuperEnumerable
 			_sequence = sequence;
 
 			Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
-			if (sequence.TryGetCollectionCount(out var cnt))
+			if (sequence.TryGetCollectionCount() is int cnt)
 				Guard.IsLessThanOrEqualTo(subsetSize, cnt - 1);
 
 			_subsetSize = subsetSize;

--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -19,26 +19,5 @@ public static partial class SuperEnumerable
 		};
 #endif
 
-	internal static bool TryGetCollectionCount<T>(this IEnumerable<T> source, out int count)
-	{
-		Guard.IsNotNull(source);
-#if NET6_0_OR_GREATER
-		return source.TryGetNonEnumeratedCount(out count);
-#else
-		switch (source)
-		{
-			case ICollection<T> collection:
-				count = collection.Count;
-				return true;
-			case System.Collections.ICollection collection:
-				count = collection.Count;
-				return true;
-			default:
-				count = default;
-				return false;
-		}
-#endif
-	}
-
 	internal static (bool HasValue, T Value) Some<T>(T value) => (true, value);
 }

--- a/Source/SuperLinq/Take.cs
+++ b/Source/SuperLinq/Take.cs
@@ -68,7 +68,7 @@ public static partial class SuperEnumerable
 		// Enumerable counts can change over time, so it is very
 		// important that this check happens at enumeration time;
 		// do not move it outside of the iterator method.
-		if (source.TryGetCollectionCount(out var count))
+		if (source.TryGetCollectionCount() is int count)
 		{
 			var startIndex = start.GetOffset(count);
 			var endIndex = end.GetOffset(count);
@@ -126,6 +126,7 @@ public static partial class SuperEnumerable
 
 			var startCount = start.Value;
 			var endCount = end.Value;
+			count = 0;
 			while (count < startCount && e.MoveNext())
 			{
 				++count;

--- a/Source/SuperLinq/TrySingle.cs
+++ b/Source/SuperLinq/TrySingle.cs
@@ -85,28 +85,25 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(resultSelector);
 
-		switch (source.TryGetCollectionCount())
+		if (source.TryGetCollectionCount() is int n)
 		{
-			case 0:
+			return n switch
+			{
+				0 => resultSelector(zero, default),
+				1 => resultSelector(one, source.First()),
+				_ => resultSelector(many, default),
+			};
+		}
+		else
+		{
+			using var e = source.GetEnumerator();
+			if (!e.MoveNext())
 				return resultSelector(zero, default);
-			case 1:
-			{
-				return resultSelector(one, source.First());
-			}
-			case > 1:
-				return resultSelector(many, default);
 
-			default:
-			{
-				using var e = source.GetEnumerator();
-				if (!e.MoveNext())
-					return resultSelector(zero, default);
-
-				var current = e.Current;
-				return !e.MoveNext()
-					? resultSelector(one, current)
-					: resultSelector(many, default);
-			}
+			var current = e.Current;
+			return !e.MoveNext()
+				? resultSelector(one, current)
+				: resultSelector(many, default);
 		}
 	}
 }


### PR DESCRIPTION
This PR consolidate usages of `TryGetCollectionCount` to a single method, rather than both `out` and `int?` versions. `int?` is more convenient and possibly easier to JIT, so convert all existing uses to that.

Fixes #200