### PR TITLE
Add `Retry` operator

### DIFF
--- a/Source/SuperLinq.Async/Retry.cs
+++ b/Source/SuperLinq.Async/Retry.cs
@@ -1,0 +1,59 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that retries enumerating the source sequence as long as an error occurs.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Sequence concatenating the results of the source sequence as long as an error occurs.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="source"/> will be enumerated and values streamed until it either completes or encounters an
+	/// error. If an error is thrown, then <paramref name="source"/> will be re-enumerated from the beginning. This will
+	/// happen until an iteration of <paramref name="source"/> has completed without errors.
+	/// </para>
+	/// <para>
+	/// This method uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Retry<TSource>(this IAsyncEnumerable<TSource> source)
+	{
+		Guard.IsNotNull(source);
+
+		return Repeat<IAsyncEnumerable<TSource>>(source).Catch();
+	}
+
+	/// <summary>
+	/// Creates a sequence that retries enumerating the source sequence as long as an error occurs, with the specified
+	/// maximum number of retries.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="count">Maximum number of retries.</param>
+	/// <returns>Sequence concatenating the results of the source sequence as long as an error occurs.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than or equal to
+	/// <c>0</c>.</exception>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="source"/> will be enumerated and values streamed until it either completes or encounters an
+	/// error. If an error is thrown, then <paramref name="source"/> will be re-enumerated from the beginning. This will
+	/// happen until an iteration of <paramref name="source"/> has completed without errors, or <paramref
+	/// name="source"/> has been enumerated <paramref name="count"/> times. If an error is thrown during the final
+	/// iteration, it will not be caught and will be thrown to the consumer.
+	/// </para>
+	/// <para>
+	/// This method uses deferred execution and streams its results.
+	/// </para>
+	/// </remarks>
+	public static IAsyncEnumerable<TSource> Retry<TSource>(this IAsyncEnumerable<TSource> source, int count)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsGreaterThan(count, 0);
+
+		return Enumerable.Repeat(source, count).Catch();
+	}
+}

--- a/Tests/SuperLinq.Async.Test/RetryTest.cs
+++ b/Tests/SuperLinq.Async.Test/RetryTest.cs
@@ -1,0 +1,113 @@
+﻿namespace Test.Async;
+
+public class RetryTest
+{
+	[Fact]
+	public void RetryIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Retry();
+	}
+
+	[Fact]
+	public async Task RetryNoExceptions()
+	{
+		await using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = ts.Retry();
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public async Task RetryWithExceptions()
+	{
+		await using var ts1 = AsyncSeqExceptionAt(2).AsTestingSequence();
+		await using var ts2 = AsyncSeqExceptionAt(5).AsTestingSequence();
+		await using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = AsyncSuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IAsyncEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		using var ts = seq.AsTestingSequence(maxEnumerations: 3);
+
+		var result = ts.Retry();
+		await result.AssertSequenceEqual(
+			Enumerable.Range(1, 1)
+				.Concat(Enumerable.Range(1, 4))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public void RetryCountIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Retry(3);
+	}
+
+	[Fact]
+	public async Task RetryCountNoExceptions()
+	{
+		await using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var result = ts.Retry(3);
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+	}
+
+	[Fact]
+	public async Task RetryCountWithExceptionsComplete()
+	{
+		await using var ts1 = AsyncSeqExceptionAt(2).AsTestingSequence();
+		await using var ts2 = AsyncSeqExceptionAt(5).AsTestingSequence();
+		await using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = AsyncSuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IAsyncEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		await using var ts = seq.AsTestingSequence(maxEnumerations: 3);
+
+		var result = ts.Retry(4);
+		await result.AssertSequenceEqual(
+			Enumerable.Range(1, 1)
+				.Concat(Enumerable.Range(1, 4))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Fact]
+	public async Task RetryCountWithExceptionsThrow()
+	{
+		await using var ts1 = AsyncSeqExceptionAt(2).AsTestingSequence();
+		await using var ts2 = AsyncSeqExceptionAt(5).AsTestingSequence();
+		await using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		var starts = 0;
+		var seq = AsyncSuperEnumerable.Case(
+			() => starts++,
+			new Dictionary<int, IAsyncEnumerable<int>>()
+			{
+				[0] = ts1,
+				[1] = ts2,
+				[2] = ts3,
+			});
+		await using var ts = seq.AsTestingSequence(maxEnumerations: 2);
+
+		var result = ts.Retry(2);
+		await using var reader = result.Read();
+		Assert.Equal(1, await reader.Read());
+		Assert.Equal(1, await reader.Read());
+		Assert.Equal(2, await reader.Read());
+		Assert.Equal(3, await reader.Read());
+		Assert.Equal(4, await reader.Read());
+		_ = await Assert.ThrowsAsync<TestException>(async () =>
+			await reader.Read());
+	}
+}


### PR DESCRIPTION
This PR copies the `Retry` operator from `SuperLinq` and adapts to an async operator.

Fixes #320
