### PR TITLE
Add `Throw` operator

### DIFF
--- a/Source/SuperLinq.Async/Throw.cs
+++ b/Source/SuperLinq.Async/Throw.cs
@@ -1,0 +1,36 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Returns a sequence that throws an exception upon enumeration.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="exception">Exception to throw upon enumerating the resulting sequence.</param>
+	/// <returns>Sequence that throws the specified exception upon enumeration.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// The provided value (<paramref name="exception"/>) will be thrown when the first element is enumerated. 
+	/// </para>
+	/// <para>
+	/// If the returned <see cref="IAsyncEnumerable{T}"/> is enumerated multiple times, the same value will be thrown each
+	/// time.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Throw<TSource>(Exception exception)
+	{
+		Guard.IsNotNull(exception);
+
+		return Core(exception);
+
+		static async IAsyncEnumerable<TSource> Core(Exception exception)
+		{
+			throw exception;
+#pragma warning disable CS0162
+			await Task.Yield();
+			yield break;
+#pragma warning restore CS0162
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/ThrowTest.cs
+++ b/Tests/SuperLinq.Async.Test/ThrowTest.cs
@@ -1,0 +1,22 @@
+﻿namespace Test.Async;
+
+public class ThrowTest
+{
+	[Fact]
+	public void ThrowIsLazy()
+	{
+		_ = AsyncSuperEnumerable.Throw<int>(new TestException());
+	}
+
+	[Fact]
+	public async Task ThrowBehavior()
+	{
+		var src = new TestException();
+
+		var seq = AsyncSuperEnumerable.Throw<int>(src);
+
+		var tgt = await Assert.ThrowsAsync<TestException>(
+			async () => await seq.Consume());
+		Assert.Same(src, tgt);
+	}
+}


### PR DESCRIPTION
This PR copies the `Throw` operator from `SuperLinq` and adapts to an async operator.

Fixes #323 