### PR TITLE
Remove CodeQL from Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: 'csharp'
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -40,6 +35,3 @@ jobs:
 
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
-      
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2

--- a/SuperLinq.sln
+++ b/SuperLinq.sln
@@ -6,13 +6,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".root", ".root", "{835F8FFA
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
-		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\dependabot.yml = .github\dependabot.yml
 		Directory.Build.props = Directory.Build.props
-		.github\workflows\docs.yml = .github\workflows\docs.yml
 		license.txt = license.txt
 		README.md = README.md
-		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{8392DDDC-9D3E-4A41-A93C-1EF1503D71F9}"


### PR DESCRIPTION
CodeQL is taking an enormous amount of time to execute lately, and is not providing any value to us. Removing from build steps to improve build times.