### PR TITLE
Add `Retry` operator

### DIFF
--- a/Source/SuperLinq/Retry.cs
+++ b/Source/SuperLinq/Retry.cs
@@ -1,0 +1,59 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that retries enumerating the source sequence as long as an error occurs.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Sequence concatenating the results of the source sequence as long as an error occurs.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="source"/> will be enumerated and values streamed until it either completes or encounters an
+	/// error. If an error is thrown, then <paramref name="source"/> will be re-enumerated from the beginning. This will
+	/// happen until an iteration of <paramref name="source"/> has completed without errors.
+	/// </para>
+	/// <para>
+	/// This method uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TSource> Retry<TSource>(this IEnumerable<TSource> source)
+	{
+		Guard.IsNotNull(source);
+
+		return Repeat<IEnumerable<TSource>>(source).Catch();
+	}
+
+	/// <summary>
+	/// Creates a sequence that retries enumerating the source sequence as long as an error occurs, with the specified
+	/// maximum number of retries.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Maximum number of retries.</param>
+	/// <returns>Sequence concatenating the results of the source sequence as long as an error occurs.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than or equal to
+	/// <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="source"/> will be enumerated and values streamed until it either completes or encounters an
+	/// error. If an error is thrown, then <paramref name="source"/> will be re-enumerated from the beginning. This will
+	/// happen until an iteration of <paramref name="source"/> has completed without errors, or <paramref
+	/// name="source"/> has been enumerated <paramref name="count"/> times. If an error is thrown during the final
+	/// iteration, it will not be caught and will be thrown to the consumer.
+	/// </para>
+	/// <para>
+	/// This method uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IEnumerable<TSource> Retry<TSource>(this IEnumerable<TSource> source, int count)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThan(count, 0);
+
+		return Enumerable.Repeat(source, count).Catch();
+	}
+}

--- a/Tests/SuperLinq.Test/RetryTest.cs
+++ b/Tests/SuperLinq.Test/RetryTest.cs
@@ -1,0 +1,112 @@
+﻿namespace Test;
+
+public class RetryTest
+{
+	[Fact]
+	public void RetryIsLazy()
+	{
+		_ = new BreakingSequence<int>().Retry();
+	}
+
+	[Fact]
+	public void RetryNoExceptions()
+	{
+		using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = ts.Retry();
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public void RetryWithExceptions()
+	{
+		using var ts1 = SeqExceptionAt(2).AsTestingSequence();
+		using var ts2 = SeqExceptionAt(5).AsTestingSequence();
+		using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = SuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		using var ts = seq.AsTestingSequence(maxEnumerations: 3);
+
+		var result = ts.Retry();
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 1)
+				.Concat(Enumerable.Range(1, 4))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public void RetryCountIsLazy()
+	{
+		_ = new BreakingSequence<int>().Retry(3);
+	}
+
+	[Fact]
+	public void RetryCountNoExceptions()
+	{
+		using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = ts.Retry(3);
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public void RetryCountWithExceptionsComplete()
+	{
+		using var ts1 = SeqExceptionAt(2).AsTestingSequence();
+		using var ts2 = SeqExceptionAt(5).AsTestingSequence();
+		using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = SuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		using var ts = seq.AsTestingSequence(maxEnumerations: 3);
+
+		var result = ts.Retry(4);
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 1)
+				.Concat(Enumerable.Range(1, 4))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public void RetryCountWithExceptionsThrow()
+	{
+		using var ts1 = SeqExceptionAt(2).AsTestingSequence();
+		using var ts2 = SeqExceptionAt(5).AsTestingSequence();
+		using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = SuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		using var ts = seq.AsTestingSequence(maxEnumerations: 2);
+
+		var result = ts.Retry(2);
+		using var reader = result.Read();
+		Assert.Equal(1, reader.Read());
+		Assert.Equal(1, reader.Read());
+		Assert.Equal(2, reader.Read());
+		Assert.Equal(3, reader.Read());
+		Assert.Equal(4, reader.Read());
+		_ = Assert.Throws<TestException>(() => reader.Read());
+	}
+}


### PR DESCRIPTION
This PR migrates the `Retry` operator from `System.Interactive`.

Fixes #246 