### PR TITLE
Add `Buffer` operator

### DIFF
--- a/Source/SuperLinq.Async/Buffer.cs
+++ b/Source/SuperLinq.Async/Buffer.cs
@@ -28,4 +28,57 @@ public static partial class AsyncSuperEnumerable
 	{
 		return Batch(source, count);
 	}
+
+	/// <summary>
+	/// Generates a sequence of buffers over the source sequence, with specified length and possible overlap.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Number of elements for allocated buffers.</param>
+	/// <param name="skip">Number of elements to skip between the start of consecutive buffers.</param>
+	/// <returns>Sequence of buffers containing source sequence elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> or <paramref name="skip"/> is less than
+	/// or equal to <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// A chunk can contain fewer elements than <paramref name="count"/>, specifically the final buffers of <paramref
+	/// name="source"/>.
+	/// </para>
+	/// <para>
+	/// Returned subsequences are buffered, but the overall operation is streamed.<br/>
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IAsyncEnumerable<TSource> source, int count, int skip)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThan(count, 0);
+		Guard.IsGreaterThan(skip, 0);
+
+		return Core(source, count, skip);
+
+		static async IAsyncEnumerable<IList<TSource>> Core(
+			IAsyncEnumerable<TSource> source,
+			int count, int skip,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			var lists = new Queue<List<TSource>>();
+
+			var i = 0;
+			await foreach (var el in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+			{
+				if (i++ % skip == 0)
+					lists.Enqueue(new());
+
+				foreach (var l in lists)
+					l.Add(el);
+
+				if (lists.Count > 0 && lists.Peek().Count == count)
+					yield return lists.Dequeue();
+			}
+
+			while (lists.Count > 0)
+				yield return lists.Dequeue();
+		}
+	}
 }

--- a/Tests/SuperLinq.Async.Test/BufferTest.cs
+++ b/Tests/SuperLinq.Async.Test/BufferTest.cs
@@ -1,0 +1,75 @@
+﻿namespace Test.Async;
+
+public class BufferTest
+{
+	[Fact]
+	public void BufferIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Buffer(2, 1);
+	}
+
+	[Fact]
+	public void BufferValidatesCount()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("count",
+			() => new AsyncBreakingSequence<int>().Buffer(0, 2));
+	}
+
+	[Fact]
+	public void BufferValidatesSkip()
+	{
+		_ = Assert.Throws<ArgumentOutOfRangeException>("skip",
+			() => new AsyncBreakingSequence<int>().Buffer(2, 0));
+	}
+
+	[Fact]
+	public async Task BufferEmptySequence()
+	{
+		await using var seq = Enumerable.Empty<int>().AsTestingSequence();
+
+		var result = seq.Buffer(1, 2);
+		await result.AssertSequenceEqual();
+	}
+
+	[Theory]
+	[InlineData(3)]
+	[InlineData(5)]
+	[InlineData(7)]
+	public async Task BufferNonOverlappingBuffers(int count)
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(count, count);
+		await foreach (var (actual, expected) in result
+			.EquiZip(AsyncEnumerable.Range(1, 10).Batch(count)))
+		{
+			actual.AssertSequenceEqual(expected);
+		}
+	}
+
+	[Fact]
+	public async Task BufferOverlappingBuffers()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(5, 3);
+		await using var reader = result.Read();
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(1, 5));
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(4, 5));
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(7, 4));
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(10, 1));
+		await reader.ReadEnd();
+	}
+
+	[Fact]
+	public async Task BufferSkippingBuffers()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Buffer(5, 7);
+		await using var reader = result.Read();
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(1, 5));
+		(await reader.Read()).AssertSequenceEqual(Enumerable.Range(8, 3));
+		await reader.ReadEnd();
+	}
+}


### PR DESCRIPTION
This PR copies the `Buffer` operator from `SuperLinq` and adapts to an `async` operator.

Fixes #290 