### PR TITLE
Add `Return` operator

### DIFF
--- a/Source/SuperLinq.Async/Return.cs
+++ b/Source/SuperLinq.Async/Return.cs
@@ -1,0 +1,17 @@
+﻿namespace SuperLinq.Async;
+
+public partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Returns a single-element sequence containing the item provided.
+	/// </summary>
+	/// <typeparam name="T">The type of the item.</typeparam>
+	/// <param name="item">The item to return in a sequence.</param>
+	/// <returns>A sequence containing only <paramref name="item"/>.</returns>
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+	public static async IAsyncEnumerable<T> Return<T>(T item)
+	{
+		yield return item;
+	}
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+}

--- a/Tests/SuperLinq.Async.Test/ReturnTest.cs
+++ b/Tests/SuperLinq.Async.Test/ReturnTest.cs
@@ -1,0 +1,12 @@
+﻿namespace Test.Async;
+
+public class ReturnTest
+{
+	[Fact]
+	public async Task TestResultingSequenceContainsSingle()
+	{
+		var item = new object();
+		await AsyncSuperEnumerable.Return(item)
+				.AssertSequenceEqual(item);
+	}
+}


### PR DESCRIPTION
This PR copies the `Return` operator from `SuperLinq` and adapts to an async operator.

Fixes #321
