### PR TITLE
Add tests for `MinItems` and `MaxItems

### DIFF
--- a/Tests/SuperLinq.Async.Test/MaxItemsTest.cs
+++ b/Tests/SuperLinq.Async.Test/MaxItemsTest.cs
@@ -1,0 +1,92 @@
+﻿namespace Test.Async;
+
+public class MaxItemsTest
+{
+	[Fact]
+	public void MaxItemsIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MaxItems();
+	}
+
+	[Fact]
+	public async Task MaxItemsEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItems();
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MaxItemsBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItems();
+		await result.AssertSequenceEqual(5, 5);
+	}
+
+	[Fact]
+	public void MaxItemsComparerIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MaxItems(comparer: null);
+	}
+
+	[Fact]
+	public async Task MaxItemsComparerEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItems(comparer: Comparer<int>.Default);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MaxItemsComparerBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItems(comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		await result.AssertSequenceEqual(2, 2, 5, 5, 2, 2);
+	}
+
+	[Fact]
+	public void MaxItemsByIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>());
+	}
+
+	[Fact]
+	public async Task MaxItemsByEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItemsBy(x => -x);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MaxItemsByBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItemsBy(x => -x);
+		await result.AssertSequenceEqual(0, 0, 0, 0);
+	}
+
+	[Fact]
+	public void MaxItemsByComparerIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+	}
+
+	[Fact]
+	public async Task MaxItemsByComparerEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItemsBy(x => -x, comparer: Comparer<int>.Default);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MaxItemsByComparerBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItemsBy(x => -x, comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		await result.AssertSequenceEqual(0, 0, 3, 3, 0, 3, 3, 0);
+	}
+}

--- a/Tests/SuperLinq.Async.Test/MinItemsTest.cs
+++ b/Tests/SuperLinq.Async.Test/MinItemsTest.cs
@@ -1,0 +1,92 @@
+﻿namespace Test.Async;
+
+public class MinItemsTest
+{
+	[Fact]
+	public void MinItemsIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MinItems();
+	}
+
+	[Fact]
+	public async Task MinItemsEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItems();
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MinItemsBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItems();
+		await result.AssertSequenceEqual(0, 0, 0, 0);
+	}
+
+	[Fact]
+	public void MinItemsComparerIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MinItems(comparer: null);
+	}
+
+	[Fact]
+	public async Task MinItemsComparerEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItems(comparer: Comparer<int>.Default);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MinItemsComparerBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItems(comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		await result.AssertSequenceEqual(0, 0, 3, 3, 0, 3, 3, 0);
+	}
+
+	[Fact]
+	public void MinItemsByIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>());
+	}
+
+	[Fact]
+	public async Task MinItemsByEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItemsBy(x => -x);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MinItemsByBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItemsBy(x => -x);
+		await result.AssertSequenceEqual(5, 5);
+	}
+
+	[Fact]
+	public void MinItemsByComparerIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+	}
+
+	[Fact]
+	public async Task MinItemsByComparerEmptyList()
+	{
+		await using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItemsBy(x => -x, comparer: Comparer<int>.Default);
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task MinItemsByComparerBehavior()
+	{
+		await using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItemsBy(x => -x, comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		await result.AssertSequenceEqual(2, 2, 5, 5, 2, 2);
+	}
+}

--- a/Tests/SuperLinq.Test/MaxItemsTest.cs
+++ b/Tests/SuperLinq.Test/MaxItemsTest.cs
@@ -1,0 +1,92 @@
+﻿namespace Test;
+
+public class MaxItemsTest
+{
+	[Fact]
+	public void MaxItemsIsLazy()
+	{
+		_ = new BreakingSequence<int>().MaxItems();
+	}
+
+	[Fact]
+	public void MaxItemsEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItems();
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MaxItemsBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItems();
+		result.AssertSequenceEqual(5, 5);
+	}
+
+	[Fact]
+	public void MaxItemsComparerIsLazy()
+	{
+		_ = new BreakingSequence<int>().MaxItems(comparer: null);
+	}
+
+	[Fact]
+	public void MaxItemsComparerEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItems(comparer: Comparer<int>.Default);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MaxItemsComparerBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItems(comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		result.AssertSequenceEqual(2, 2, 5, 5, 2, 2);
+	}
+
+	[Fact]
+	public void MaxItemsByIsLazy()
+	{
+		_ = new BreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>());
+	}
+
+	[Fact]
+	public void MaxItemsByEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItemsBy(x => -x);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MaxItemsByBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItemsBy(x => -x);
+		result.AssertSequenceEqual(0, 0, 0, 0);
+	}
+
+	[Fact]
+	public void MaxItemsByComparerIsLazy()
+	{
+		_ = new BreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+	}
+
+	[Fact]
+	public void MaxItemsByComparerEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MaxItemsBy(x => -x, comparer: Comparer<int>.Default);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MaxItemsByComparerBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MaxItemsBy(x => -x, comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		result.AssertSequenceEqual(0, 0, 3, 3, 0, 3, 3, 0);
+	}
+}

--- a/Tests/SuperLinq.Test/MinItemsTest.cs
+++ b/Tests/SuperLinq.Test/MinItemsTest.cs
@@ -1,0 +1,92 @@
+﻿namespace Test;
+
+public class MinItemsTest
+{
+	[Fact]
+	public void MinItemsIsLazy()
+	{
+		_ = new BreakingSequence<int>().MinItems();
+	}
+
+	[Fact]
+	public void MinItemsEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItems();
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MinItemsBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItems();
+		result.AssertSequenceEqual(0, 0, 0, 0);
+	}
+
+	[Fact]
+	public void MinItemsComparerIsLazy()
+	{
+		_ = new BreakingSequence<int>().MinItems(comparer: null);
+	}
+
+	[Fact]
+	public void MinItemsComparerEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItems(comparer: Comparer<int>.Default);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MinItemsComparerBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItems(comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		result.AssertSequenceEqual(0, 0, 3, 3, 0, 3, 3, 0);
+	}
+
+	[Fact]
+	public void MinItemsByIsLazy()
+	{
+		_ = new BreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>());
+	}
+
+	[Fact]
+	public void MinItemsByEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItemsBy(x => -x);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MinItemsByBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItemsBy(x => -x);
+		result.AssertSequenceEqual(5, 5);
+	}
+
+	[Fact]
+	public void MinItemsByComparerIsLazy()
+	{
+		_ = new BreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+	}
+
+	[Fact]
+	public void MinItemsByComparerEmptyList()
+	{
+		using var seq = TestingSequence.Of<int>();
+		var result = seq.MinItemsBy(x => -x, comparer: Comparer<int>.Default);
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void MinItemsByComparerBehavior()
+	{
+		using var seq = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 4, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = seq.MinItemsBy(x => -x, comparer: Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(x % 3, y % 3)));
+		result.AssertSequenceEqual(2, 2, 5, 5, 2, 2);
+	}
+}


### PR DESCRIPTION
This PR adds missing tests for `MinItems` and `MaxItems` operators. Though the underlying behavior is tested (these are proxies for `DensePartialSort` and `DensePartialSortBy`), that does not test these operators are correct proxies.

Fixes #150 