### PR TITLE
Add `OnErrorResumeNext` operator

### DIFF
--- a/Source/SuperLinq.Async/OnErrorResumeNext.cs
+++ b/Source/SuperLinq.Async/OnErrorResumeNext.cs
@@ -1,0 +1,94 @@
+﻿namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates a sequence that concatenates both given sequences, regardless of whether an error occurs.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="first">First sequence.</param>
+	/// <param name="second">Second sequence.</param>
+	/// <returns>Sequence concatenating the elements of both sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second)
+	{
+		Guard.IsNotNull(first);
+		Guard.IsNotNull(second);
+
+		return OnErrorResumeNext(new[] { first, second, });
+	}
+
+	/// <summary>
+	/// Creates a sequence that concatenates the given sequences, regardless of whether an error occurs in any of the
+	/// sequences.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence concatenating the elements of the given sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(params IAsyncEnumerable<TSource>[] sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.ToAsyncEnumerable().OnErrorResumeNext();
+	}
+
+	/// <summary>
+	/// Creates a sequence that concatenates the given sequences, regardless of whether an error occurs in any of the
+	/// sequences.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence concatenating the elements of the given sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return sources.ToAsyncEnumerable().OnErrorResumeNext();
+	}
+
+	/// <summary>
+	/// Creates a sequence that concatenates the given sequences, regardless of whether an error occurs in any of the
+	/// sequences.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="sources">Source sequences.</param>
+	/// <returns>Sequence concatenating the elements of the given sequences, ignoring errors.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
+	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IAsyncEnumerable<IAsyncEnumerable<TSource>> sources)
+	{
+		Guard.IsNotNull(sources);
+
+		return Core(sources);
+
+		static async IAsyncEnumerable<TSource> Core(
+			IAsyncEnumerable<IAsyncEnumerable<TSource>> sources,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await foreach (var source in sources.WithCancellation(cancellationToken).ConfigureAwait(false))
+			{
+				Guard.IsNotNull(source);
+				await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
+
+				while (true)
+				{
+#pragma warning disable CA1031 // Do not catch general exception types
+					try
+					{
+						if (!await e.MoveNextAsync())
+							break;
+					}
+					catch
+					{
+						break;
+					}
+#pragma warning restore CA1031 // Do not catch general exception types
+
+					yield return e.Current;
+				}
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/OnErrorResumeNextTest.cs
+++ b/Tests/SuperLinq.Async.Test/OnErrorResumeNextTest.cs
@@ -1,0 +1,57 @@
+﻿namespace Test.Async;
+
+public class OnErrorResumeNextTest
+{
+	[Fact]
+	public void OnErrorResumeNextIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().OnErrorResumeNext(new AsyncBreakingSequence<int>());
+		_ = AsyncSuperEnumerable.OnErrorResumeNext(new AsyncBreakingSequence<int>(), new AsyncBreakingSequence<int>());
+		_ = new[] { new AsyncBreakingSequence<int>(), new AsyncBreakingSequence<int>() }.OnErrorResumeNext();
+		_ = new AsyncBreakingSequence<IAsyncEnumerable<int>>().OnErrorResumeNext();
+	}
+
+	[Fact]
+	public async Task OnErrorResumeNextMultipleSequencesNoExceptions()
+	{
+		await using var ts1 = Enumerable.Range(1, 10).AsTestingSequence();
+		await using var ts2 = Enumerable.Range(1, 10).AsTestingSequence();
+		await using var ts3 = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var seq = new[] { ts1, ts2, ts3 }
+			.AsTestingSequence();
+
+		var result = seq.OnErrorResumeNext();
+
+		await result.AssertSequenceEqual(
+			Enumerable.Range(1, 10)
+				.Concat(Enumerable.Range(1, 10))
+				.Concat(Enumerable.Range(1, 10)));
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(4)]
+	[InlineData(5)]
+	public async Task OnErrorResumeNextMultipleSequencesWithNoExceptionOnSequence(int sequenceNumber)
+	{
+		var cnt = 1;
+		await using var ts1 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts2 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts3 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts4 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+		await using var ts5 = (cnt++ == sequenceNumber ? AsyncEnumerable.Range(1, 10) : AsyncSeqExceptionAt(5)).AsTestingSequence();
+
+		await using var seq = new[] { ts1, ts2, ts3, ts4, ts5, }.AsTestingSequence();
+
+		var result = seq.OnErrorResumeNext();
+
+		var expected = Enumerable.Empty<int>();
+		for (cnt = 1; cnt <= 5; cnt++)
+			expected = expected.Concat(Enumerable.Range(1, cnt == sequenceNumber ? 10 : 4));
+
+		await result.AssertSequenceEqual(expected);
+	}
+}


### PR DESCRIPTION
This PR copies the `OnErrorResumeNext` operator from `SuperLinq` and adapts to an async operator.

Fixes #318
