### PR TITLE
Add `ForEach` operator

### DIFF
--- a/Source/SuperLinq/ForEach.cs
+++ b/Source/SuperLinq/ForEach.cs
@@ -1,0 +1,47 @@
+﻿namespace SuperLinq;
+
+public partial class SuperEnumerable
+{
+	/// <summary>
+	/// Immediately executes the given action on each element in the source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements in the sequence</typeparam>
+	/// <param name="source">The sequence of elements</param>
+	/// <param name="action">The action to execute on each element</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="action"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This operator executes immediately.
+	/// </remarks>
+	public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(action);
+
+		foreach (var element in source)
+			action(element);
+	}
+
+	/// <summary>
+	/// Immediately executes the given action on each element in the source sequence. Each element's index is used in
+	/// the logic of the action.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements in the sequence</typeparam>
+	/// <param name="source">The sequence of elements</param>
+	/// <param name="action">The action to execute on each element; the second parameter of the action represents the
+	/// index of the source element.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="action"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This operator executes immediately.
+	/// </remarks>
+	public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource, int> action)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(action);
+
+		var index = 0;
+		foreach (var element in source)
+			action(element, index++);
+	}
+}

--- a/Tests/SuperLinq.Test/ForEachTest.cs
+++ b/Tests/SuperLinq.Test/ForEachTest.cs
@@ -1,0 +1,28 @@
+﻿namespace Test;
+
+public class ForEachTest
+{
+	[Fact]
+	public void ForEachWithSequence()
+	{
+		using var seq = TestingSequence.Of(1, 2, 3);
+
+		var results = new List<int>();
+		seq.ForEach(results.Add);
+
+		results.AssertSequenceEqual(1, 2, 3);
+	}
+
+	[Fact]
+	public void ForEachIndexedWithSequence()
+	{
+		using var seq = TestingSequence.Of(9, 8, 7);
+
+		var valueResults = new List<int>();
+		var indexResults = new List<int>();
+		seq.ForEach((x, index) => { valueResults.Add(x); indexResults.Add(index); });
+
+		valueResults.AssertSequenceEqual(9, 8, 7);
+		indexResults.AssertSequenceEqual(0, 1, 2);
+	}
+}


### PR DESCRIPTION
This PR restores the `ForEach` operator removed for compatibility with `System.Interactive`.

Fixes #240 