### PR TITLE
`FallBackward`: `ICollection<>` implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -206,6 +206,7 @@ csharp_preserve_single_line_statements = true:silent
 # Style Analytics
 dotnet_analyzer_diagnostic.category-Style.severity = warning
 
+dotnet_diagnostic.IDE0011.severity = silent				# IDE0011: Add braces
 dotnet_diagnostic.IDE0046.severity = silent				# IDE0046: Convert to conditional expression
 
 # For ScanEx()

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -46,7 +48,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(predicate);
 
-		return FillBackwardImpl(source, predicate, null);
+		return source is ICollection<T> coll
+			? new FillBackwardCollection<T>(coll, predicate, fillSelector: default)
+			: FillBackwardCore(source, predicate, fillSelector: default);
 	}
 
 	/// <summary>
@@ -78,10 +82,12 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(predicate);
 		Guard.IsNotNull(fillSelector);
 
-		return FillBackwardImpl(source, predicate, fillSelector);
+		return source is ICollection<T> coll
+			? new FillBackwardCollection<T>(coll, predicate, fillSelector)
+			: FillBackwardCore(source, predicate, fillSelector);
 	}
 
-	private static IEnumerable<T> FillBackwardImpl<T>(IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T>? fillSelector)
+	private static IEnumerable<T> FillBackwardCore<T>(IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T>? fillSelector)
 	{
 		List<T>? blanks = null;
 
@@ -99,8 +105,8 @@ public static partial class SuperEnumerable
 					foreach (var blank in blanks)
 					{
 						yield return fillSelector != null
-								   ? fillSelector(blank, item)
-								   : item;
+							? fillSelector(blank, item)
+							: item;
 					}
 
 					blanks.Clear();
@@ -114,5 +120,56 @@ public static partial class SuperEnumerable
 			foreach (var blank in blanks)
 				yield return blank;
 		}
+	}
+
+	private sealed class FillBackwardCollection<T> : IteratorCollection<T, T>
+	{
+		private readonly ICollection<T> _source;
+		private readonly Func<T, bool> _predicate;
+		private readonly Func<T, T, T>? _fillSelector;
+
+		public FillBackwardCollection(ICollection<T> source, Func<T, bool> predicate, Func<T, T, T>? fillSelector)
+		{
+			_source = source;
+			_predicate = predicate;
+			_fillSelector = fillSelector;
+		}
+
+		public override int Count => _source.Count;
+
+		[ExcludeFromCodeCoverage]
+		public override IEnumerator<T> GetEnumerator() =>
+			FillBackwardCore(_source, _predicate, _fillSelector)
+				.GetEnumerator();
+
+		public override void CopyTo(T[] array, int arrayIndex)
+		{
+			_source.CopyTo(array, arrayIndex);
+
+			var i = arrayIndex + _source.Count - 1;
+			for (; !_predicate(array[i]); i--)
+			{
+				if (i < arrayIndex)
+					return;
+			}
+
+			var last = array[i--];
+			for (; i >= arrayIndex; i--)
+			{
+				if (_predicate(array[i]))
+				{
+					array[i] = _fillSelector != null
+						? _fillSelector(array[i], last)
+						: last;
+				}
+				else
+					last = array[i];
+			}
+		}
+
+		[ExcludeFromCodeCoverage]
+		public override bool Contains(T item) =>
+			FillBackwardCore(_source, _predicate, _fillSelector)
+				.Contains(item);
 	}
 }

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -144,6 +144,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsGreaterThanOrEqualTo(arrayIndex, 0);
+
 			_source.CopyTo(array, arrayIndex);
 
 			var i = arrayIndex + _source.Count - 1;

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -18,10 +18,9 @@ public static partial class SuperEnumerable
 	/// results. If references or values are null at the end of the
 	/// sequence then they remain null.
 	/// </remarks>
-
-	public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source)
+	public static IEnumerable<T?> FillBackward<T>(this IEnumerable<T?> source)
 	{
-		return source.FillBackward(e => e == null);
+		return source.FillBackward(static e => e == null);
 	}
 
 	/// <summary>
