### PR TITLE
`Scan`: `ICollection<>` implementation

### DIFF
--- a/Source/SuperLinq/PartialSort.cs
+++ b/Source/SuperLinq/PartialSort.cs
@@ -115,34 +115,34 @@ public static partial class SuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<T>(comparer);
 
-		return Core(source, count, comparer);
+		return PartialSortCore(source, count, comparer);
+	}
 
-		static IEnumerable<T> Core(IEnumerable<T> source, int count, IComparer<T> comparer)
+	private static IEnumerable<T> PartialSortCore<T>(IEnumerable<T> source, int count, IComparer<T> comparer)
+	{
+		var top = new SortedSet<(T Item, int Index)>(
+			ValueTupleComparer.Create<T, int>(comparer, default));
+
+		var index = -1;
+		foreach (var item in source)
 		{
-			var top = new SortedSet<(T Item, int Index)>(
-				ValueTupleComparer.Create<T, int>(comparer, default));
+			index++;
 
-			var index = -1;
-			foreach (var item in source)
+			if (top.Count < count)
 			{
-				index++;
-
-				if (top.Count < count)
-				{
-					_ = top.Add((item, index));
-					continue;
-				}
-
-				if (comparer.Compare(item, top.Max.Item) >= 0)
-					continue;
-
-				_ = top.Remove(top.Max);
 				_ = top.Add((item, index));
+				continue;
 			}
 
-			foreach (var (item, _) in top)
-				yield return item;
+			if (comparer.Compare(item, top.Max.Item) >= 0)
+				continue;
+
+			_ = top.Remove(top.Max);
+			_ = top.Add((item, index));
 		}
+
+		foreach (var (item, _) in top)
+			yield return item;
 	}
 
 	/// <summary>

--- a/Source/SuperLinq/PartialSort.cs
+++ b/Source/SuperLinq/PartialSort.cs
@@ -115,34 +115,34 @@ public static partial class SuperEnumerable
 		if (direction == OrderByDirection.Descending)
 			comparer = new ReverseComparer<T>(comparer);
 
-		return PartialSortCore(source, count, comparer);
-	}
+		return Core(source, count, comparer);
 
-	private static IEnumerable<T> PartialSortCore<T>(IEnumerable<T> source, int count, IComparer<T> comparer)
-	{
-		var top = new SortedSet<(T Item, int Index)>(
-			ValueTupleComparer.Create<T, int>(comparer, default));
-
-		var index = -1;
-		foreach (var item in source)
+		static IEnumerable<T> Core(IEnumerable<T> source, int count, IComparer<T> comparer)
 		{
-			index++;
+			var top = new SortedSet<(T Item, int Index)>(
+				ValueTupleComparer.Create<T, int>(comparer, default));
 
-			if (top.Count < count)
+			var index = -1;
+			foreach (var item in source)
 			{
+				index++;
+
+				if (top.Count < count)
+				{
+					_ = top.Add((item, index));
+					continue;
+				}
+
+				if (comparer.Compare(item, top.Max.Item) >= 0)
+					continue;
+
+				_ = top.Remove(top.Max);
 				_ = top.Add((item, index));
-				continue;
 			}
 
-			if (comparer.Compare(item, top.Max.Item) >= 0)
-				continue;
-
-			_ = top.Remove(top.Max);
-			_ = top.Add((item, index));
+			foreach (var (item, _) in top)
+				yield return item;
 		}
-
-		foreach (var (item, _) in top)
-			yield return item;
 	}
 
 	/// <summary>

--- a/Tests/SuperLinq.Test/ScanTest.cs
+++ b/Tests/SuperLinq.Test/ScanTest.cs
@@ -38,6 +38,16 @@ public class ScanTest
 	}
 
 	[Fact]
+	public void ScanCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.Scan((a, b) => a + b);
+		Assert.Equal(10_000, result.Count());
+	}
+
+	[Fact]
 	public void SeededScanEmpty()
 	{
 		using var seq = TestingSequence.Of<int>();
@@ -71,5 +81,15 @@ public class ScanTest
 
 		_ = Assert.Throws<TestException>(result.Consume);
 		result.Take(4).AssertSequenceEqual(0, 1, 3, 6);
+	}
+
+	[Fact]
+	public void SeededScanCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.Scan(23, (a, b) => a + b);
+		Assert.Equal(10_001, result.Count());
 	}
 }


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `Scan` operator. 

Fixes #384
