### PR TITLE
Address issues with `Memoize`

### DIFF
--- a/Source/SuperLinq/DoWhile.cs
+++ b/Source/SuperLinq/DoWhile.cs
@@ -34,7 +34,7 @@ public partial class SuperEnumerable
 
 			do
 			{
-				foreach (var item in source)
+				foreach (var item in memo)
 					yield return item;
 			} while (condition());
 		}

--- a/Tests/SuperLinq.Test/DoWhileTest.cs
+++ b/Tests/SuperLinq.Test/DoWhileTest.cs
@@ -11,8 +11,10 @@ public class DoWhileTest
 	[Fact]
 	public void DoWhileBehavior()
 	{
+		using var ts = Enumerable.Range(1, 10).AsTestingSequence();
+
 		var starts = 0;
-		var seq = Enumerable.Range(1, 10)
+		var seq = ts
 			.DoWhile(
 				() =>
 					starts++ switch


### PR DESCRIPTION
This PR fixes the `Memoize` operator, which incorrectly used `source` instead of the local `memo`. The unit tests were updated to identify this issue.

Fixes #329 