@@ -42,7 +41,6 @@ public static partial class SuperEnumerable
 	/// results. If elements are missing at the end of the sequence then
 	/// they remain missing.
 	/// </remarks>
-
 	public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
 	{
 		Guard.IsNotNull(source);
@@ -74,7 +72,6 @@ public static partial class SuperEnumerable
 	/// results. If elements are missing at the end of the sequence then
 	/// they remain missing.
 	/// </remarks>
-
 	public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
 	{
 		Guard.IsNotNull(source);

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -150,11 +150,11 @@ public static partial class SuperEnumerable
 			_source.CopyTo(array, arrayIndex);
 
 			var i = arrayIndex + _source.Count - 1;
-			for (; _predicate(array[i]); i--)
-			{
-				if (i < arrayIndex)
-					return;
-			}
+			for (; i >= arrayIndex && _predicate(array[i]); i--)
+				;
+
+			if (i < arrayIndex)
+				return;
 
 			var last = array[i--];
 			for (; i >= arrayIndex; i--)

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -147,7 +147,7 @@ public static partial class SuperEnumerable
 			_source.CopyTo(array, arrayIndex);
 
 			var i = arrayIndex + _source.Count - 1;
-			for (; !_predicate(array[i]); i--)
+			for (; _predicate(array[i]); i--)
 			{
 				if (i < arrayIndex)
 					return;

--- a/Source/SuperLinq/IteratorCollection.cs
+++ b/Source/SuperLinq/IteratorCollection.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
+
+public partial class SuperEnumerable
+{
+	[ExcludeFromCodeCoverage]
+	private abstract class IteratorCollection<TSource, TResult> : ICollection<TResult>, IReadOnlyCollection<TResult>
+	{
+		public bool IsReadOnly => true;
+		public void Add(TResult item) =>
+			throw new NotSupportedException();
+		public bool Remove(TResult item) =>
+			throw new NotSupportedException();
+		public void Clear() =>
+			throw new NotSupportedException();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public abstract int Count { get; }
+		public abstract IEnumerator<TResult> GetEnumerator();
+		public abstract bool Contains(TResult item);
+		public abstract void CopyTo(TResult[] array, int arrayIndex);
+	}
+}

--- a/Source/SuperLinq/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/Source/SuperLinq/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -103,7 +103,7 @@ static SuperLinq.SuperEnumerable.ExceptBy<TSource, TKey>(System.Collections.Gene
 static SuperLinq.SuperEnumerable.Exclude<T>(this System.Collections.Generic.IEnumerable<T>! sequence, int startIndex, int count) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, params T[]! fallback) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Collections.Generic.IEnumerable<T>! fallback) -> System.Collections.Generic.IEnumerable<T>!
-static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T?>! source) -> System.Collections.Generic.IEnumerable<T?>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate, System.Func<T, T, T>! fillSelector) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillForward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!

--- a/Source/SuperLinq/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/Source/SuperLinq/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -103,7 +103,7 @@ static SuperLinq.SuperEnumerable.ExceptBy<TSource, TKey>(System.Collections.Gene
 static SuperLinq.SuperEnumerable.Exclude<T>(this System.Collections.Generic.IEnumerable<T>! sequence, int startIndex, int count) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, params T[]! fallback) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Collections.Generic.IEnumerable<T>! fallback) -> System.Collections.Generic.IEnumerable<T>!
-static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T?>! source) -> System.Collections.Generic.IEnumerable<T?>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate, System.Func<T, T, T>! fillSelector) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillForward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!

--- a/Source/SuperLinq/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/Source/SuperLinq/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -103,7 +103,7 @@ static SuperLinq.SuperEnumerable.ExceptBy<TSource, TKey>(this System.Collections
 static SuperLinq.SuperEnumerable.Exclude<T>(this System.Collections.Generic.IEnumerable<T>! sequence, int startIndex, int count) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, params T[]! fallback) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FallbackIfEmpty<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Collections.Generic.IEnumerable<T>! fallback) -> System.Collections.Generic.IEnumerable<T>!
