### PR TITLE
Mark two operators obsolete

### DIFF
--- a/Source/SuperLinq/GenerateByIndex.cs
+++ b/Source/SuperLinq/GenerateByIndex.cs
@@ -19,6 +19,7 @@ public static partial class SuperEnumerable
 	/// <para>
 	/// This function defers execution and streams the results.</para>
 	/// </remarks>
+	[Obsolete("Will be removed in v6.0.0; better implemented as `Enumerable.Range().Select()`")]
 	public static IEnumerable<TResult> GenerateByIndex<TResult>(Func<int, TResult> generator)
 	{
 		Guard.IsNotNull(generator);

--- a/Source/SuperLinq/Unfold.cs
+++ b/Source/SuperLinq/Unfold.cs
@@ -28,7 +28,7 @@ public static partial class SuperEnumerable
 	/// <remarks>
 	/// This operator uses deferred execution and streams its results.
 	/// </remarks>
-
+	[Obsolete("Will be removed in v6.0.0; better implemented as `SuperEnumerable.Generate().TakeWhile().Select()`")]
 	public static IEnumerable<TResult> Unfold<TState, T, TResult>(
 		TState state,
 		Func<TState, T> generator,

--- a/Tests/SuperLinq.Test/GenerateTest.cs
+++ b/Tests/SuperLinq.Test/GenerateTest.cs
@@ -1,5 +1,8 @@
 ﻿namespace Test;
 
+// Keep testing `GenerateByIndex` for now
+#pragma warning disable CS0618
+
 public class GenerateTest
 {
 	[Fact]

--- a/Tests/SuperLinq.Test/UnfoldTest.cs
+++ b/Tests/SuperLinq.Test/UnfoldTest.cs
@@ -1,5 +1,8 @@
 ﻿namespace Test;
 
+// Keep testing `Unfold` for now
+#pragma warning disable CS0618
+
 public class UnfoldTest
 {
 	[Fact]


### PR DESCRIPTION
These operators can be better implemented via other operators, so maintaining the code for each of these is unnecessary.