### PR TITLE
Fix `Interleave` use of `IEnumerable<T>`

### DIFF
--- a/Source/SuperLinq.Async/Interleave.cs
+++ b/Source/SuperLinq.Async/Interleave.cs
@@ -51,12 +51,9 @@ public static partial class AsyncSuperEnumerable
 	/// <param name="sources">The sequences to interleave together</param>
 	/// <returns>A sequence of interleaved elements from all of the source sequences</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
-	/// <exception cref="ArgumentNullException">Any of the items in <paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<T> Interleave<T>(this IEnumerable<IAsyncEnumerable<T>> sources)
 	{
 		Guard.IsNotNull(sources);
-		foreach (var s in sources)
-			Guard.IsNotNull(s, nameof(sources));
 
 		return Core(sources);
 

--- a/Source/SuperLinq/Interleave.cs
+++ b/Source/SuperLinq/Interleave.cs
@@ -51,13 +51,9 @@ public static partial class SuperEnumerable
 	/// <param name="sources">The sequences to interleave together</param>
 	/// <returns>A sequence of interleaved elements from all of the source sequences</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
-	/// <exception cref="ArgumentNullException">Any of the items in <paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<T> Interleave<T>(this IEnumerable<IEnumerable<T>> sources)
 	{
 		Guard.IsNotNull(sources);
-
-		if (sources.Any(s => s == null))
-			ThrowHelper.ThrowArgumentNullException(nameof(sources), "One or more sequences passed to Interleave was null.");
 
 		return Core(sources);
 

--- a/Tests/SuperLinq.Test/InterleaveTest.cs
+++ b/Tests/SuperLinq.Test/InterleaveTest.cs
@@ -15,16 +15,6 @@ public class InterleaveTests
 	}
 
 	/// <summary>
-	/// Verify that Interleave fails when encountering a null source
-	/// </summary>
-	[Fact]
-	public void TestInterleaveTestsSourcesForNull()
-	{
-		_ = Assert.Throws<ArgumentNullException>("sources", () =>
-			new[] { new BreakingSequence<int>(), default!, }.Interleave<int>());
-	}
-
-	/// <summary>
 	/// Verify that interleaving disposes those enumerators that it managed
 	/// to open successfully
 	/// </summary>
@@ -133,7 +123,9 @@ public class InterleaveTests
 		using var sequenceD = TestingSequence.Of(3);
 		using var sequenceE = TestingSequence.Of(4, 7, 10, 13, 15, 17);
 
-		var result = sequenceA.Interleave(sequenceB, sequenceC, sequenceD, sequenceE);
+		using var sequences = TestingSequence.Of<IEnumerable<int>>(sequenceA, sequenceB, sequenceC, sequenceD, sequenceE);
+		var result = sequences.Interleave();
+
 		result.AssertSequenceEqual(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
 	}
 }


### PR DESCRIPTION
This PR fixes the `Interleave` operator so that the outer enumerable is not iterated more than once. 

Fixes #260 