### PR TITLE
`Rank`: `ICollection<>` implementation

### DIFF
--- a/Source/SuperLinq/Rank.cs
+++ b/Source/SuperLinq/Rank.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -218,6 +220,7 @@ public static partial class SuperEnumerable
 
 		public override int Count => _source.Count;
 
+		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<(TSource, int)> GetEnumerable() =>
 			RankByCore(_source, _keySelector, _comparer, _isDense);
 	}

--- a/Tests/SuperLinq.Test/DenseRankTest.cs
+++ b/Tests/SuperLinq.Test/DenseRankTest.cs
@@ -144,4 +144,17 @@ public class DenseRankTests
 			.OrderByDescending(x => x.Day)
 			.Select((x, i) => (x, i + 1)));
 	}
+
+	[Fact]
+	public void TestRankCollectionCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.DenseRank();
+		Assert.Equal(10_000, result.Count());
+
+		result = sequence.DenseRank(comparer: Comparer<int>.Default);
+		Assert.Equal(10_000, result.Count());
+	}
 }

--- a/Tests/SuperLinq.Test/RankTest.cs
+++ b/Tests/SuperLinq.Test/RankTest.cs
@@ -156,11 +156,5 @@ public class RankTests
 
 		result = sequence.Rank(comparer: Comparer<int>.Default);
 		Assert.Equal(10_000, result.Count());
-
-		result = sequence.RankBy(x => -x);
-		Assert.Equal(10_000, result.Count());
-
-		result = sequence.RankBy(x => -x, comparer: Comparer<int>.Default);
-		Assert.Equal(10_000, result.Count());
 	}
 }

--- a/Tests/SuperLinq.Test/RankTest.cs
+++ b/Tests/SuperLinq.Test/RankTest.cs
@@ -144,4 +144,23 @@ public class RankTests
 				.Select((x, i) => (x, i + 1)));
 		}
 	}
+
+	[Fact]
+	public void TestRankCollectionCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.Rank();
+		Assert.Equal(10_000, result.Count());
+
+		result = sequence.Rank(comparer: Comparer<int>.Default);
+		Assert.Equal(10_000, result.Count());
+
+		result = sequence.RankBy(x => -x);
+		Assert.Equal(10_000, result.Count());
+
+		result = sequence.RankBy(x => -x, comparer: Comparer<int>.Default);
+		Assert.Equal(10_000, result.Count());
+	}
 }


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `Rank(By)` and `Dense(By)` operators. 

Fixes #377 
Fixes #378  