### PR TITLE
Add `Catch` operator

### DIFF
--- a/Source/SuperLinq/Catch.cs
+++ b/Source/SuperLinq/Catch.cs
@@ -1,0 +1,157 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that corresponds to the source sequence, concatenating it with the sequence resulting from
+	/// calling an exception handler function in case of an error.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TException">Exception type to catch.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="handler">Handler to invoke when an exception of the specified type occurs.</param>
+	/// <returns>Source sequence, concatenated with an exception handler result sequence in case of an error.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IEnumerable<TSource> Catch<TSource, TException>(
+		this IEnumerable<TSource> source,
+		Func<TException, IEnumerable<TSource>> handler)
+		where TException : Exception
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(handler);
+
+		return Core(source, handler);
+
+		static IEnumerable<TSource> Core(
+			IEnumerable<TSource> source,
+			Func<TException, IEnumerable<TSource>> handler)
+		{
+			IEnumerable<TSource>? errSource;
+			using var e = source.GetEnumerator();
+			while (true)
+			{
+				try
+				{
+					if (!e.MoveNext())
+						yield break;
+				}
+				catch (TException ex)
+				{
+					errSource = handler(ex);
+					break;
+				}
+
+				yield return e.Current;
+			}
+
+			if (errSource == null)
+				// should not be able to get here without setting `errSource`
+				ThrowHelper.ThrowInvalidOperationException();
+
+			foreach (var item in errSource)
+				yield return item;
+		}
+	}
+
+	/// <summary>
+	/// Creates a sequence that returns the elements of the first sequence, switching to the second in case of an error.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="first">First sequence.</param>
+	/// <param name="second">Second sequence, concatenated to the result in case the first sequence completes
+	/// exceptionally.</param>
+	/// <returns>The first sequence, followed by the second sequence in case an error is produced.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IEnumerable<TSource> Catch<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
+	{
+		Guard.IsNotNull(first);
+		Guard.IsNotNull(second);
+
+		return Catch(new[] { first, second, });
+	}
+
+	/// <summary>
+	/// Creates a sequence by concatenating source sequences until a source sequence completes successfully.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence that continues to concatenate source sequences while errors occur.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IEnumerable<TSource> Catch<TSource>(params IEnumerable<TSource>[] sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.AsEnumerable().Catch();
+	}
+
+	/// <summary>
+	/// Creates a sequence by concatenating source sequences until a source sequence completes successfully.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence that continues to concatenate source sequences while errors occur.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IEnumerable<TSource> Catch<TSource>(this IEnumerable<IEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return Core(sources);
+
+		static IEnumerable<TSource> Core(IEnumerable<IEnumerable<TSource>> sources)
+		{
+			using var sourceIter = sources.GetEnumerator();
+
+			if (!sourceIter.MoveNext())
+				yield break;
+
+			var source = sourceIter.Current;
+			var hasNext = sourceIter.MoveNext();
+
+			// outer loop is not infinite.
+			// on last loop (`hasNext == false`), then either
+			// `source` will iterate successfully (yield break)
+			// or it will fail (throw). either way, it will not
+			// make it outside of the inner `while (true)`
+			while (true)
+			{
+				Guard.IsNotNull(source);
+				using var e = source.GetEnumerator();
+
+				while (true)
+				{
+					try
+					{
+						if (!e.MoveNext())
+							yield break;
+					}
+					catch
+					{
+						if (!hasNext)
+							throw;
+
+						break;
+					}
+
+					yield return e.Current;
+				}
+
+				source = sourceIter.Current;
+				hasNext = sourceIter.MoveNext();
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Test/CatchTest.cs
+++ b/Tests/SuperLinq.Test/CatchTest.cs
@@ -1,0 +1,118 @@
+﻿using SuperLinq;
+
+namespace Test;
+
+public class CatchTest
+{
+	[Fact]
+	public void CatchIsLazy()
+	{
+		_ = new BreakingSequence<int>().Catch(BreakingFunc.Of<Exception, IEnumerable<int>>());
+		_ = new BreakingSequence<int>().Catch(new BreakingSequence<int>());
+		_ = SuperEnumerable.Catch(new BreakingSequence<IEnumerable<int>>());
+		_ = new[] { new BreakingSequence<int>(), new BreakingSequence<int>() }.Catch();
+	}
+
+	[Fact]
+	public void CatchThrowsDelayedExceptionOnNullSource()
+	{
+		var seq = SuperEnumerable.Catch(new IEnumerable<int>[] { null!, });
+		_ = Assert.Throws<ArgumentNullException>(seq.Consume);
+	}
+
+	[Fact]
+	public void CatchHandlerWithNoExceptions()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Catch(BreakingFunc.Of<Exception, IEnumerable<int>>());
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public void CatchHandlerWithException()
+	{
+		using var seq = SeqExceptionAt(5).AsTestingSequence();
+
+		var ran = false;
+		var result = seq
+			.Catch((Exception _) =>
+			{
+				ran = true;
+				return SuperEnumerable.Return(-5);
+			});
+
+		Assert.False(ran);
+		result.AssertSequenceEqual(1, 2, 3, 4, -5);
+		Assert.True(ran);
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	public void CatchMultipleSequencesNoExceptions(int count)
+	{
+		using var ts1 = Enumerable.Range(1, 10).AsTestingSequence();
+		using var ts2 = Enumerable.Range(1, 10).AsTestingSequence();
+		using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var seq = new[] { ts1, ts2, ts3 }
+			.Take(count)
+			.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		// no matter what, only first sequence enumerated due to no exceptions
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Theory]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(4)]
+	public void CatchMultipleSequencesWithNoExceptionOnSequence(int sequenceNumber)
+	{
+		var cnt = 1;
+		using var ts1 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts2 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts3 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts4 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts5 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+
+		using var seq = new[] { ts1, ts2, ts3, ts4, ts5, }.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		var x = result.ToList();
+
+		x.AssertSequenceEqual(
+			Enumerable.Range(1, 4)
+				.Repeat(sequenceNumber - 1)
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public void CatchMultipleSequencesThrowsIfNoFollowingSequence()
+	{
+		using var ts1 = SeqExceptionAt(5).AsTestingSequence();
+		using var ts2 = SeqExceptionAt(5).AsTestingSequence();
+		using var ts3 = SeqExceptionAt(5).AsTestingSequence();
+
+		using var seq = new[] { ts1, ts2, ts3 }
+			.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		_ = Assert.Throws<TestException>(() =>
+		{
+			var i = 1;
+			foreach (var item in result)
+			{
+				Assert.Equal(i++, item);
+				if (i == 5)
+					i = 1;
+			}
+		});
+	}
+}


### PR DESCRIPTION
This PR migrates the `Catch` operator from `System.Interactive`.

Fixes #259
