### PR TITLE
Add `Buffer` overload

### DIFF
--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -1,21 +1,4 @@
-﻿#region License and Terms
-// SuperLinq - Extensions to LINQ to Objects
-// Copyright (c) 2009 Atif Aziz. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-#endregion
-
-namespace SuperLinq;
+﻿namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -25,9 +8,19 @@ public static partial class SuperEnumerable
 	/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
 	/// <param name="source">An <see cref="IEnumerable{T}"/> whose elements to chunk.</param>
 	/// <param name="size">The maximum size of each chunk.</param>
-	/// <returns>An <see cref="IEnumerable{T}"/> that contains the elements the input sequence split into chunks of size size.</returns>
+	/// <returns>An <see cref="IEnumerable{T}"/> that contains the elements the input sequence split into chunks of size
+	/// size.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="size"/>, specifically the final buffer of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
 	public static IEnumerable<IList<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
 	{
 		// yes this operator duplicates on net6+; but no name overlap, so leave alone

--- a/Source/SuperLinq/Buffer.cs
+++ b/Source/SuperLinq/Buffer.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Generates a sequence of non-overlapping adjacent buffers over the source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Number of elements for allocated buffers.</param>
+	/// <returns>Sequence of buffers containing source sequence elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than or equal to
+	/// <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="count"/>, specifically the final buffer of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// This method is a synonym for <see cref="Batch{TSource}(IEnumerable{TSource}, int)"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<IList<TSource>> Buffer<TSource>(this IEnumerable<TSource> source, int count)
+	{
+		return Batch(source, count);
+	}
+
+	/// <summary>
+	/// Generates a sequence of buffers over the source sequence, with specified length and possible overlap.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Number of elements for allocated buffers.</param>
+	/// <param name="skip">Number of elements to skip between the start of consecutive buffers.</param>
+	/// <returns>Sequence of buffers containing source sequence elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> or <paramref name="skip"/> is less than
+	/// or equal to <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="count"/>, specifically the final buffers of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<IList<TSource>> Buffer<TSource>(this IEnumerable<TSource> source, int count, int skip)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThan(count, 0);
+		Guard.IsGreaterThan(skip, 0);
+
+		return Core(source, count, skip);
+
+		static IEnumerable<IList<TSource>> Core(IEnumerable<TSource> source, int count, int skip)
+		{
+			var lists = new Queue<List<TSource>>();
+
+			var i = 0;
+			foreach (var el in source)
+			{
+				if (i++ % skip == 0)
+					lists.Enqueue(new());
+
+				foreach (var l in lists)
+					l.Add(el);
+
+				if (lists.Count > 0 && lists.Peek().Count == count)
+					yield return lists.Dequeue();
+			}
+
+			while (lists.Count > 0)
+				yield return lists.Dequeue();
+		}
+	}
+}

--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -6,6 +6,7 @@ public class BatchTest
 	public void BatchIsLazy()
 	{
 		_ = new BreakingSequence<int>().Batch(1);
+		_ = new BreakingSequence<int>().Buffer(1);
 	}
 
 	[Fact]

--- a/Tests/SuperLinq.Test/BufferTest.cs
+++ b/Tests/SuperLinq.Test/BufferTest.cs
@@ -1,0 +1,72 @@
+﻿namespace Test;
+
+public class BufferTest
+{
+	[Fact]
+	public void BufferIsLazy()
+	{
+		_ = new BreakingSequence<int>().Buffer(2, 1);
+	}
+
+	[Fact]
+	public void BufferValidatesCount()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("count",
+			() => new BreakingSequence<int>().Buffer(0, 2));
+	}
+
+	[Fact]
+	public void BufferValidatesSkip()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("skip",
+			() => new BreakingSequence<int>().Buffer(2, 0));
+	}
+
+	[Fact]
+	public void BufferEmptySequence()
+	{
+		using var seq = Enumerable.Empty<int>().AsTestingSequence();
+
+		var result = seq.Buffer(1, 2);
+		result.AssertSequenceEqual();
+	}
+
+	[Theory]
+	[InlineData(3)]
+	[InlineData(5)]
+	[InlineData(7)]
+	public void BufferNonOverlappingBuffers(int count)
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(count, count);
+		foreach (var (actual, expected) in result.EquiZip(Enumerable.Range(1, 10).Batch(count)))
+			actual.AssertSequenceEqual(expected);
+	}
+
+	[Fact]
+	public void BufferOverlappingBuffers()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(5, 3);
+		using var reader = result.Read();
+		reader.Read().AssertSequenceEqual(Enumerable.Range(1, 5));
+		reader.Read().AssertSequenceEqual(Enumerable.Range(4, 5));
+		reader.Read().AssertSequenceEqual(Enumerable.Range(7, 4));
+		reader.Read().AssertSequenceEqual(Enumerable.Range(10, 1));
+		reader.ReadEnd();
+	}
+
+	[Fact]
+	public void BufferSkippingBuffers()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(5, 7);
+		using var reader = result.Read();
+		reader.Read().AssertSequenceEqual(Enumerable.Range(1, 5));
+		reader.Read().AssertSequenceEqual(Enumerable.Range(8, 3));
+		reader.ReadEnd();
+	}
+}


### PR DESCRIPTION
This PR migrates the `Buffer` operator from `System.Interactive`.

Fixes #212 