-static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T?>! source) -> System.Collections.Generic.IEnumerable<T?>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillBackward<T>(this System.Collections.Generic.IEnumerable<T>! source, System.Func<T, bool>! predicate, System.Func<T, T, T>! fillSelector) -> System.Collections.Generic.IEnumerable<T>!
 static SuperLinq.SuperEnumerable.FillForward<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -40,4 +40,20 @@ public class FillBackwardTest
 				new { X = 0, Y = 0 },
 				new { X = 0, Y = 0 });
 	}
+
+	[Fact]
+	public void FillBackwardCollectionCopyTo()
+	{
+		using var xs = new BreakingCollection<int>(0, 0, 1, 2, 0, 0, 0, 3, 4, 0, 0);
+
+		var result = xs.FillBackward(e => e == 0);
+		Assert.Equal(xs.Count, (result as ICollection<int>)!.Count);
+
+		var arr = new int[xs.Count];
+		_ = result.CopyTo(arr, 0);
+
+		arr.AssertSequenceEqual(
+			1, 1, 1, 2, 3, 3, 3, 3, 4, 0, 0);
+	}
+
 }

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -17,6 +17,18 @@ public class FillBackwardTest
 
 	[Theory]
 	[MemberData(nameof(GetIntNullSequences))]
+	public void FillBackwardBlank(IDisposableEnumerable<int?> seq)
+	{
+		using (seq)
+		{
+			seq
+				.FillBackward(x => x == 200)
+				.AssertSequenceEqual(default(int?), null, 1, 2, null, null, null, 3, 4, null, null);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetIntNullSequences))]
 	public void FillBackward(IDisposableEnumerable<int?> seq)
 	{
 		using (seq)

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -6,54 +6,41 @@ public class FillBackwardTest
 	public void FillBackwardIsLazy()
 	{
 		_ = new BreakingSequence<object>().FillBackward();
+		_ = new BreakingSequence<object>().FillBackward(BreakingFunc.Of<object, bool>());
+		_ = new BreakingSequence<object>().FillBackward(BreakingFunc.Of<object, bool>(), BreakingFunc.Of<object, object, object>());
 	}
 
-	[Fact]
-	public void FillBackward()
+	public static IEnumerable<object[]> GetIntNullSequences() =>
+		Seq<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null)
+			.ArrangeCollectionInlineDatas()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetIntNullSequences))]
+	public void FillBackward(IDisposableEnumerable<int?> seq)
 	{
-		using var input = TestingSequence.Of<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null);
-
-		input
-			.FillBackward()
-			.AssertSequenceEqual(1, 1, 1, 2, 3, 3, 3, 3, 4, null, null);
+		using (seq)
+		{
+			seq
+				.FillBackward()
+				.AssertSequenceEqual(1, 1, 1, 2, 3, 3, 3, 3, 4, null, null);
+		}
 	}
 
-	[Fact]
-	public void FillBackwardWithFillSelector()
+	public static IEnumerable<object[]> GetIntSequences() =>
+		Enumerable.Range(1, 13)
+			.ArrangeCollectionInlineDatas()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void FillBackwardWithFillSelector(IDisposableEnumerable<int> seq)
 	{
-		using var xs = Seq(0, 0, 1, 2, 0, 0, 0, 3, 4, 0, 0)
-			.Select(x => new { X = x, Y = x })
-			.AsTestingSequence();
-
-		xs
-			.FillBackward(e => e.X == 0, (m, nm) => new { m.X, nm.Y })
-			.AssertSequenceEqual(
-				new { X = 0, Y = 1 },
-				new { X = 0, Y = 1 },
-				new { X = 1, Y = 1 },
-				new { X = 2, Y = 2 },
-				new { X = 0, Y = 3 },
-				new { X = 0, Y = 3 },
-				new { X = 0, Y = 3 },
-				new { X = 3, Y = 3 },
-				new { X = 4, Y = 4 },
-				new { X = 0, Y = 0 },
-				new { X = 0, Y = 0 });
+		using (seq)
+		{
+			seq
+				.FillBackward(e => e % 5 != 0, (x, y) => x * y)
+				.AssertSequenceEqual(5, 10, 15, 20, 5, 60, 70, 80, 90, 10, 11, 12, 13);
+		}
 	}
