### PR TITLE
Add `MinByWithTies` and `MaxByWithTies`

### DIFF
--- a/Source/SuperLinq.Async/MaxItems.cs
+++ b/Source/SuperLinq.Async/MaxItems.cs
@@ -73,6 +73,29 @@ public static partial class AsyncSuperEnumerable
 	/// <typeparam name="TKey">Type of keys.</typeparam>
 	/// <param name="source">The source sequence.</param>
 	/// <param name="keySelector">A function to extract a key from an element.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// This operator is a shortcut for <see cref="DensePartialSortBy{TSource, TKey}(IAsyncEnumerable{TSource}, int,
+	/// Func{TSource, TKey}, OrderByDirection)"/> with a <c>direction</c> of <see cref="OrderByDirection.Descending"/>
+	/// and a <c>count</c> of <c>1</c>. 
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams it results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> MaxByWithTies<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+	{
+		return source.DensePartialSortBy(1, keySelector, OrderByDirection.Descending);
+	}
+
+	/// <summary>
+	/// Returns all of the items that share the maximum value of a sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in the sequence.</typeparam>
+	/// <typeparam name="TKey">Type of keys.</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="keySelector">A function to extract a key from an element.</param>
 	/// <param name="comparer">A <see cref="IComparer{T}"/> to compare keys.</param>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -86,6 +109,30 @@ public static partial class AsyncSuperEnumerable
 	/// </para>
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> MaxItemsBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
+	{
+		return source.DensePartialSortBy(1, keySelector, comparer, OrderByDirection.Descending);
+	}
+
+	/// <summary>
+	/// Returns all of the items that share the maximum value of a sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in the sequence.</typeparam>
+	/// <typeparam name="TKey">Type of keys.</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="keySelector">A function to extract a key from an element.</param>
+	/// <param name="comparer">A <see cref="IComparer{T}"/> to compare keys.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// This operator is a shortcut for <see cref="DensePartialSortBy{TSource, TKey}(IAsyncEnumerable{TSource}, int,
+	/// Func{TSource, TKey}, IComparer{TKey}?, OrderByDirection)"/> with a <c>direction</c> of <see
+	/// cref="OrderByDirection.Descending"/> and a <c>count</c> of <c>1</c>. 
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams it results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> MaxByWithTies<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
 	{
 		return source.DensePartialSortBy(1, keySelector, comparer, OrderByDirection.Descending);
 	}

--- a/Source/SuperLinq.Async/MinItems.cs
+++ b/Source/SuperLinq.Async/MinItems.cs
@@ -73,6 +73,29 @@ public static partial class AsyncSuperEnumerable
 	/// <typeparam name="TKey">Type of keys.</typeparam>
 	/// <param name="source">The source sequence.</param>
 	/// <param name="keySelector">A function to extract a key from an element.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// This operator is a shortcut for <see cref="DensePartialSortBy{TSource, TKey}(IAsyncEnumerable{TSource}, int,
+	/// Func{TSource, TKey}, OrderByDirection)"/> with a <c>direction</c> of <see cref="OrderByDirection.Ascending"/>
+	/// and a <c>count</c> of <c>1</c>. 
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams it results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> MinByWithTies<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+	{
+		return source.DensePartialSortBy(1, keySelector, OrderByDirection.Ascending);
+	}
+
+	/// <summary>
+	/// Returns all of the items that share the minimum value of a sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in the sequence.</typeparam>
+	/// <typeparam name="TKey">Type of keys.</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="keySelector">A function to extract a key from an element.</param>
 	/// <param name="comparer">A <see cref="IComparer{T}"/> to compare keys.</param>
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	/// <remarks>
@@ -86,6 +109,30 @@ public static partial class AsyncSuperEnumerable
 	/// </para>
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> MinItemsBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
+	{
+		return source.DensePartialSortBy(1, keySelector, comparer, OrderByDirection.Ascending);
+	}
+
+	/// <summary>
+	/// Returns all of the items that share the minimum value of a sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Type of elements in the sequence.</typeparam>
+	/// <typeparam name="TKey">Type of keys.</typeparam>
+	/// <param name="source">The source sequence.</param>
+	/// <param name="keySelector">A function to extract a key from an element.</param>
+	/// <param name="comparer">A <see cref="IComparer{T}"/> to compare keys.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// This operator is a shortcut for <see cref="DensePartialSortBy{TSource, TKey}(IAsyncEnumerable{TSource}, int,
+	/// Func{TSource, TKey}, IComparer{TKey}?, OrderByDirection)"/> with a <c>direction</c> of <see
+	/// cref="OrderByDirection.Ascending"/> and a <c>count</c> of <c>1</c>. 
+	/// </para>
+	/// <para>
+	/// This operator uses deferred execution and streams it results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> MinByWithTies<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
 	{
 		return source.DensePartialSortBy(1, keySelector, comparer, OrderByDirection.Ascending);
 	}

--- a/Tests/SuperLinq.Async.Test/MaxItemsTest.cs
+++ b/Tests/SuperLinq.Async.Test/MaxItemsTest.cs
@@ -50,6 +50,7 @@ public class MaxItemsTest
 	public void MaxItemsByIsLazy()
 	{
 		_ = new AsyncBreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>());
+		_ = new AsyncBreakingSequence<int>().MaxByWithTies(BreakingFunc.Of<int, int>());
 	}
 
 	[Fact]
@@ -72,6 +73,7 @@ public class MaxItemsTest
 	public void MaxItemsByComparerIsLazy()
 	{
 		_ = new AsyncBreakingSequence<int>().MaxItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+		_ = new AsyncBreakingSequence<int>().MaxByWithTies(BreakingFunc.Of<int, int>(), comparer: null);
 	}
 
 	[Fact]

--- a/Tests/SuperLinq.Async.Test/MinItemsTest.cs
+++ b/Tests/SuperLinq.Async.Test/MinItemsTest.cs
@@ -50,6 +50,7 @@ public class MinItemsTest
 	public void MinItemsByIsLazy()
 	{
 		_ = new AsyncBreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>());
+		_ = new AsyncBreakingSequence<int>().MinByWithTies(BreakingFunc.Of<int, int>());
 	}
 
 	[Fact]
@@ -72,6 +73,8 @@ public class MinItemsTest
 	public void MinItemsByComparerIsLazy()
 	{
 		_ = new AsyncBreakingSequence<int>().MinItemsBy(BreakingFunc.Of<int, int>(), comparer: null);
+		_ = new AsyncBreakingSequence<int>().MinByWithTies
+			(BreakingFunc.Of<int, int>(), comparer: null);
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR adds `MinByWithTies` and `MaxByWithTies` as synonyms for `MinItemsBy` and `MaxItemsBy` respectively. This is to match naming in `System.Interactive.Async`.

Fixes #296 
Fixes #297 