### PR TITLE
Add `Case` operator

### DIFF
--- a/Source/SuperLinq.Async/AsyncSuperEnumerable.cs
+++ b/Source/SuperLinq.Async/AsyncSuperEnumerable.cs
@@ -28,4 +28,13 @@ public static partial class AsyncSuperEnumerable
 			return default;
 		};
 	}
+
+	private static Func<ValueTask<TResult>> ToAsync<TResult>(this Func<TResult> func)
+	{
+		return () =>
+		{
+			var ret = func();
+			return new ValueTask<TResult>(ret);
+		};
+	}
 }

--- a/Source/SuperLinq.Async/Case.cs
+++ b/Source/SuperLinq.Async/Case.cs
@@ -1,0 +1,132 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Returns a sequence from a dictionary based on the result of evaluating a selector function.
+	/// </summary>
+	/// <typeparam name="TValue">Type of the selector value.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="selector">Selector function used to pick a sequence from the given sources.</param>
+	/// <param name="sources">Dictionary mapping selector values onto resulting sequences.</param>
+	/// <returns>The source sequence corresponding with the evaluated selector value; otherwise, an empty
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="selector"/> or <paramref name="sources"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="selector"/> is not evaluated until enumeration. The value returned will be used to select a
+	/// sequence from <paramref name="sources"/>; enumeration will continue with items from that sequence.
+	/// </para>
+	/// <para>
+	/// If the value returned by <paramref name="selector"/> is not present in <paramref name="sources"/>, the resulting
+	/// sequence will be empty.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TResult> Case<TValue, TResult>(
+		Func<TValue> selector,
+		IDictionary<TValue, IAsyncEnumerable<TResult>> sources)
+		where TValue : notnull
+	{
+		return Case(selector.ToAsync(), sources, AsyncEnumerable.Empty<TResult>());
+	}
+
+	/// <summary>
+	/// Returns a sequence from a dictionary based on the result of evaluating a selector function.
+	/// </summary>
+	/// <typeparam name="TValue">Type of the selector value.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="selector">Selector function used to pick a sequence from the given sources.</param>
+	/// <param name="sources">Dictionary mapping selector values onto resulting sequences.</param>
+	/// <returns>The source sequence corresponding with the evaluated selector value; otherwise, an empty
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="selector"/> or <paramref name="sources"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="selector"/> is not evaluated until enumeration. The value returned will be used to select a
+	/// sequence from <paramref name="sources"/>; enumeration will continue with items from that sequence.
+	/// </para>
+	/// <para>
+	/// If the value returned by <paramref name="selector"/> is not present in <paramref name="sources"/>, the resulting
+	/// sequence will be empty.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TResult> Case<TValue, TResult>(
+		Func<ValueTask<TValue>> selector,
+		IDictionary<TValue, IAsyncEnumerable<TResult>> sources)
+		where TValue : notnull
+	{
+		return Case(selector, sources, AsyncEnumerable.Empty<TResult>());
+	}
+
+	/// <summary>
+	/// Returns a sequence from a dictionary based on the result of evaluating a selector function.
+	/// </summary>
+	/// <typeparam name="TValue">Type of the selector value.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="selector">Selector function used to pick a sequence from the given sources.</param>
+	/// <param name="sources">Dictionary mapping selector values onto resulting sequences.</param>
+	/// <param name="defaultSource">Default sequence to return in case there's no corresponding source for the computed
+	/// selector value.</param>
+	/// <returns>The source sequence corresponding with the evaluated selector value; otherwise, an empty
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="selector"/>, <paramref name="sources"/>, or <paramref
+	/// name="defaultSource"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <paramref name="selector"/> is not evaluated until enumeration. The value returned will be used to select a
+	/// sequence from <paramref name="sources"/>; enumeration will continue with items from that sequence.
+	/// </remarks>
+	public static IAsyncEnumerable<TResult> Case<TValue, TResult>(
+		Func<TValue> selector,
+		IDictionary<TValue, IAsyncEnumerable<TResult>> sources,
+		IAsyncEnumerable<TResult> defaultSource)
+		where TValue : notnull
+	{
+		return Case(selector.ToAsync(), sources, defaultSource);
+	}
+
+	/// <summary>
+	/// Returns a sequence from a dictionary based on the result of evaluating a selector function.
+	/// </summary>
+	/// <typeparam name="TValue">Type of the selector value.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="selector">Selector function used to pick a sequence from the given sources.</param>
+	/// <param name="sources">Dictionary mapping selector values onto resulting sequences.</param>
+	/// <param name="defaultSource">Default sequence to return in case there's no corresponding source for the computed
+	/// selector value.</param>
+	/// <returns>The source sequence corresponding with the evaluated selector value; otherwise, an empty
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="selector"/>, <paramref name="sources"/>, or <paramref
+	/// name="defaultSource"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <paramref name="selector"/> is not evaluated until enumeration. The value returned will be used to select a
+	/// sequence from <paramref name="sources"/>; enumeration will continue with items from that sequence.
+	/// </remarks>
+	public static IAsyncEnumerable<TResult> Case<TValue, TResult>(
+		Func<ValueTask<TValue>> selector,
+		IDictionary<TValue, IAsyncEnumerable<TResult>> sources,
+		IAsyncEnumerable<TResult> defaultSource)
+		where TValue : notnull
+	{
+		Guard.IsNotNull(selector);
+		Guard.IsNotNull(sources);
+		Guard.IsNotNull(defaultSource);
+
+		return Core(selector, sources, defaultSource);
+
+		static async IAsyncEnumerable<TResult> Core(
+			Func<ValueTask<TValue>> selector,
+			IDictionary<TValue, IAsyncEnumerable<TResult>> sources,
+			IAsyncEnumerable<TResult> defaultSource,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			var selection = await selector().ConfigureAwait(false);
+			if (!sources.TryGetValue(selection, out var source))
+				source = defaultSource;
+
+			await foreach (var el in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return el;
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/CaseTest.cs
+++ b/Tests/SuperLinq.Async.Test/CaseTest.cs
@@ -6,6 +6,7 @@ public class CaseTest
 	public void CaseIsLazy()
 	{
 		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<int>(), new Dictionary<int, IAsyncEnumerable<int>>());
+		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<ValueTask<int>>(), new Dictionary<int, IAsyncEnumerable<int>>());
 	}
 
 	[Fact]
@@ -38,6 +39,7 @@ public class CaseTest
 	public void CaseSourceIsLazy()
 	{
 		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<int>(), new Dictionary<int, IAsyncEnumerable<int>>(), new AsyncBreakingSequence<int>());
+		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<ValueTask<int>>(), new Dictionary<int, IAsyncEnumerable<int>>(), new AsyncBreakingSequence<int>());
 	}
 
 	[Fact]

