### PR TITLE
Add `Share` operator

### DIFF
--- a/Source/SuperLinq.Async/Share.cs
+++ b/Source/SuperLinq.Async/Share.cs
@@ -1,0 +1,219 @@
+﻿using System.Runtime.ExceptionServices;
+
+namespace SuperLinq.Async;
+
+public static partial class AsyncSuperEnumerable
+{
+	/// <summary>
+	/// Creates a buffer with a shared view over the source sequence, causing each enumerator to fetch the next element
+	/// from the source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <returns>Buffer enabling each enumerator to retrieve elements from the shared source sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/></exception>
+	public static IAsyncBuffer<TSource> Share<TSource>(this IAsyncEnumerable<TSource> source)
+	{
+		Guard.IsNotNull(source);
+
+		return new SharedBuffer<TSource>(source);
+	}
+
+	/// <summary>
+	/// Shares the source sequence within a selector function where each enumerator can fetch the next element from the
+	/// source sequence.
+	/// </summary>
+	/// <typeparam name="TSource">Source sequence element type.</typeparam>
+	/// <typeparam name="TResult">Result sequence element type.</typeparam>
+	/// <param name="source">Source sequence.</param>
+	/// <param name="selector">Selector function with shared access to the source sequence for each enumerator.</param>
+	/// <returns>Sequence resulting from applying the selector function to the shared view over the source
+	/// sequence.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is <see
+	/// langword="null"/>.</exception>
+	public static IAsyncEnumerable<TResult> Share<TSource, TResult>(
+		this IAsyncEnumerable<TSource> source,
+		Func<IAsyncEnumerable<TSource>, IAsyncEnumerable<TResult>> selector)
+	{
+		Guard.IsNotNull(source);
+		Guard.IsNotNull(selector);
+
+		return Core(source, selector);
+
+		static async IAsyncEnumerable<TResult> Core(
+			IAsyncEnumerable<TSource> source,
+			Func<IAsyncEnumerable<TSource>, IAsyncEnumerable<TResult>> selector,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await using var buffer = source.Share();
+			await foreach (var i in selector(buffer).WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return i;
+		}
+	}
+
+	private sealed class SharedBuffer<T> : IAsyncBuffer<T>
+	{
+		private readonly SemaphoreSlim _lock = new(initialCount: 1);
+
+		private IAsyncEnumerable<T>? _source;
+
+		private IAsyncEnumerator<T>? _enumerator;
+		private bool _initialized;
+		private int _version;
+
+		private ExceptionDispatchInfo? _exception;
+
+		private bool _disposed;
+
+		public SharedBuffer(IAsyncEnumerable<T> source)
+		{
+			_source = source;
+		}
+
+		public int Count => 0;
+
+		public async ValueTask Reset(CancellationToken cancellationToken = default)
+		{
+			if (_disposed)
+				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+			await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+			try
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				_initialized = false;
+				_version++;
+
+				if (_enumerator != null)
+					await _enumerator.DisposeAsync();
+				_enumerator = null;
+				_exception = null;
+			}
+			finally
+			{
+				_ = _lock.Release();
+			}
+		}
+
+		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+		{
+			InitializeEnumerator(cancellationToken);
+			return GetEnumeratorImpl(cancellationToken);
+		}
+
+		private void InitializeEnumerator(CancellationToken cancellationToken)
+		{
+			if (_disposed)
+				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+			_lock.Wait(cancellationToken);
+			try
+			{
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				Assert.NotNull(_source);
+
+				_exception?.Throw();
+
+				if (_initialized)
+					return;
+
+				try
+				{
+					_enumerator = _source.GetAsyncEnumerator(cancellationToken);
+					_initialized = true;
+				}
+				catch (Exception ex)
+				{
+					_exception = ExceptionDispatchInfo.Capture(ex);
+					throw;
+				}
+			}
+			finally
+			{
+				_ = _lock.Release();
+			}
+		}
+
+		private async IAsyncEnumerator<T> GetEnumeratorImpl(CancellationToken cancellationToken)
+		{
+			var version = _version;
+			while (true)
+			{
+				T? element;
+
+				if (_disposed)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+
+				await _lock.WaitAsync(cancellationToken);
+				try
+				{
+					if (_disposed)
+						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					if (!_initialized
+						|| version != _version)
+					{
+						ThrowHelper.ThrowInvalidOperationException("Buffer reset during iteration.");
+					}
+
+					_exception?.Throw();
+
+					if (_enumerator == null)
+						break;
+
+					var moved = false;
+					try
+					{
+						moved = await _enumerator.MoveNextAsync(cancellationToken).ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						_exception = ExceptionDispatchInfo.Capture(ex);
+						await _enumerator.DisposeAsync().ConfigureAwait(false);
+						_enumerator = null;
+						throw;
+					}
+
+					if (!moved)
+					{
+						await _enumerator.DisposeAsync().ConfigureAwait(false);
+						_enumerator = null;
+						break;
+					}
+
+					element = _enumerator.Current;
+				}
+				finally
+				{
+					_ = _lock.Release();
+				}
+
+				yield return element;
+			}
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			if (_disposed)
+				return;
+
+			await _lock.WaitAsync().ConfigureAwait(false);
+			try
+			{
+				_disposed = true;
+				if (_enumerator != null)
+					await _enumerator.DisposeAsync().ConfigureAwait(false);
+				_enumerator = null;
+				_source = null;
+			}
+			finally
+			{
+				_ = _lock.Release();
+				_lock.Dispose();
+			}
+		}
+	}
+}

