### PR TITLE
Add `Defer` operator

### DIFF
--- a/Source/SuperLinq.Async/Defer.cs
+++ b/Source/SuperLinq.Async/Defer.cs
@@ -1,0 +1,27 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates an enumerable sequence based on an enumerable factory function.
+	/// </summary>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="enumerableFactory">Enumerable factory function.</param>
+	/// <returns>Sequence that will invoke the enumerable factory upon iteration.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="enumerableFactory"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TResult> Defer<TResult>(Func<IAsyncEnumerable<TResult>> enumerableFactory)
+	{
+		Guard.IsNotNull(enumerableFactory);
+
+		return Core(enumerableFactory);
+
+		static async IAsyncEnumerable<TResult> Core(
+			Func<IAsyncEnumerable<TResult>> enumerableFactory,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await foreach (var el in enumerableFactory().WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return el;
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/DeferTest.cs
+++ b/Tests/SuperLinq.Async.Test/DeferTest.cs
@@ -1,0 +1,32 @@
+﻿namespace Test.Async;
+
+public class DeferTest
+{
+	[Fact]
+	public void DeferIsLazy()
+	{
+		_ = AsyncSuperEnumerable.Defer(BreakingFunc.Of<IAsyncEnumerable<int>>());
+	}
+
+	[Fact]
+	public async Task DeferBehavior()
+	{
+		var starts = 0;
+		var length = 5;
+
+		var seq = AsyncSuperEnumerable.Defer(() =>
+		{
+			starts++;
+			return AsyncEnumerable.Range(1, length);
+		});
+
+		Assert.Equal(0, starts);
+
+		await seq.AssertSequenceEqual(Enumerable.Range(1, length));
+		Assert.Equal(1, starts);
+
+		length = 10;
+		await seq.AssertSequenceEqual(Enumerable.Range(1, length));
+		Assert.Equal(2, starts);
+	}
+}


### PR DESCRIPTION
This PR copies the `Defer` operator from `SuperLinq` and adapts to an async operator.

Fixes #313
