### PR TITLE
`Interleave`: `ICollection<>` implementation

### DIFF
--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -138,9 +138,8 @@ public static partial class SuperEnumerable
 		public override int Count => _source.Count;
 
 		[ExcludeFromCodeCoverage]
-		public override IEnumerator<T> GetEnumerator() =>
-			FillBackwardCore(_source, _predicate, _fillSelector)
-				.GetEnumerator();
+		protected override IEnumerable<T> GetEnumerable() =>
+			FillBackwardCore(_source, _predicate, _fillSelector);
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
@@ -169,10 +168,5 @@ public static partial class SuperEnumerable
 					last = array[i];
 			}
 		}
-
-		[ExcludeFromCodeCoverage]
-		public override bool Contains(T item) =>
-			FillBackwardCore(_source, _predicate, _fillSelector)
-				.Contains(item);
 	}
 }

--- a/Source/SuperLinq/FillForward.cs
+++ b/Source/SuperLinq/FillForward.cs
@@ -126,9 +126,8 @@ public static partial class SuperEnumerable
 		public override int Count => _source.Count;
 
 		[ExcludeFromCodeCoverage]
-		public override IEnumerator<T> GetEnumerator() =>
-			FillForwardCore(_source, _predicate, _fillSelector)
-				.GetEnumerator();
+		protected override IEnumerable<T> GetEnumerable() =>
+			FillForwardCore(_source, _predicate, _fillSelector);
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
@@ -158,10 +157,5 @@ public static partial class SuperEnumerable
 					last = array[i];
 			}
 		}
-
-		[ExcludeFromCodeCoverage]
-		public override bool Contains(T item) =>
-			FillForwardCore(_source, _predicate, _fillSelector)
-				.Contains(item);
 	}
 }

--- a/Source/SuperLinq/IteratorCollection.cs
+++ b/Source/SuperLinq/IteratorCollection.cs
@@ -18,9 +18,17 @@ public partial class SuperEnumerable
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+		protected abstract IEnumerable<TResult> GetEnumerable();
+
 		public abstract int Count { get; }
-		public abstract IEnumerator<TResult> GetEnumerator();
-		public abstract bool Contains(TResult item);
-		public abstract void CopyTo(TResult[] array, int arrayIndex);
+
+		public virtual IEnumerator<TResult> GetEnumerator() =>
+			GetEnumerable().GetEnumerator();
+
+		public virtual bool Contains(TResult item) =>
+			GetEnumerable().Contains(item);
+
+		public virtual void CopyTo(TResult[] array, int arrayIndex) =>
+			GetEnumerable().CopyTo(array, arrayIndex);
 	}
 }

--- a/Tests/SuperLinq.Test/BreakingCollection.cs
+++ b/Tests/SuperLinq.Test/BreakingCollection.cs
@@ -1,5 +1,10 @@
 ﻿namespace Test;
 
+internal static class BreakingCollection
+{
+	public static BreakingCollection<T> AsBreakingCollection<T>(this IEnumerable<T> source) => new(source);
+}
+
 internal class BreakingCollection<T> : BreakingSequence<T>, ICollection<T>, IDisposableEnumerable<T>
 {
 	protected readonly IList<T> List;

--- a/Tests/SuperLinq.Test/InterleaveTest.cs
+++ b/Tests/SuperLinq.Test/InterleaveTest.cs
@@ -128,4 +128,14 @@ public class InterleaveTests
 
 		result.AssertSequenceEqual(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
 	}
+
+	[Fact]
+	public void TestInterleaveCollectionCount()
+	{
+		using var sequenceA = Enumerable.Range(1, 100).AsTestingSequence();
+		using var sequenceB = Enumerable.Range(1, 100).AsTestingSequence();
+
+		var coll = sequenceA.Interleave(sequenceB);
+		Assert.Equal(200, coll.Count());
+	}
 }

--- a/Tests/SuperLinq.Test/InterleaveTest.cs
+++ b/Tests/SuperLinq.Test/InterleaveTest.cs
@@ -132,10 +132,13 @@ public class InterleaveTests
 	[Fact]
 	public void TestInterleaveCollectionCount()
 	{
-		using var sequenceA = Enumerable.Range(1, 100).AsTestingSequence();
-		using var sequenceB = Enumerable.Range(1, 100).AsTestingSequence();
+		using var sequenceA = Enumerable.Range(1, 100).AsBreakingCollection();
+		using var sequenceB = Enumerable.Range(1, 100).AsBreakingCollection();
 
 		var coll = sequenceA.Interleave(sequenceB);
+		Assert.Equal(200, coll.Count());
+
+		coll = Seq(sequenceA, sequenceB).Interleave<int>();
 		Assert.Equal(200, coll.Count());
 	}
 }


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `Interleave` operator. 

Fixes #375 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|           Method |               source |    N |      Mean |     Error |    StdDev |   Gen0 |   Gen1 | Allocated |
|----------------- |--------------------- |----- |----------:|----------:|----------:|-------:|-------:|----------:|
|  InterleaveCount | Syste(...)t32]] [82] | 4096 |  1.584 μs | 0.0069 μs | 0.0061 μs | 0.0992 | 0.0019 |   1.22 KB |
|  InterleaveCount |  Syst(...)32]] [154] | 4096 | 43.721 μs | 0.2876 μs | 0.2691 μs | 0.4272 | 0.0610 |   5.77 KB |
| InterleaveCopyTo | Syste(...)t32]] [82] | 4096 | 47.959 μs | 0.3584 μs | 0.3177 μs | 1.7090 | 0.1221 |  20.98 KB |
| InterleaveCopyTo |  Syst(...)32]] [154] | 4096 | 50.174 μs | 0.2550 μs | 0.2130 μs | 3.1128 | 0.0610 |  38.20 KB |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 64, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Select(_ => Enumerable.Range(1, i).ToList().Select(SuperEnumerable.Identity)).ToList().Select(SuperEnumerable.Identity),
			i * i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).Select(_ => Enumerable.Range(1, i).ToList()).ToList(),
			i * i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void InterleaveCount(IEnumerable<IEnumerable<int>> source, int N)
{
	_ = source.Interleave<int>().Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void InterleaveCopyTo(IEnumerable<IEnumerable<int>> source, int N)
{
	_ = source.Interleave<int>().ToArray();
}
```
</details>