### PR TITLE
Add `Share` operator

### DIFF
--- a/Source/SuperLinq/Share.cs
+++ b/Source/SuperLinq/Share.cs
@@ -1,0 +1,196 @@
+﻿using System.Collections;
+using System.Runtime.ExceptionServices;
+
+namespace SuperLinq;
+
+public static partial class SuperEnumerable
+{
+	/// <summary>
+	/// Creates a buffer with a shared view over the source sequence, causing each enumerator to fetch the next element
+	/// from the source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Buffer enabling each enumerator to retrieve elements from the shared source sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/></exception>
+	/// <example>
+	/// <code><![CDATA[
+	///     using var rng = Enumerable.Range(0, 10).Share();
+	///     var e1 = rng.GetEnumerator();    // Both e1 and e2 will consume elements from
+	///     var e2 = rng.GetEnumerator();    // the source sequence.
+	///     Assert.IsTrue(e1.MoveNext());
+	///     Assert.AreEqual(0, e1.Current);
+	///     Assert.IsTrue(e1.MoveNext());
+	///     Assert.AreEqual(1, e1.Current);
+	///     Assert.IsTrue(e2.MoveNext());    // e2 "steals" element 2
+	///     Assert.AreEqual(2, e2.Current);
+	///     Assert.IsTrue(e1.MoveNext());    // e1 can't see element 2
+	///     Assert.AreEqual(3, e1.Current);
+	/// ]]></code>
+	/// </example>
+	public static IBuffer<TSource> Share<TSource>(this IEnumerable<TSource> source)
+	{
+		Guard.IsNotNull(source);
+
+		return new SharedBuffer<TSource>(source);
+	}
+
+	/// <summary>
+	/// Shares the source sequence within a selector function where each enumerator can fetch the next element from the
+	/// source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="selector">Selector function with shared access to the source sequence for each enumerator.</param>
+	/// <returns>Sequence resulting from applying the selector function to the shared view over the source
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IEnumerable<TResult> Share<TSource, TResult>(this IEnumerable<TSource> source, Func<IEnumerable<TSource>, IEnumerable<TResult>> selector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(selector);
+
+		return Core(source, selector);
+
+		static IEnumerable<TResult> Core(IEnumerable<TSource> source, Func<IEnumerable<TSource>, IEnumerable<TResult>> selector)
+		{
+			using var buffer = source.Share();
+			foreach (var i in selector(buffer))
+				yield return i;
+		}
+	}
+
+	private sealed class SharedBuffer<T> : IBuffer<T>
+	{
+		private readonly object _lock = new();
+
+		private IEnumerable<T>? _source;
+
+		private IEnumerator<T>? _enumerator;
+		private bool _initialized;
+		private int _version;
+
+		private ExceptionDispatchInfo? _exception;
+
+		private bool _disposed;
+
+		public SharedBuffer(IEnumerable<T> source)
+		{
+			_source = source;
+		}
+
+		public int Count => 0;
+
+		public void Reset()
+		{
+			lock (_lock)
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+
+				_initialized = false;
+				_version++;
+
+				_enumerator?.Dispose();
+				_enumerator = null;
+				_exception = null;
+			}
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			InitializeEnumerator();
+			return GetEnumeratorImpl();
+		}
+
+		private void InitializeEnumerator()
+		{
+			lock (_lock)
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+
+				Assert.NotNull(_source);
+
+				_exception?.Throw();
+
+				if (_initialized)
+					return;
+
+				try
+				{
+					_enumerator = _source.GetEnumerator();
+					_initialized = true;
+				}
+				catch (Exception ex)
+				{
+					_exception = ExceptionDispatchInfo.Capture(ex);
+					throw;
+				}
+			}
+		}
+
+		private IEnumerator<T> GetEnumeratorImpl()
+		{
+			var version = _version;
+			while (true)
+			{
+				T? element;
+				lock (_lock)
+				{
+					if (_disposed)
+						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					if (!_initialized
+						|| version != _version)
+					{
+						ThrowHelper.ThrowInvalidOperationException("Buffer reset during iteration.");
+					}
+
+					_exception?.Throw();
+
+					if (_enumerator == null)
+						break;
+
+					var moved = false;
+					try
+					{
+						moved = _enumerator.MoveNext();
+					}
+					catch (Exception ex)
+					{
+						_exception = ExceptionDispatchInfo.Capture(ex);
+						_enumerator.Dispose();
+						_enumerator = null;
+						throw;
+					}
+
+					if (!moved)
+					{
+						_enumerator.Dispose();
+						_enumerator = null;
+						break;
+					}
+
+					element = _enumerator.Current;
+				}
+
+				yield return element;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public void Dispose()
+		{
+			lock (_lock)
+			{
+				_disposed = true;
+				_enumerator?.Dispose();
+				_enumerator = null;
+				_source = null;
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Test/ShareTest.cs
+++ b/Tests/SuperLinq.Test/ShareTest.cs
@@ -232,4 +232,19 @@ public class ShareTest
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
+
+	[Fact]
+	public void ShareLambdaIsLazy()
+	{
+		_ = new BreakingSequence<int>().Share(BreakingFunc.Of<IEnumerable<int>, IEnumerable<string>>());
+	}
+
+	[Fact]
+	public void ShareLambdaSimple()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		var result = seq.Share(xs => xs.Zip(xs, (l, r) => l + r).Take(4));
+		result.AssertSequenceEqual(1, 5, 9, 13);
+	}
 }

--- a/Tests/SuperLinq.Test/ShareTest.cs
+++ b/Tests/SuperLinq.Test/ShareTest.cs
@@ -1,0 +1,235 @@
+﻿using System.Collections;
+
+namespace Test;
+
+public class ShareTest
+{
+	[Fact]
+	public void ShareIsLazy()
+	{
+		_ = new BreakingSequence<int>().Share();
+	}
+
+	[Fact]
+	public void ShareWithSingleConsumer()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var result = seq.Share();
+		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public void ShareWithMultipleConsumers()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var result = seq.Share();
+
+		using var r1 = result.Read();
+		using var r2 = result.Read();
+
+		Assert.Equal(1, r1.Read());
+		Assert.Equal(2, r2.Read());
+		Assert.Equal(3, r2.Read());
+		Assert.Equal(4, r1.Read());
+		Assert.Equal(5, r1.Read());
+		Assert.Equal(6, r1.Read());
+		Assert.Equal(7, r2.Read());
+		Assert.Equal(8, r2.Read());
+		Assert.Equal(9, r1.Read());
+		Assert.Equal(10, r2.Read());
+
+		r1.ReadEnd();
+		r2.ReadEnd();
+	}
+
+	[Fact]
+	public void ShareWithInnerConsumer()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var result = seq.Share();
+
+		using var r1 = result.Read();
+		Assert.Equal(1, r1.Read());
+		Assert.Equal(2, r1.Read());
+
+		using (var r2 = result.Read())
+		{
+			Assert.Equal(3, r2.Read());
+			Assert.Equal(4, r1.Read());
+			Assert.Equal(5, r2.Read());
+			Assert.Equal(6, r2.Read());
+		}
+
+		Assert.Equal(7, r1.Read());
+		Assert.Equal(8, r1.Read());
+		Assert.Equal(9, r1.Read());
+		Assert.Equal(10, r1.Read());
+
+		r1.ReadEnd();
+	}
+
+	[Fact]
+	public void ShareWithSequentialPartialConsumers()
+	{
+		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		using var result = seq.Share();
+
+		using (var r1 = result.Read())
+		{
+			Assert.Equal(1, r1.Read());
+			Assert.Equal(2, r1.Read());
+			Assert.Equal(3, r1.Read());
+			Assert.Equal(4, r1.Read());
+			Assert.Equal(5, r1.Read());
+		}
+
+		using (var r2 = result.Read())
+		{
+			Assert.Equal(6, r2.Read());
+			Assert.Equal(7, r2.Read());
+			Assert.Equal(8, r2.Read());
+			Assert.Equal(9, r2.Read());
+			Assert.Equal(10, r2.Read());
+			r2.ReadEnd();
+		}
+
+		using var r3 = result.Read();
+		r3.ReadEnd();
+	}
+
+	[Fact]
+	public void ShareDisposesAfterSourceIsIteratedEntirely()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = seq.Share();
+		buffer.Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public void ShareDisposesWithPartialEnumeration()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		using var buffer = seq.Share();
+
+		using (buffer)
+			buffer.Take(5).Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public void ShareRestartsAfterReset()
+	{
+		var starts = 0;
+
+		IEnumerable<int> TestSequence()
+		{
+			starts++;
+			yield return 1;
+			yield return 2;
+		}
+
+		using var seq = TestSequence().AsTestingSequence(maxEnumerations: 2);
+		using var buffer = seq.Share();
+
+		buffer.Take(1).Consume();
+		Assert.Equal(1, starts);
+
+		buffer.Reset();
+		buffer.Take(1).Consume();
+		Assert.Equal(2, starts);
+	}
+
+	[Fact]
+	public void ShareThrowsWhenCacheDisposedDuringIteration()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		using var buffer = seq.Share();
+
+		using var reader = buffer.Read();
+
+		Assert.Equal(0, reader.Read());
+		buffer.Dispose();
+
+		_ = Assert.Throws<ObjectDisposedException>(
+			() => reader.Read());
+	}
+
+	[Fact]
+	public void ShareThrowsWhenResetDuringIteration()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		using var buffer = seq.Share();
+
+		using var reader = buffer.Read();
+
+		Assert.Equal(0, reader.Read());
+		buffer.Reset();
+
+		var ex = Assert.Throws<InvalidOperationException>(
+			() => reader.Read());
+		Assert.Equal("Buffer reset during iteration.", ex.Message);
+	}
+
+	[Fact]
+	public void ShareThrowsWhenGettingIteratorAfterDispose()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		using var buffer = seq.Share();
+		buffer.Consume();
+		buffer.Dispose();
+
+		_ = Assert.Throws<ObjectDisposedException>(
+			buffer.Consume);
+	}
+
+	[Fact]
+	public void ShareThrowsWhenResettingAfterDispose()
+	{
+		using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		using var buffer = seq.Share();
+		buffer.Consume();
+		buffer.Dispose();
+
+		_ = Assert.Throws<ObjectDisposedException>(
+			buffer.Reset);
+	}
+
+	[Fact]
+	public void ShareRethrowsErrorDuringFirstIterationStartToAllIterationsUntilReset()
+	{
+		using var seq = new FailingEnumerable().AsTestingSequence(maxEnumerations: 2);
+
+		using var buffer = seq.Share();
+
+		for (var i = 0; i < 2; i++)
+			_ = Assert.Throws<TestException>(() => buffer.First());
+
+		buffer.Reset();
+		buffer.AssertSequenceEqual(1);
+	}
+
+	private class FailingEnumerable : IEnumerable<int>
+	{
+		private bool _started;
+		public IEnumerator<int> GetEnumerator()
+		{
+			if (!_started)
+			{
+				_started = true;
+				throw new TestException();
+			}
+			return Enumerable.Range(1, 1).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}


### PR DESCRIPTION
This PR migrates the `Share` operator from `System.Interactive`.

Fixes #264 