### PR TITLE
Add `OnErrorResumeNext` operator

### DIFF
--- a/Source/SuperLinq/OnErrorResumeNext.cs
+++ b/Source/SuperLinq/OnErrorResumeNext.cs
@@ -1,0 +1,77 @@
+﻿namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that concatenates both given sequences, regardless of whether an error occurs.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="first">First sequence.</param>
+	/// <param name="second">Second sequence.</param>
+	/// <returns>Sequence concatenating the elements of both sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is <see
+	/// langword="null"/>.</exception>
+	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
+	{
+		Guard.IsNotNull(first);
+		Guard.IsNotNull(second);
+
+		return OnErrorResumeNext(new[] { first, second, });
+	}
+
+	/// <summary>
+	/// Creates a sequence that concatenates the given sequences, regardless of whether an error occurs in any of the
+	/// sequences.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence concatenating the elements of the given sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(params IEnumerable<TSource>[] sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.AsEnumerable().OnErrorResumeNext();
+	}
+
+	/// <summary>
+	/// Creates a sequence that concatenates the given sequences, regardless of whether an error occurs in any of the
+	/// sequences.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence concatenating the elements of the given sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<IEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return Core(sources);
+
+		static IEnumerable<TSource> Core(IEnumerable<IEnumerable<TSource>> sources)
+		{
+			foreach (var source in sources)
+			{
+				Guard.IsNotNull(source);
+				using var e = source.GetEnumerator();
+
+				while (true)
+				{
+#pragma warning disable CA1031 // Do not catch general exception types
+					try
+					{
+						if (!e.MoveNext())
+							break;
+					}
+					catch
+					{
+						break;
+					}
+#pragma warning restore CA1031 // Do not catch general exception types
+
+					yield return e.Current;
+				}
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Test/OnErrorResumeNextTest.cs
+++ b/Tests/SuperLinq.Test/OnErrorResumeNextTest.cs
@@ -1,0 +1,56 @@
+﻿namespace Test;
+
+public class OnErrorResumeNextTest
+{
+	[Fact]
+	public void OnErrorResumeNextIsLazy()
+	{
+		_ = new BreakingSequence<int>().OnErrorResumeNext(new BreakingSequence<int>());
+		_ = new[] { new BreakingSequence<int>(), new BreakingSequence<int>() }.OnErrorResumeNext();
+		_ = new BreakingSequence<IEnumerable<int>>().OnErrorResumeNext();
+	}
+
+	[Fact]
+	public void OnErrorResumeNextMultipleSequencesNoExceptions()
+	{
+		using var ts1 = Enumerable.Range(1, 10).AsTestingSequence();
+		using var ts2 = Enumerable.Range(1, 10).AsTestingSequence();
+		using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var seq = new[] { ts1, ts2, ts3 }
+			.AsTestingSequence();
+
+		var result = seq.OnErrorResumeNext();
+
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 10)
+				.Concat(Enumerable.Range(1, 10))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(4)]
+	[InlineData(5)]
+	public void OnErrorResumeNextMultipleSequencesWithNoExceptionOnSequence(int sequenceNumber)
+	{
+		var cnt = 1;
+		using var ts1 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts2 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts3 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts4 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+		using var ts5 = (cnt++ == sequenceNumber ? Enumerable.Range(1, 10) : SeqExceptionAt(5)).AsTestingSequence();
+
+		using var seq = new[] { ts1, ts2, ts3, ts4, ts5, }.AsTestingSequence();
+
+		var result = seq.OnErrorResumeNext();
+
+		var expected = Enumerable.Empty<int>();
+		for (cnt = 1; cnt <= 5; cnt++)
+			expected = expected.Concat(Enumerable.Range(1, cnt == sequenceNumber ? 10 : 4));
+
+		result.AssertSequenceEqual(expected);
+	}
+}


### PR DESCRIPTION
This PR migrates the `OnErrorResumeNext` operator from `System.Interactive`.

Fixes #266 