--- a/Tests/SuperLinq.Async.Test/ShareTest.cs
+++ b/Tests/SuperLinq.Async.Test/ShareTest.cs
@@ -1,0 +1,277 @@
+﻿using System.Collections;
+using CommunityToolkit.Diagnostics;
+
+namespace Test.Async;
+
+public class ShareTest
+{
+	[Fact]
+	public void ShareIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Share();
+	}
+
+	[Fact]
+	public async Task ShareWithSingleConsumer()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var result = seq.Share();
+		await result.AssertSequenceEqual(Enumerable.Range(1, 10));
+		Assert.Equal(0, result.Count);
+	}
+
+	[Fact]
+	public async Task ShareWithMultipleConsumers()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var result = seq.Share();
+
+		await using var r1 = result.Read();
+		await using var r2 = result.Read();
+
+		Assert.Equal(1, await r1.Read());
+		Assert.Equal(2, await r2.Read());
+		Assert.Equal(3, await r2.Read());
+		Assert.Equal(4, await r1.Read());
+		Assert.Equal(5, await r1.Read());
+		Assert.Equal(6, await r1.Read());
+		Assert.Equal(7, await r2.Read());
+		Assert.Equal(8, await r2.Read());
+		Assert.Equal(9, await r1.Read());
+		Assert.Equal(10, await r2.Read());
+
+		await r1.ReadEnd();
+		await r2.ReadEnd();
+	}
+
+	[Fact]
+	public async Task ShareWithInnerConsumer()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var result = seq.Share();
+
+		await using var r1 = result.Read();
+		Assert.Equal(1, await r1.Read());
+		Assert.Equal(2, await r1.Read());
+
+		await using (var r2 = result.Read())
+		{
+			Assert.Equal(3, await r2.Read());
+			Assert.Equal(4, await r1.Read());
+			Assert.Equal(5, await r2.Read());
+			Assert.Equal(6, await r2.Read());
+		}
+
+		Assert.Equal(7, await r1.Read());
+		Assert.Equal(8, await r1.Read());
+		Assert.Equal(9, await r1.Read());
+		Assert.Equal(10, await r1.Read());
+
+		await r1.ReadEnd();
+	}
+
+	[Fact]
+	public async Task ShareWithSequentialPartialConsumers()
+	{
+		await using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+
+		await using var result = seq.Share();
+
+		await using (var r1 = result.Read())
+		{
+			Assert.Equal(1, await r1.Read());
+			Assert.Equal(2, await r1.Read());
+			Assert.Equal(3, await r1.Read());
+			Assert.Equal(4, await r1.Read());
+			Assert.Equal(5, await r1.Read());
+		}
+
+		await using (var r2 = result.Read())
+		{
+			Assert.Equal(6, await r2.Read());
+			Assert.Equal(7, await r2.Read());
+			Assert.Equal(8, await r2.Read());
+			Assert.Equal(9, await r2.Read());
+			Assert.Equal(10, await r2.Read());
+			await r2.ReadEnd();
+		}
+
+		await using var r3 = result.Read();
+		await r3.ReadEnd();
+	}
+
+	[Fact]
+	public async Task ShareDisposesAfterSourceIsIteratedEntirely()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		await using var buffer = seq.Share();
+		await buffer.Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ShareDisposesWithPartialEnumeration()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		await using var buffer = seq.Share();
+
+		await using (buffer)
+			await buffer.Take(5).Consume();
+
+		Assert.True(seq.IsDisposed);
+	}
+
+	[Fact]
+	public async Task ShareRestartsAfterReset()
+	{
+		var starts = 0;
+
+		IEnumerable<int> TestSequence()
+		{
+			starts++;
+			yield return 1;
+			yield return 2;
+		}
+
+		await using var seq = TestSequence().AsTestingSequence(maxEnumerations: 2);
+		await using var buffer = seq.Share();
+
+		await buffer.Take(1).Consume();
+		Assert.Equal(1, starts);
+
+		await buffer.Reset();
+		await buffer.Take(1).Consume();
+		Assert.Equal(2, starts);
+	}
+
+	[Fact]
+	public async Task ShareThrowsWhenCacheDisposedDuringIteration()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		await using var buffer = seq.Share();
+
+		await using var reader = buffer.Read();
+
+		Assert.Equal(0, await reader.Read());
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await reader.Read());
+	}
+
+	[Fact]
+	public async Task ShareThrowsWhenResetDuringIteration()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		await using var buffer = seq.Share();
+
+		await using var reader = buffer.Read();
+
+		Assert.Equal(0, await reader.Read());
+		await buffer.Reset();
+
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+			async () => await reader.Read());
+		Assert.Equal("Buffer reset during iteration.", ex.Message);
+	}
+
+	[Fact]
+	public async Task ShareThrowsWhenGettingIteratorAfterDispose()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		await using var buffer = seq.Share();
+		await buffer.Consume();
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await buffer.Consume());
+	}
+
+	[Fact]
+	public async Task ShareThrowsWhenResettingAfterDispose()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+		await using var buffer = seq.Share();
+		await buffer.Consume();
+		await buffer.DisposeAsync();
+
+		_ = await Assert.ThrowsAsync<ObjectDisposedException>(
+			async () => await buffer.Reset());
+	}
+
+	[Fact]
+	public async Task ShareRethrowsErrorDuringIterationToAllIteratorsUntilReset()
+	{
+		await using var xs = AsyncSeqExceptionAt(2).AsTestingSequence(maxEnumerations: 2);
+
+		await using var buffer = xs.Share();
+
+		await using (var r1 = buffer.Read())
+		await using (var r2 = buffer.Read())
+		{
+			Assert.Equal(1, await r1.Read());
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r2.Read());
+
+			Guard.IsTrue(xs.IsDisposed);
+			_ = await Assert.ThrowsAsync<TestException>(async () => await r1.Read());
+		}
+
+		_ = Assert.Throws<TestException>(() => buffer.Read());
+
+		await buffer.Reset();
+
+		await using (var r1 = buffer.Read())
+			Assert.Equal(1, await r1.Read());
+	}
+
+	[Fact]
+	public async Task ShareRethrowsErrorDuringFirstIterationStartToAllIterationsUntilReset()
+	{
+		await using var seq = new FailingEnumerable().AsTestingSequence(maxEnumerations: 2);
+
+		await using var buffer = seq.Share();
+
+		for (var i = 0; i < 2; i++)
+			_ = await Assert.ThrowsAsync<TestException>(async () => await buffer.FirstAsync());
+
+		await buffer.Reset();
+		await buffer.AssertSequenceEqual(1);
+	}
+
+	private class FailingEnumerable : IEnumerable<int>
+	{
+		private bool _started;
+		public IEnumerator<int> GetEnumerator()
+		{
+			if (!_started)
+			{
+				_started = true;
+				throw new TestException();
+			}
+			return Enumerable.Range(1, 1).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	[Fact]
+	public void ShareLambdaIsLazy()
+	{
+		_ = new AsyncBreakingSequence<int>().Share(BreakingFunc.Of<IAsyncEnumerable<int>, IAsyncEnumerable<string>>());
+	}
+
+	[Fact]
+	public async Task ShareLambdaSimple()
+	{
+		await using var seq = Enumerable.Range(0, 10).AsTestingSequence();
+
+		var result = seq.Share(xs => xs.Zip(xs, (l, r) => l + r).Take(4));
+		await result.AssertSequenceEqual(1, 5, 9, 13);
+	}
+}


### PR DESCRIPTION
This PR copies the `Share` operator from `SuperLinq` and adapts to an async operator.

Fixes #322
