### PR TITLE
Fix `Unfold` to be idempotent

### DIFF
--- a/Source/SuperLinq/Unfold.cs
+++ b/Source/SuperLinq/Unfold.cs
@@ -41,7 +41,14 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(stateSelector);
 		Guard.IsNotNull(resultSelector);
 
-		return Core(); IEnumerable<TResult> Core()
+		return Core(state, generator, predicate, stateSelector, resultSelector);
+
+		static IEnumerable<TResult> Core(
+			TState state,
+			Func<TState, T> generator,
+			Func<T, bool> predicate,
+			Func<T, TState> stateSelector,
+			Func<T, TResult> resultSelector)
 		{
 			while (true)
 			{

--- a/Tests/SuperLinq.Test/UnfoldTest.cs
+++ b/Tests/SuperLinq.Test/UnfoldTest.cs
@@ -5,60 +5,92 @@ public class UnfoldTest
 	[Fact]
 	public void UnfoldInfiniteSequence()
 	{
-		var result = SuperEnumerable.Unfold(1, x => (Result: x, State: x + 1),
-											  _ => true,
-											  e => e.State,
-											  e => e.Result)
-								   .Take(100);
+		var result = SuperEnumerable
+			.Unfold(
+				1,
+				x => (Result: x, State: x + 1),
+				_ => true,
+				e => e.State,
+				e => e.Result)
+			.Take(100);
 
-		var expectations = SuperEnumerable.Generate(1, x => x + 1).Take(100);
 
-		Assert.Equal(expectations, result);
+		result.AssertSequenceEqual(
+			SuperEnumerable.Generate(1, x => x + 1).Take(100));
 	}
 
 	[Fact]
 	public void UnfoldFiniteSequence()
 	{
-		var result = SuperEnumerable.Unfold(1, x => (Result: x, State: x + 1),
-											  e => e.Result <= 100,
-											  e => e.State,
-											  e => e.Result);
+		var result = SuperEnumerable
+			.Unfold(
+				1,
+				x => (Result: x, State: x + 1),
+				e => e.Result <= 100,
+				e => e.State,
+				e => e.Result);
 
-		var expectations = SuperEnumerable.Generate(1, x => x + 1).Take(100);
-
-		Assert.Equal(expectations, result);
+		result.AssertSequenceEqual(
+			SuperEnumerable.Generate(1, x => x + 1).Take(100));
 	}
 
 	[Fact]
 	public void UnfoldIsLazy()
 	{
-		_ = SuperEnumerable.Unfold(0, BreakingFunc.Of<int, (int, int)>(),
-								 BreakingFunc.Of<(int, int), bool>(),
-								 BreakingFunc.Of<(int, int), int>(),
-								 BreakingFunc.Of<(int, int), int>());
+		_ = SuperEnumerable
+			.Unfold(
+				0,
+				BreakingFunc.Of<int, (int, int)>(),
+				BreakingFunc.Of<(int, int), bool>(),
+				BreakingFunc.Of<(int, int), int>(),
+				BreakingFunc.Of<(int, int), int>());
 	}
 
 
 	[Fact]
 	public void UnfoldSingleElementSequence()
 	{
-		var result = SuperEnumerable.Unfold(0, x => (Result: x, State: x + 1),
-											  x => x.Result == 0,
-											  e => e.State,
-											  e => e.Result);
+		var result = SuperEnumerable
+			.Unfold(
+				0,
+				x => (Result: x, State: x + 1),
+				x => x.Result == 0,
+				e => e.State,
+				e => e.Result);
 
-		var expectations = new[] { 0 };
-
-		Assert.Equal(expectations, result);
+		result.AssertSequenceEqual(0);
 	}
 
 	[Fact]
 	public void UnfoldEmptySequence()
 	{
-		var result = SuperEnumerable.Unfold(0, x => (Result: x, State: x + 1),
-											  x => x.Result < 0,
-											  e => e.State,
-											  e => e.Result);
-		Assert.Empty(result);
+		var result = SuperEnumerable
+			.Unfold(
+				0,
+				x => (Result: x, State: x + 1),
+				x => x.Result < 0,
+				e => e.State,
+				e => e.Result);
+
+		result.AssertSequenceEqual();
+	}
+
+	[Fact]
+	public void UnfoldIsIdempotent()
+	{
+		var result = SuperEnumerable
+			.Unfold(
+				1,
+				n => (Result: n, Next: n + 1),
+				_ => true,
+				n => n.Next,
+				n => n.Result)
+			.Take(5);
+
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 5));
+
+		result.AssertSequenceEqual(
+			Enumerable.Range(1, 5));
 	}
 }


### PR DESCRIPTION
This PR addresses a bug in `Unfold` where the operator keeps `state` active across multiple enumerations. A new test is added to confirm bug-fix.

Fixes #345 