### PR TITLE
Add `Batch` operator

### DIFF
--- a/Source/SuperLinq.Async/Batch.cs
+++ b/Source/SuperLinq.Async/Batch.cs
@@ -1,0 +1,56 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Split the elements of a sequence into chunks of size at most <paramref name="size"/>.
+	/// </summary>
+	/// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+	/// <param name="source">An <see cref="IAsyncEnumerable{T}"/> whose elements to chunk.</param>
+	/// <param name="size">The maximum size of each chunk.</param>
+	/// <returns>An <see cref="IAsyncEnumerable{T}"/> that contains the elements the input sequence split into chunks of size
+	/// size.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is below 1.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="size"/>, specifically the final buffer of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<IList<TSource>> Batch<TSource>(this IAsyncEnumerable<TSource> source, int size)
+	{
+		// yes this operator duplicates on net6+; but no name overlap, so leave alone
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThanOrEqualTo(size, 1);
+
+		return Core(source, size);
+
+		static async IAsyncEnumerable<IList<TSource>> Core(
+			IAsyncEnumerable<TSource> source, int size,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			TSource[]? array = null;
+
+			var n = 0;
+			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+			{
+				(array ??= new TSource[size])[n++] = item;
+				if (n == size)
+				{
+					yield return array;
+					n = 0;
+				}
+			}
+
+			if (n != 0)
+			{
+				Array.Resize(ref array, n);
+				yield return array;
+			}
+		}
+	}
+}

--- a/Source/SuperLinq.Async/Buffer.cs
+++ b/Source/SuperLinq.Async/Buffer.cs
@@ -1,0 +1,31 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Generates a sequence of non-overlapping adjacent buffers over the source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Number of elements for allocated buffers.</param>
+	/// <returns>Sequence of buffers containing source sequence elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than or equal to
+	/// <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="count"/>, specifically the final buffer of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// This method is a synonym for <see cref="Batch{TSource}(IAsyncEnumerable{TSource}, int)"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IAsyncEnumerable<TSource> source, int count)
+	{
+		return Batch(source, count);
+	}
+}

--- a/Tests/SuperLinq.Async.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Async.Test/BatchTest.cs
@@ -1,0 +1,53 @@
+﻿namespace Test.Async;
+
+public class BatchTest
+{
+	[Fact]
+	public void BatchIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Batch(1);
+		_ = new AsyncBreakingSequence<int>().Buffer(1);
+	}
+
+	[Fact]
+	public void BatchValidatesSize()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("size",
+			() => new AsyncBreakingSequence<int>()
+				.Batch(0));
+	}
+
+	[Fact]
+	public async Task BatchWithEmptySource()
+	{
+		await using var seq = Enumerable.Empty<int>().AsTestingSequence();
+		var result = seq.Batch(1);
+		await seq.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task BatchEvenlyDivisibleSequence()
+	{
+		await using var seq = Enumerable.Range(1, 9).AsTestingSequence();
+
+		var result = seq.Batch(3);
+		await using var reader = result.Read();
+		(await reader.Read()).AssertSequenceEqual(1, 2, 3);
+		(await reader.Read()).AssertSequenceEqual(4, 5, 6);
+		(await reader.Read()).AssertSequenceEqual(7, 8, 9);
+		await reader.ReadEnd();
+	}
+
+	[Fact]
+	public async Task BatchUnevenlyDivisibleSequence()
+	{
+		await using var seq = Enumerable.Range(1, 9).AsTestingSequence();
+
+		var result = seq.Batch(4);
+		await using var reader = result.Read();
+		(await reader.Read()).AssertSequenceEqual(1, 2, 3, 4);
+		(await reader.Read()).AssertSequenceEqual(5, 6, 7, 8);
+		(await reader.Read()).AssertSequenceEqual(9);
+		await reader.ReadEnd();
+	}
+}


### PR DESCRIPTION
This PR copies the `Batch` operator from `SuperLinq` and adapts to an `async` operator.

Fixes #288