### PR TITLE
Add `Memoize` operator

### DIFF
--- a/Source/SuperLinq.Async/IAsyncBuffer.cs
+++ b/Source/SuperLinq.Async/IAsyncBuffer.cs
@@ -1,0 +1,22 @@
+﻿namespace SuperLinq.Async;
+
+/// <summary>
+/// Represents a cached sequence that can be re-enumerated multiple times.
+/// </summary>
+/// <typeparam name="T">The type of the items in the cached sequence.</typeparam>
+public interface IAsyncBuffer<out T> : IAsyncEnumerable<T>, IAsyncDisposable
+{
+	/// <summary>
+	/// Clears the current buffer and restarts the enumeration from the beginning.
+	/// </summary>
+	/// <remarks>
+	/// Any active iterators of this buffer may receive an <see cref="InvalidOperationException"/> when they next <see
+	/// cref="IAsyncEnumerator{T}.MoveNextAsync"/> due to the invalid state of iteration.
+	/// </remarks>
+	ValueTask Reset(CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// The number of elements currently cached.
+	/// </summary>
+	int Count { get; }
+}

--- a/Source/SuperLinq.Async/Memoize.cs
+++ b/Source/SuperLinq.Async/Memoize.cs
@@ -1,0 +1,221 @@
+﻿using System.Runtime.ExceptionServices;
+
+namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that lazily caches the source as it is iterated for the first time, reusing the cache
+	/// thereafter for future re-iterations. By default, all sequences are cached, whether they are instantiated or
+	/// lazy.
+	/// </summary>
+	/// <typeparam name="TSource">
+	/// Type of elements in <paramref name="source"/>.</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <returns>
+	/// Returns a sequence that corresponds to a cached version of the input sequence.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="source"/> is <see langword="null"/>.
+	/// </exception>
+	/// <remarks>
+	/// <para>
+	/// The returned <see cref="IAsyncBuffer{T}"/> will cache items from <paramref name="source"/> in a thread-safe
+	/// manner. The sequence supplied in <paramref name="source"/> is not expected to be thread-safe but it is required
+	/// to be thread-agnostic.
+	/// </para>
+	/// </remarks>
+	public static IAsyncBuffer<TSource> Memoize<TSource>(this IAsyncEnumerable<TSource> source)
+	{
+		Guard.IsNotNull(source);
+
+		return new EnumerableMemoizedBuffer<TSource>(source);
+	}
+
+	private sealed class EnumerableMemoizedBuffer<T> : IAsyncBuffer<T>
+	{
+		private readonly SemaphoreSlim _lock = new(initialCount: 1);
+
+		private IAsyncEnumerable<T>? _source;
+
+		private IAsyncEnumerator<T>? _enumerator;
+		private List<T> _buffer = new();
+		private bool _initialized;
+
+		private ExceptionDispatchInfo? _exception;
+		private int? _exceptionIndex;
+
+		private bool _disposed;
+
+		public EnumerableMemoizedBuffer(IAsyncEnumerable<T> source)
+		{
+			_source = source;
+		}
+
+		public int Count => _buffer.Count;
+
+		public async ValueTask Reset(CancellationToken cancellationToken = default)
+		{
+			if (_disposed)
+				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+			await _lock.WaitAsync(cancellationToken);
+			try
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				_buffer = new();
+				_initialized = false;
+				if (_enumerator != null)
+					await _enumerator.DisposeAsync();
+				_enumerator = null;
+				_exceptionIndex = null;
+				_exception = null;
+			}
+			finally
+			{
+				_ = _lock.Release();
+			}
+		}
+
+		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+		{
+			InitializeEnumerator(cancellationToken);
+			return GetEnumeratorImpl(cancellationToken);
+		}
+
+		private void InitializeEnumerator(CancellationToken cancellationToken)
+		{
+			if (_disposed)
+				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+			_lock.Wait(cancellationToken);
+			try
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				Assert.NotNull(_source);
+
+				if (_exceptionIndex == -1)
+				{
+					Guard.IsNotNull(_exception);
+					_exception.Throw();
+				}
+
+				if (_initialized)
+					return;
+
+				try
+				{
+					_enumerator = _source.GetAsyncEnumerator(cancellationToken);
+					_initialized = true;
+				}
+				catch (Exception ex)
+				{
+					_exception = ExceptionDispatchInfo.Capture(ex);
+					_exceptionIndex = -1;
+					throw;
+				}
+			}
+			finally
+			{
+				_ = _lock.Release();
+			}
+		}
+
+		private async IAsyncEnumerator<T> GetEnumeratorImpl(CancellationToken cancellationToken)
+		{
+			var buffer = _buffer;
+			var index = 0;
+			while (true)
+			{
+				T? element;
+
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				await _lock.WaitAsync(cancellationToken);
+				try
+				{
+					if (_disposed)
+						ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					if (!_initialized
+						|| buffer != _buffer)
+					{
+						ThrowHelper.ThrowInvalidOperationException("Buffer reset during iteration.");
+					}
+
+					if (index >= _buffer.Count)
+					{
+						if (index == _exceptionIndex)
+						{
+							Assert.NotNull(_exception);
+							_exception.Throw();
+						}
+
+						if (_enumerator == null)
+							break;
+
+						var moved = false;
+						try
+						{
+							moved = await _enumerator.MoveNextAsync(cancellationToken);
+						}
+						catch (Exception ex)
+						{
+							_exception = ExceptionDispatchInfo.Capture(ex);
+							_exceptionIndex = index;
+							await _enumerator.DisposeAsync();
+							_enumerator = null;
+							throw;
+						}
+
+						if (!moved)
+						{
+							await _enumerator.DisposeAsync();
+							_enumerator = null;
+							break;
+						}
+
+						_buffer.Add(_enumerator.Current);
+
+						Assert.True(index < _buffer.Count);
+					}
+
+					element = _buffer[index];
+				}
+				finally
+				{
+					_ = _lock.Release();
+				}
+
+				yield return element;
+				index++;
+			}
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			if (_disposed)
+				return;
+
+			await _lock.WaitAsync();
+			try
+			{
+				_disposed = true;
+				_buffer.Clear();
+				if (_enumerator != null)
+					await _enumerator.DisposeAsync();
+				_enumerator = null;
+				_source = null;
+			}
+			finally
+			{
+				_ = _lock.Release();
+				_lock.Dispose();
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/MemoizeTest.cs
+++ b/Tests/SuperLinq.Async.Test/MemoizeTest.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.Collections;
+using System.Reflection.PortableExecutable;
+using CommunityToolkit.Diagnostics;
+
+namespace Test.Async;
+
+public class MemoizeTest
+{
+	[Fact]
+	public void MemoizeIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Memoize();
+	}
+
+	[Fact]
+	public async Task MemoizeSimpleUse()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+		Assert.Equal(0, buffer.Count);
+
+		await buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+		Assert.Equal(10, buffer.Count);
+	}
+
+	[Fact]
+	public async Task MemoizeReturningExpectedElementsWhenUsedAtInnerForEach()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		var buffer = seq.Memoize();
+
+		var flowArray = InnerForEach(AsyncEnumerable.Range(1, 10));
+		var flowBuffer = InnerForEach(buffer);
+
+		await flowArray.AssertSequenceEqual(flowBuffer);
+
+		static async IAsyncEnumerable<object> InnerForEach(IAsyncEnumerable<int> source)
+		{
+			var firstVisitAtInnerLoopDone = false;
+
+			//add 1-3 to cache (so enter inner loop)
+			//consume 4-5 already cached
+			//add 6-7 to cache (so enter inner loop)
+			//consume 8-10 already cached
+
+			yield return "enter outer loop";
+			await foreach (var i in source)
+			{
+				yield return i;
+
+				if (i is 3 or 7)
+				{
+					//consume 1-3 already cached
+					//add 4-5 to cache (so go to outer loop)
+					//consume 1-7 already cached
+					//add 8-10 to cache (so go to outer loop)
+
+					yield return "enter inner loop";
+					await foreach (var j in source)
+					{
+						yield return j;
+
+						if (!firstVisitAtInnerLoopDone && j == 5)
+						{
+							firstVisitAtInnerLoopDone = true;
+							break;
+						}
+					}
+					yield return "exit inner loop";
+				}
+			}
+			yield return "exit outer loop";
+
+			yield return "enter last loop";
+			//consume 1-10 (all item were already cached)
+			await foreach (var k in source)
+			{
+				yield return k;
+			}
+			yield return "exit last loop";
+		}
+	}
+
+	[Fact]
+	public static async Task MemoizeThrowsWhenCacheDisposedDuringIteration()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+
+		await using var reader = buffer.Read();
+		Assert.Equal(1, await reader.Read());
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await reader.Read());
+	}
+
+	[Fact]
+	public static async Task MemoizeThrowsWhenResetDuringIteration()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+
+		await using var reader = buffer.Read();
+		Assert.Equal(1, await reader.Read());
+
+		await buffer.Reset();
+
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+			async () => await reader.Read());
+		Assert.Equal("Buffer reset during iteration.", ex.Message);
+	}
+
+	[Fact]
+	public async Task MemoizeThrowsWhenGettingAfterDispose()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+
+		await buffer.Consume();
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await buffer.Consume());
+	}
+
+	[Fact]
+	public static async Task MemoizeThrowsWhenResettingAfterDispose()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+
+		await buffer.Consume();
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await buffer.Reset());
+	}
+
+	[Fact]
+	public async Task MemoizeWithPartialIterationBeforeCompleteIteration()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+		Assert.Equal(0, buffer.Count);
+
+		await buffer.Take(5).AssertSequenceEqual(Enumerable.Range(1, 5));
+		Assert.Equal(5, buffer.Count);
+
+		await buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+		Assert.Equal(10, buffer.Count);
+	}
+
+	[Fact]
+	public async Task MemoizeWithDisposeOnEarlyExitTrue()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+		Assert.Equal(0, buffer.Count);
+
+		await using (buffer)
+			await buffer.Take(1).Consume();
+
+		Assert.Equal(0, buffer.Count);
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public async Task MemoizeDisposesAfterSourceIsIteratedEntirely()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+		await buffer.Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public async Task MemoizeEnumeratesOnlyOnce()
+	{
+		await using var seq = AsyncEnumerable.Range(1, 10).AsTestingSequence();
+
+		await using var buffer = seq.Memoize();
+
+		await buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+		await buffer.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public static async Task MemoizeRestartsAfterReset()
+	{
+		var starts = 0;
+
+		IEnumerable<int> TestSequence()
+		{
+			starts++;
+			yield return 1;
+			yield return 2;
+		}
+
+		await using var seq = TestSequence().AsTestingSequence(maxEnumerations: 2);
+		await using var memoized = seq.Memoize();
+
+		await memoized.Take(1).Consume();
+		Assert.Equal(1, starts);
+
+		await memoized.Reset();
+		await memoized.Take(1).Consume();
+		Assert.Equal(2, starts);
+	}
+
+	[Fact]
+	public async Task MemoizeRethrowsErrorDuringIterationToAllsUntilReset()
+	{
+		await using var xs = AsyncSeqExceptionAt(2).AsTestingSequence(maxEnumerations: 2);
+
+		await using var memoized = xs.Memoize();
+
+		await using (var r1 = memoized.Read())
+		await using (var r2 = memoized.Read())
+		{
+			Guard.IsTrue(await r1.Read() == await r2.Read());
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r1.Read());
+
+			Guard.IsTrue(xs.IsDisposed);
+
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r2.Read());
+		}
+
+		await memoized.Reset();
+
+		await using (var r1 = memoized.Read())
+			Assert.Equal(1, await r1.Read());
+	}
+
+	[Fact]
+	public async Task MemoizeRethrowsErrorDuringIterationStartToAllsUntilReset()
+	{
+		var i = 0;
+		await using var xs = AsyncSuperEnumerable
+			.From(() => i++ == 0 ? throw new TestException() : Task.FromResult(42))
+			.AsTestingSequence(maxEnumerations: 2);
+
+		await using var buffer = xs.Memoize();
+		Assert.Equal(0, buffer.Count);
+
+		await using (var r1 = buffer.Read())
+		await using (var r2 = buffer.Read())
+		{
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r1.Read());
+			Guard.IsTrue(xs.IsDisposed);
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r2.Read());
+		}
+		Assert.Equal(0, buffer.Count);
+
+		await buffer.Reset();
+		Assert.Equal(0, buffer.Count);
+		await using (var r1 = buffer.Read())
+		await using (var r2 = buffer.Read())
+			Guard.IsTrue(await r1.Read() == await r2.Read());
+		Assert.Equal(1, buffer.Count);
+	}
+
+	[Fact]
+	public async Task MemoizeRethrowsErrorDuringFirstIterationStartToAllIterationsUntilReset()
+	{
+		using var seq = new FailingEnumerable().AsTestingSequence(maxEnumerations: 2);
+
+		await using var buffer = seq.Memoize();
+		Assert.Equal(0, buffer.Count);
+
+		for (var i = 0; i < 2; i++)
+			_ = await Assert.ThrowsAsync<TestException>(async () => await buffer.FirstAsync());
+
+		await buffer.Reset();
+		await buffer.AssertSequenceEqual(1);
+		Assert.Equal(1, buffer.Count);
+	}
+
+	private class FailingEnumerable : IEnumerable<int>
+	{
+		private bool _started;
+		public IEnumerator<int> GetEnumerator()
+		{
+			if (!_started)
+			{
+				_started = true;
+				throw new TestException();
+			}
+			return Enumerable.Range(1, 1).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}


### PR DESCRIPTION
This PR copies the `Memoize` operator from `SuperLinq` and adapts to an `async` operator.

Fixes #278 