### PR TITLE
Add `DistinctUntilChanged` operator

### DIFF
--- a/Source/SuperLinq/DistinctUntilChanged.cs
+++ b/Source/SuperLinq/DistinctUntilChanged.cs
@@ -1,0 +1,85 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Returns consecutive distinct elements by using the default equality comparer to compare values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	public static IEnumerable<TSource> DistinctUntilChanged<TSource>(this IEnumerable<TSource> source)
+	{
+		return DistinctUntilChanged(source, Identity, comparer: null);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements by using the specified equality comparer to compare values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="comparer">Comparer used to compare values.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	public static IEnumerable<TSource> DistinctUntilChanged<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
+	{
+		Guard.IsNotNull(source);
+		return DistinctUntilChanged(source, Identity, comparer);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare
+	/// key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+	{
+		return DistinctUntilChanged(source, keySelector, comparer: null);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <param name="comparer">Comparer used to compare key values.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(keySelector);
+
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+
+		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+		{
+			using var e = source.GetEnumerator();
+			if (!e.MoveNext())
+				yield break;
+
+			yield return e.Current;
+			var lastKey = keySelector(e.Current);
+
+			while (e.MoveNext())
+			{
+				var nextKey = keySelector(e.Current);
+				if (!comparer.Equals(lastKey, nextKey))
+				{
+					yield return e.Current;
+					lastKey = nextKey;
+				}
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Test/DistinctUntilChangedTest.cs
+++ b/Tests/SuperLinq.Test/DistinctUntilChangedTest.cs
@@ -1,0 +1,99 @@
+﻿namespace Test;
+
+public class DistinctUntilChangedTest
+{
+	[Fact]
+	public void DistinctUntilChangedIsLazy()
+	{
+		_ = new BreakingSequence<int>().DistinctUntilChanged();
+	}
+
+	[Fact]
+	public void DistinctUntilChangedEmptySequence()
+	{
+		using var source = TestingSequence.Of<int>();
+		var result = source.DistinctUntilChanged();
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void DistinctUntilChanged()
+	{
+		using var source = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = source.DistinctUntilChanged();
+		result.AssertSequenceEqual(2, 0, 5, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 0);
+	}
+
+	[Fact]
+	public void DistinctUntilChangedComparer()
+	{
+		using var source = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = source.DistinctUntilChanged(
+			EqualityComparer.Create<int>((x, y) => (x % 3) == (y % 3)));
+		result.AssertSequenceEqual(2, 0, 5, 1, 0, 2, 3, 1, 0, 2, 4, 3);
+	}
+
+	[Fact]
+	public void DistinctUntilChangedSelectorIsLazy()
+	{
+		_ = new BreakingSequence<int>().DistinctUntilChanged(BreakingFunc.Of<int, int>());
+	}
+
+	[Fact]
+	public void DistinctUntilChangedSelectorEmptySequence()
+	{
+		using var source = TestingSequence.Of<int>();
+		var result = source.DistinctUntilChanged(BreakingFunc.Of<int, int>());
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void DistinctUntilChangedSelector()
+	{
+		using var source = TestingSequence.Of(
+			"one",
+			"two",
+			"three",
+			"four",
+			"five",
+			"six",
+			"seven",
+			"eight",
+			"nine",
+			"ten");
+		var result = source.DistinctUntilChanged(x => x.Length);
+		result.AssertSequenceEqual(
+			"one",
+			"three",
+			"four",
+			"six",
+			"seven",
+			"nine",
+			"ten");
+	}
+
+	[Fact]
+	public void DistinctUntilChangedSelectorComparer()
+	{
+		using var source = TestingSequence.Of(
+			"one",
+			"two",
+			"three",
+			"four",
+			"five",
+			"six",
+			"seven",
+			"eight",
+			"nine",
+			"ten");
+		var result = source.DistinctUntilChanged(
+			x => x.Length,
+			EqualityComparer.Create<int>((x, y) => Math.Abs(x - y) <= 1));
+		result.AssertSequenceEqual(
+			"one",
+			"three",
+			"six",
+			"seven",
+			"ten");
+	}
+}


### PR DESCRIPTION
This PR migrates the `DistinctUntilChanged` operator from `System.Interactive`.

Fixes #234 