### PR TITLE
Add `Catch` operator

### DIFF
--- a/Source/SuperLinq.Async/Catch.cs
+++ b/Source/SuperLinq.Async/Catch.cs
@@ -1,0 +1,175 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that corresponds to the source sequence, concatenating it with the sequence resulting from
+	/// calling an exception handler function in case of an error.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TException">Exception type to catch.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="handler">Handler to invoke when an exception of the specified type occurs.</param>
+	/// <returns>Source sequence, concatenated with an exception handler result sequence in case of an error.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Catch<TSource, TException>(
+		this IAsyncEnumerable<TSource> source,
+		Func<TException, IAsyncEnumerable<TSource>> handler)
+		where TException : Exception
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(handler);
+
+		return Core(source, handler);
+
+		static async IAsyncEnumerable<TSource> Core(
+			IAsyncEnumerable<TSource> source,
+			Func<TException, IAsyncEnumerable<TSource>> handler,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			IAsyncEnumerable<TSource>? errSource;
+			await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
+			while (true)
+			{
+				try
+				{
+					if (!await e.MoveNextAsync())
+						yield break;
+				}
+				catch (TException ex)
+				{
+					errSource = handler(ex);
+					break;
+				}
+
+				yield return e.Current;
+			}
+
+			Assert.NotNull(errSource);
+
+			await foreach (var item in errSource.WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return item;
+		}
+	}
+
+	/// <summary>
+	/// Creates a sequence that returns the elements of the first sequence, switching to the second in case of an error.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="first">First sequence.</param>
+	/// <param name="second">Second sequence, concatenated to the result in case the first sequence completes
+	/// exceptionally.</param>
+	/// <returns>The first sequence, followed by the second sequence in case an error is produced.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is <see
+	/// langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Catch<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second)
+	{
+		Guard.IsNotNull(first);
+		Guard.IsNotNull(second);
+
+		return Catch(new[] { first, second, });
+	}
+
+	/// <summary>
+	/// Creates a sequence by concatenating source sequences until a source sequence completes successfully.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence that continues to concatenate source sequences while errors occur.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Catch<TSource>(params IAsyncEnumerable<TSource>[] sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.ToAsyncEnumerable().Catch();
+	}
+
+	/// <summary>
+	/// Creates a sequence by concatenating source sequences until a source sequence completes successfully.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence that continues to concatenate source sequences while errors occur.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Catch<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.ToAsyncEnumerable().Catch();
+	}
+
+	/// <summary>
+	/// Creates a sequence by concatenating source sequences until a source sequence completes successfully.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence that continues to concatenate source sequences while errors occur.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// This method uses deferred execution and streams its results.
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Catch<TSource>(this IAsyncEnumerable<IAsyncEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return Core(sources);
+
+		static async IAsyncEnumerable<TSource> Core(
+			IAsyncEnumerable<IAsyncEnumerable<TSource>> sources,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await using var sourceIter = sources.GetConfiguredAsyncEnumerator(cancellationToken);
+
+			if (!await sourceIter.MoveNextAsync())
+				yield break;
+
+			var source = sourceIter.Current;
+			var hasNext = await sourceIter.MoveNextAsync();
+
+			// outer loop is not infinite.
+			// on last loop (`hasNext == false`), then either
+			// `source` will iterate successfully (yield break)
+			// or it will fail (throw). either way, it will not
+			// make it outside of the inner `while (true)`
+			while (true)
+			{
+				Guard.IsNotNull(source);
+				await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
+
+				while (true)
+				{
+					try
+					{
+						if (!await e.MoveNextAsync())
+							yield break;
+					}
+					catch
+					{
+						if (!hasNext)
+							throw;
+
+						break;
+					}
+
+					yield return e.Current;
+				}
+
+				source = sourceIter.Current;
+				hasNext = await sourceIter.MoveNextAsync();
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/CatchTest.cs
+++ b/Tests/SuperLinq.Async.Test/CatchTest.cs
@@ -1,0 +1,124 @@
+﻿namespace Test.Async;
+
+public class CatchTest
+{
+	[Fact]
+	public void CatchIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Catch(BreakingFunc.Of<Exception, IAsyncEnumerable<int>>());
+		_ = new AsyncBreakingSequence<int>().Catch(new AsyncBreakingSequence<int>());
+		_ = AsyncSuperEnumerable.Catch(new AsyncBreakingSequence<IAsyncEnumerable<int>>());
+		_ = new[] { new AsyncBreakingSequence<int>(), new AsyncBreakingSequence<int>() }.Catch();
+	}
+
+	[Fact]
+	public async Task CatchThrowsDelayedExceptionOnNullSource()
+	{
+		var seq = AsyncSuperEnumerable.Catch(new IAsyncEnumerable<int>[] { null!, });
+		_ = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+			await seq.Consume());
+	}
+
+	[Fact]
+	public async Task CatchHandlerWithNoExceptions()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = seq.Catch(BreakingFunc.Of<Exception, IAsyncEnumerable<int>>());
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public async Task CatchHandlerWithException()
+	{
+		await using var seq = AsyncSeqExceptionAt(5).AsTestingSequence();
+
+		var ran = false;
+		var result = seq
+			.Catch((Exception _) =>
+			{
+				ran = true;
+				return SuperEnumerable.Return(-5).ToAsyncEnumerable();
+			});
+
+		Assert.False(ran);
+		await result.AssertSequenceEqual(1, 2, 3, 4, -5);
+		Assert.True(ran);
+	}
+
+	[Fact]
+	public async Task CatchWithEmptySequenceList()
+	{
+		await using var seq = Enumerable.Empty<IAsyncEnumerable<int>>().AsTestingSequence();
+
+		var result = seq.Catch();
+		await result.AssertSequenceEqual();
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	public async Task CatchMultipleSequencesNoExceptions(int count)
+	{
+		await using var ts1 = Enumerable.Range(1, 10).AsTestingSequence();
+		await using var ts2 = Enumerable.Range(1, 10).AsTestingSequence();
+		await using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var seq = new[] { ts1, ts2, ts3 }
+			.Take(count)
+			.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		// no matter what, only first sequence enumerated due to no exceptions
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Theory]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(4)]
+	public async Task CatchMultipleSequencesWithNoExceptionOnSequence(int sequenceNumber)
+	{
+		var cnt = 1;
+		await using var ts1 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts2 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts3 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts4 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts5 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+
+		await using var seq = new[] { ts1, ts2, ts3, ts4, ts5, }.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		await result.AssertSequenceEqual(
+			Enumerable.Range(1, 4)
+				.Repeat(sequenceNumber - 1)
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public async Task CatchMultipleSequencesThrowsIfNoFollowingSequence()
+	{
+		await using var ts1 = AsyncSeqExceptionAt(5).AsTestingSequence();
+		await using var ts2 = AsyncSeqExceptionAt(5).AsTestingSequence();
+		await using var ts3 = AsyncSeqExceptionAt(5).AsTestingSequence();
+
+		await using var seq = new[] { ts1, ts2, ts3 }
+			.AsTestingSequence();
+
+		var result = seq.Catch();
+
+		_ = await Assert.ThrowsAsync<TestException>(async () =>
+		{
+			var i = 1;
+			await foreach (var item in result)
+			{
+				Assert.Equal(i++, item);
+				if (i == 5)
+					i = 1;
+			}
+		});
+	}
+}


### PR DESCRIPTION
This PR copies the `Catch` operator from `SuperLinq` and adapts to an async operator.

Fixes #311 
