### PR TITLE
Automate GH Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ on:
       - 'master'
     paths-ignore:
       - '**/readme.md'
-    tags:
-      - '**'
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -45,10 +43,3 @@ jobs:
       
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-
-    - name: Package 
-      run: dotnet pack -c Release --no-build -o nupkgs
-      if: startsWith(github.ref, 'refs/tags/')
-    - name: Push to Nuget
-      run: dotnet nuget push "./nupkgs/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGETPUBLISHKEY }}
-      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build -c Release --no-restore
+
+    - name: Package 
+      run: dotnet pack -c Release --no-build -o nupkgs
+    - name: Push to Nuget
+      run: dotnet nuget push "./nupkgs/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGETPUBLISHKEY }}
+
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        generateReleaseNotes: 'true'
+        makeLatest: 'true'

--- a/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
+++ b/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net7.0</TargetFrameworks>
 		<NoWarn>$(NoWarn);CA1852;NU1701</NoWarn>
+		<IsPackable>false</IsPackable>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/SuperLinq.sln
+++ b/SuperLinq.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".root", ".root", "{835F8FFA
 		.github\workflows\docs.yml = .github\workflows\docs.yml
 		license.txt = license.txt
 		README.md = README.md
+		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{8392DDDC-9D3E-4A41-A93C-1EF1503D71F9}"
@@ -34,7 +35,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuperLinq.Async.Generator",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{210A4922-6BBE-47D6-901E-38127E15C4C4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuperLinq.Docs", "Docs\SuperLinq.Docs\SuperLinq.Docs.csproj", "{33BCC44C-84B3-4C0A-9643-1530B5B65C11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuperLinq.Docs", "Docs\SuperLinq.Docs\SuperLinq.Docs.csproj", "{33BCC44C-84B3-4C0A-9643-1530B5B65C11}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{30FDB542-4F2B-40E0-9FD9-2BCC8CA05009}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
+		.github\workflows\docs.yml = .github\workflows\docs.yml
+		.github\workflows\release.yml = .github\workflows\release.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -82,6 +90,7 @@ Global
 		{41ECAC75-34E3-4C8A-A7BA-DF2C186FF7DE} = {7805222E-6CD5-41FE-9945-0D9FD7DFA24C}
 		{B6503F7F-B3DE-47E5-922E-3A6108E75970} = {7805222E-6CD5-41FE-9945-0D9FD7DFA24C}
 		{33BCC44C-84B3-4C0A-9643-1530B5B65C11} = {210A4922-6BBE-47D6-901E-38127E15C4C4}
+		{30FDB542-4F2B-40E0-9FD9-2BCC8CA05009} = {835F8FFA-471F-4322-B721-A897F27872FA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6A8EBCB0-B3EB-4D85-AD02-D349122C1D8E}


### PR DESCRIPTION
This PR updates the `build` job to only complete CI. A new `release` job is added to handle CD. The `release` job handles submission to Nuget as well as (new) creating a GH release.

Fixes #168 