### PR TITLE
Add `DistinctUntilChanged` operator

### DIFF
--- a/Source/SuperLinq.Async/AsyncSuperEnumerable.cs
+++ b/Source/SuperLinq.Async/AsyncSuperEnumerable.cs
@@ -37,4 +37,13 @@ public static partial class AsyncSuperEnumerable
 			return new ValueTask<TResult>(ret);
 		};
 	}
+
+	private static Func<T, ValueTask<TResult>> ToAsync<T, TResult>(this Func<T, TResult> func)
+	{
+		return arg1 =>
+		{
+			var ret = func(arg1);
+			return new ValueTask<TResult>(ret);
+		};
+	}
 }

--- a/Source/SuperLinq.Async/DistinctUntilChanged.cs
+++ b/Source/SuperLinq.Async/DistinctUntilChanged.cs
@@ -1,0 +1,123 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Returns consecutive distinct elements by using the default equality comparer to compare values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource>(this IAsyncEnumerable<TSource> source)
+	{
+		return DistinctUntilChanged(source, Identity, comparer: null);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements by using the specified equality comparer to compare values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="comparer">Comparer used to compare values.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource>(this IAsyncEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
+	{
+		Guard.IsNotNull(source);
+		return DistinctUntilChanged(source, Identity, comparer);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare
+	/// key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+	{
+		Guard.IsNotNull(keySelector);
+		return DistinctUntilChanged<TSource, TKey>(source, keySelector.ToAsync(), comparer: null);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare
+	/// key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
+	{
+		return DistinctUntilChanged<TSource, TKey>(source, keySelector, comparer: null);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <param name="comparer">Comparer used to compare key values.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+	{
+		Guard.IsNotNull(keySelector);
+		return DistinctUntilChanged(source, keySelector.ToAsync(), comparer);
+	}
+
+	/// <summary>
+	/// Returns consecutive distinct elements based on a key value by using the specified equality comparer to compare key values.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TKey">Key type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="keySelector">Key selector.</param>
+	/// <param name="comparer">Comparer used to compare key values.</param>
+	/// <returns>Sequence without adjacent non-distinct elements.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey>? comparer)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(keySelector);
+
+		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
+
+		static async IAsyncEnumerable<TSource> Core(
+			IAsyncEnumerable<TSource> source,
+			Func<TSource, ValueTask<TKey>> keySelector,
+			IEqualityComparer<TKey> comparer,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
+			if (!await e.MoveNextAsync())
+				yield break;
+
+			yield return e.Current;
+			var lastKey = await keySelector(e.Current).ConfigureAwait(false);
+
+			while (await e.MoveNextAsync())
+			{
+				var nextKey = await keySelector(e.Current).ConfigureAwait(false);
+				if (!comparer.Equals(lastKey, nextKey))
+				{
+					yield return e.Current;
+					lastKey = nextKey;
+				}
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/DistinctUntilChangedTest.cs
+++ b/Tests/SuperLinq.Async.Test/DistinctUntilChangedTest.cs
@@ -1,0 +1,100 @@
+﻿namespace Test.Async;
+
+public class DistinctUntilChangedTest
+{
+	[Fact]
+	public void DistinctUntilChangedIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().DistinctUntilChanged();
+	}
+
+	[Fact]
+	public async Task DistinctUntilChangedEmptySequence()
+	{
+		await using var source = TestingSequence.Of<int>();
+		var result = source.DistinctUntilChanged();
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task DistinctUntilChanged()
+	{
+		await using var source = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = source.DistinctUntilChanged();
+		await result.AssertSequenceEqual(2, 0, 5, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 0);
+	}
+
+	[Fact]
+	public async Task DistinctUntilChangedComparer()
+	{
+		await using var source = TestingSequence.Of(2, 2, 0, 5, 5, 1, 1, 0, 3, 0, 2, 3, 1, 4, 0, 2, 4, 3, 3, 0);
+		var result = source.DistinctUntilChanged(
+			EqualityComparer.Create<int>((x, y) => (x % 3) == (y % 3)));
+		await result.AssertSequenceEqual(2, 0, 5, 1, 0, 2, 3, 1, 0, 2, 4, 3);
+	}
+
+	[Fact]
+	public void DistinctUntilChangedSelectorIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().DistinctUntilChanged(BreakingFunc.Of<int, int>());
+		_ = new AsyncBreakingSequence<int>().DistinctUntilChanged(BreakingFunc.Of<int, ValueTask<int>>());
+	}
+
+	[Fact]
+	public async Task DistinctUntilChangedSelectorEmptySequence()
+	{
+		await using var source = TestingSequence.Of<int>();
+		var result = source.DistinctUntilChanged(BreakingFunc.Of<int, int>());
+		await result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public async Task DistinctUntilChangedSelector()
+	{
+		await using var source = TestingSequence.Of(
+			"one",
+			"two",
+			"three",
+			"four",
+			"five",
+			"six",
+			"seven",
+			"eight",
+			"nine",
+			"ten");
+		var result = source.DistinctUntilChanged(x => x.Length);
+		await result.AssertSequenceEqual(
+			"one",
+			"three",
+			"four",
+			"six",
+			"seven",
+			"nine",
+			"ten");
+	}
+
+	[Fact]
+	public async Task DistinctUntilChangedSelectorComparer()
+	{
+		await using var source = TestingSequence.Of(
+			"one",
+			"two",
+			"three",
+			"four",
+			"five",
+			"six",
+			"seven",
+			"eight",
+			"nine",
+			"ten");
+		var result = source.DistinctUntilChanged(
+			x => x.Length,
+			EqualityComparer.Create<int>((x, y) => Math.Abs(x - y) <= 1));
+		await result.AssertSequenceEqual(
+			"one",
+			"three",
+			"six",
+			"seven",
+			"ten");
+	}
+}


### PR DESCRIPTION
This PR copies the `DistinctUntilChanged` operator from `SuperLinq` and adapts to an async operator.

Fixes #304 