-
-	[Fact]
-	public void FillBackwardCollectionCopyTo()
-	{
-		using var xs = new BreakingCollection<int>(0, 0, 1, 2, 0, 0, 0, 3, 4, 0, 0);
-
-		var result = xs.FillBackward(e => e == 0);
-		Assert.Equal(xs.Count, (result as ICollection<int>)!.Count);
-
-		var arr = new int[xs.Count];
-		_ = result.CopyTo(arr, 0);
-
-		arr.AssertSequenceEqual(
-			1, 1, 1, 2, 3, 3, 3, 3, 4, 0, 0);
-	}
-
 }

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -22,7 +22,7 @@ public class FillBackwardTest
 		using (seq)
 		{
 			seq
-				.FillBackward(x => x == 200)
+				.FillBackward(x => x != 200)
 				.AssertSequenceEqual(default(int?), null, 1, 2, null, null, null, 3, 4, null, null);
 		}
 	}

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -22,7 +22,6 @@ internal static partial class TestExtensions
 	/// <summary>
 	/// Just to make our testing easier so we can chain the assertion call.
 	/// </summary>
-
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected) =>
 		Assert.Equal(expected, actual);
 
@@ -30,9 +29,22 @@ internal static partial class TestExtensions
 	/// Make testing even easier - a params array makes for readable tests :)
 	/// The sequence should be evaluated exactly once.
 	/// </summary>
+	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected)
+	{
+		if (actual is ICollection<T> coll)
+		{
+			Assert.Equal(expected.Length, coll.Count);
 
-	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected) =>
-		Assert.Equal(expected, actual);
+			var arr = new T[expected.Length];
+			_ = actual.CopyTo(arr);
+
+			Assert.Equal(expected, arr);
+		}
+		else
+		{
+			Assert.Equal(expected, actual);
+		}
+	}
 
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, Func<T, T, bool> comparer, params T[] expected) =>
 		Assert.Equal(expected, actual, EqualityComparer.Create(comparer));


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `Fallback` operator. 

Fixes #370 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|             Method |               source |     N |         Mean |      Error |     StdDev |   Gen0 |   Gen1 | Allocated |
|------------------- |--------------------- |------ |-------------:|-----------:|-----------:|-------:|-------:|----------:|
|  FillBackwardCount | Syste(...)nt32] [47] | 10000 |     13.57 ns |   0.169 ns |   0.150 ns | 0.0032 | 0.0000 |      40 B |
|  FillBackwardCount | Syste(...)rator [36] | 10000 | 80,539.61 ns | 569.023 ns | 532.265 ns |      - |      - |     376 B |
| FillBackwardCopyTo | Syste(...)nt32] [47] | 10000 | 20,054.10 ns | 173.320 ns | 153.643 ns | 3.1738 | 0.0305 |   40064 B |
| FillBackwardCopyTo | Syste(...)rator [36] | 10000 | 95,658.32 ns | 497.560 ns | 465.418 ns | 3.1738 | 0.1221 |   40400 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[] { Enumerable.Range(1, i), i, };
		yield return new object[] { Enumerable.Range(1, i).ToList(), i, };
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void FillBackwardCount(IEnumerable<int> source, int N)
{
	_ = source.FillBackward(e => e % 10 != 5).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void FillBackwardCopyTo(IEnumerable<int> source, int N)
{
	var arr = new int[N];
	_ = source.FillBackward(e => e % 10 != 5).CopyTo(arr);
}
```
</details>