### PR TITLE
Update docs to support `View Source` link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,14 +27,12 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          3.1.x
-          6.0.x
           7.0.102
 
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build -c Release --no-restore
+      run: dotnet build -f net7.0 -c Release --no-restore
 
     - name: Build documentation
       run: dotnet run -f net7.0 -c Release --no-build

--- a/Docs/SuperLinq.Docs/docfx.json
+++ b/Docs/SuperLinq.Docs/docfx.json
@@ -4,17 +4,15 @@
 			"src": [
 				{
 					"files": [
-						"**/*.csproj"
+						"SuperLinq/bin/Release/net7.0/SuperLinq.dll",
+						"SuperLinq.Async/bin/Release/net7.0/SuperLinq.Async.dll"
 					],
 					"src": "../../Source"
 				}
 			],
 			"dest": "api",
 			"disableGitFeatures": false,
-			"disableDefaultFilter": false,
-			"properties": {
-				"TargetFramework": "net7.0"
-			}
+			"disableDefaultFilter": false
 		}
   ],
   "build": {
@@ -25,10 +23,9 @@
 			"_appFooter": "",
 			"_enableSearch": true,
 			"_enableNewTab": true,
-			"_disableContribution": true
+			"_disableContribution": false
 		},
     "template": ["default", "./singulinkfx/singulinkfx"],
-    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ],
     "content": [
       {
         "files": [


### PR DESCRIPTION
This PR updates docfx.json and the `docs` build action to light up the `View Source` link on function pages.