--- a/Tests/SuperLinq.Async.Test/CaseTest.cs
+++ b/Tests/SuperLinq.Async.Test/CaseTest.cs
@@ -1,0 +1,70 @@
+﻿namespace Test.Async;
+
+public class CaseTest
+{
+	[Fact]
+	public void CaseIsLazy()
+	{
+		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<int>(), new Dictionary<int, IAsyncEnumerable<int>>());
+	}
+
+	[Fact]
+	public async Task CaseBehavior()
+	{
+		var starts = 0;
+		await using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+		var sources = new Dictionary<int, IAsyncEnumerable<int>>()
+		{
+			[0] = new AsyncBreakingSequence<int>(),
+			[1] = ts,
+		};
+
+		var seq = AsyncSuperEnumerable.Case(
+			() => starts++,
+			sources);
+
+		Assert.Equal(0, starts);
+		_ = await Assert.ThrowsAsync<TestException>(async () =>
+			await seq.Consume());
+
+		Assert.Equal(1, starts);
+		await seq.AssertSequenceEqual(Enumerable.Range(1, 10));
+
+		Assert.Equal(2, starts);
+		await seq.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void CaseSourceIsLazy()
+	{
+		_ = AsyncSuperEnumerable.Case(BreakingFunc.Of<int>(), new Dictionary<int, IAsyncEnumerable<int>>(), new AsyncBreakingSequence<int>());
+	}
+
+	[Fact]
+	public async Task CaseSourceBehavior()
+	{
+		var starts = 0;
+		await using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+		await using var ts2 = Enumerable.Range(1, 20).AsTestingSequence();
+		var sources = new Dictionary<int, IAsyncEnumerable<int>>()
+		{
+			[0] = new AsyncBreakingSequence<int>(),
+			[1] = ts,
+		};
+
+		var seq = AsyncSuperEnumerable.Case(
+			() => starts++,
+			sources,
+			ts2);
+
+		Assert.Equal(0, starts);
+		_ = await Assert.ThrowsAsync<TestException>(async () =>
+			await seq.Consume());
+
+		Assert.Equal(1, starts);
+		await seq.AssertSequenceEqual(Enumerable.Range(1, 10));
+
+		Assert.Equal(2, starts);
+		await seq.AssertSequenceEqual(Enumerable.Range(1, 20));
+	}
+}


### PR DESCRIPTION
This PR copies the `Case` operator from `SuperLinq` and adapts to an `async` operator.

Fixes #283 