### PR TITLE
`ScanRight`: `ICollection<>` implementation

### DIFF
--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -6,29 +6,29 @@ namespace SuperLinq;
 public partial class SuperEnumerable
 {
 	[ExcludeFromCodeCoverage]
-	private abstract class IteratorCollection<TSource, TResult> : ICollection<TResult>, IReadOnlyCollection<TResult>
+	private abstract class CollectionIterator<T> : ICollection<T>, IReadOnlyCollection<T>
 	{
 		public bool IsReadOnly => true;
-		public void Add(TResult item) =>
+		public void Add(T item) =>
 			throw new NotSupportedException();
-		public bool Remove(TResult item) =>
+		public bool Remove(T item) =>
 			throw new NotSupportedException();
 		public void Clear() =>
 			throw new NotSupportedException();
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-		protected abstract IEnumerable<TResult> GetEnumerable();
+		protected abstract IEnumerable<T> GetEnumerable();
 
 		public abstract int Count { get; }
 
-		public virtual IEnumerator<TResult> GetEnumerator() =>
+		public virtual IEnumerator<T> GetEnumerator() =>
 			GetEnumerable().GetEnumerator();
 
-		public virtual bool Contains(TResult item) =>
+		public virtual bool Contains(T item) =>
 			GetEnumerable().Contains(item);
 
-		public virtual void CopyTo(TResult[] array, int arrayIndex) =>
+		public virtual void CopyTo(T[] array, int arrayIndex) =>
 			GetEnumerable().CopyTo(array, arrayIndex);
 	}
 }

--- a/Source/SuperLinq/Do.cs
+++ b/Source/SuperLinq/Do.cs
@@ -124,7 +124,7 @@ public partial class SuperEnumerable
 	}
 
 
-	private class DoIterator<T> : IteratorCollection<T, T>
+	private class DoIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Action<T> _onNext;

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -122,7 +122,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class FillBackwardCollection<T> : IteratorCollection<T, T>
+	private sealed class FillBackwardCollection<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, bool> _predicate;

--- a/Source/SuperLinq/FillForward.cs
+++ b/Source/SuperLinq/FillForward.cs
@@ -110,7 +110,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class FillForwardCollection<T> : IteratorCollection<T, T>
+	private sealed class FillForwardCollection<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, bool> _predicate;

--- a/Source/SuperLinq/Interleave.cs
+++ b/Source/SuperLinq/Interleave.cs
@@ -82,7 +82,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class InterleaveIterator<T> : IteratorCollection<T, T>
+	private sealed class InterleaveIterator<T> : CollectionIterator<T>
 	{
 		private readonly IEnumerable<ICollection<T>> _sources;
 

--- a/Source/SuperLinq/Rank.cs
+++ b/Source/SuperLinq/Rank.cs
@@ -203,7 +203,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class RankIterator<TSource, TKey> : IteratorCollection<TSource, (TSource, int)>
+	private sealed class RankIterator<TSource, TKey> : CollectionIterator<(TSource, int)>
 	{
 		private readonly ICollection<TSource> _source;
 		private readonly Func<TSource, TKey> _keySelector;

--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -48,7 +48,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class ScanIterator<T> : IteratorCollection<T, T>
+	private class ScanIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, T, T> _transformation;
@@ -132,7 +132,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class ScanStateIterator<TSource, TState> : IteratorCollection<TSource, TState>
+	private class ScanStateIterator<TSource, TState> : CollectionIterator<TState>
 	{
 		private readonly ICollection<TSource> _source;
 		private readonly TState _state;

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -41,7 +41,7 @@ public static partial class SuperEnumerable
 
 	private static IEnumerable<TSource> ScanRightCore<TSource>(IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
 	{
-		var list = source is IList<TSource> l ? l : source.ToList();
+		var list = source.ToList();
 
 		if (list.Count == 0)
 			yield break;
@@ -133,7 +133,7 @@ public static partial class SuperEnumerable
 
 	private static IEnumerable<TAccumulate> ScanRightCore<TSource, TAccumulate>(IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
 	{
-		var list = source is IList<TSource> l ? l : source.ToList();
+		var list = source.ToList();
 		var stack = new Stack<TAccumulate>(list.Count + 1);
 		stack.Push(seed);
 

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -31,27 +33,65 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return Core(source, func);
+		if (source is ICollection<TSource> coll)
+			return new ScanRightIterator<TSource>(coll, func);
 
-		static IEnumerable<TSource> Core(IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
+		return ScanRightCore(source, func);
+	}
+
+	private static IEnumerable<TSource> ScanRightCore<TSource>(IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
+	{
+		var list = source is IList<TSource> l ? l : source.ToList();
+
+		if (list.Count == 0)
+			yield break;
+
+		var seed = list[^1];
+		var stack = new Stack<TSource>(list.Count);
+		stack.Push(seed);
+
+		for (var i = list.Count - 2; i >= 0; i--)
 		{
-			var list = source is IList<TSource> l ? l : source.ToList();
-
-			if (list.Count == 0)
-				yield break;
-
-			var seed = list[^1];
-			var stack = new Stack<TSource>(list.Count);
+			seed = func(list[i], seed);
 			stack.Push(seed);
+		}
 
-			for (var i = list.Count - 2; i >= 0; i--)
+		foreach (var item in stack)
+			yield return item;
+	}
+
+	private class ScanRightIterator<T> : CollectionIterator<T>
+	{
+		private readonly ICollection<T> _source;
+		private readonly Func<T, T, T> _func;
+
+		public ScanRightIterator(ICollection<T> source, Func<T, T, T> func)
+		{
+			_source = source;
+			_func = func;
+		}
+
+		public override int Count => _source.Count;
+
+		[ExcludeFromCodeCoverage]
+		protected override IEnumerable<T> GetEnumerable() =>
+			ScanRightCore(_source, _func);
+
+		public override void CopyTo(T[] array, int arrayIndex)
+		{
+			var (sList, b, cnt) = _source is IList<T> s
+				? (s, 0, s.Count)
+				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));
+
+			var i = cnt - 1;
+			var state = sList[b + i];
+			array[arrayIndex + i] = state;
+
+			for (i--; i >= 0; i--)
 			{
-				seed = func(list[i], seed);
-				stack.Push(seed);
+				state = _func(sList[b + i], state);
+				array[arrayIndex + i] = state;
 			}
-
-			foreach (var item in stack)
-				yield return item;
 		}
 	}
 
@@ -85,22 +125,59 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(func);
 
-		return Core(source, seed, func);
+		if (source is ICollection<TSource> coll)
+			return new ScanRightStateIterator<TSource, TAccumulate>(coll, seed, func);
 
-		static IEnumerable<TAccumulate> Core(IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
+		return ScanRightCore(source, seed, func);
+	}
+
+	private static IEnumerable<TAccumulate> ScanRightCore<TSource, TAccumulate>(IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
+	{
+		var list = source is IList<TSource> l ? l : source.ToList();
+		var stack = new Stack<TAccumulate>(list.Count + 1);
+		stack.Push(seed);
+
+		for (var i = list.Count - 1; i >= 0; i--)
 		{
-			var list = source is IList<TSource> l ? l : source.ToList();
-			var stack = new Stack<TAccumulate>(list.Count + 1);
+			seed = func(list[i], seed);
 			stack.Push(seed);
+		}
+
+		foreach (var item in stack)
+			yield return item;
+	}
+
+	private class ScanRightStateIterator<TSource, TAccumulate> : CollectionIterator<TAccumulate>
+	{
+		private readonly ICollection<TSource> _source;
+		private readonly TAccumulate _seed;
+		private readonly Func<TSource, TAccumulate, TAccumulate> _func;
+
+		public ScanRightStateIterator(ICollection<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
+		{
+			_source = source;
+			_seed = seed;
+			_func = func;
+		}
+
+		public override int Count => _source.Count + 1;
+
+		[ExcludeFromCodeCoverage]
+		protected override IEnumerable<TAccumulate> GetEnumerable() =>
+			ScanRightCore(_source, _seed, _func);
+
+		public override void CopyTo(TAccumulate[] array, int arrayIndex)
+		{
+			var list = _source is IList<TSource> l ? l : _source.ToList();
+
+			var seed = _seed;
+			array[arrayIndex + list.Count] = seed;
 
 			for (var i = list.Count - 1; i >= 0; i--)
 			{
-				seed = func(list[i], seed);
-				stack.Push(seed);
+				seed = _func(list[i], seed);
+				array[arrayIndex + i] = seed;
 			}
-
-			foreach (var item in stack)
-				yield return item;
 		}
 	}
 }

--- a/Tests/SuperLinq.Test/BreakingList.cs
+++ b/Tests/SuperLinq.Test/BreakingList.cs
@@ -1,0 +1,41 @@
+﻿namespace Test;
+
+internal static class BreakingList
+{
+	public static BreakingList<T> AsBreakingList<T>(this IEnumerable<T> source) => new(source);
+}
+
+internal class BreakingList<T> : BreakingSequence<T>, IList<T>, IDisposableEnumerable<T>
+{
+	protected readonly IList<T> List;
+
+	public BreakingList(params T[] values) : this((IList<T>)values) { }
+	public BreakingList(IEnumerable<T> source) => List = source.ToList();
+	public BreakingList(IList<T> list) => List = list;
+
+	public int Count => List.Count;
+
+	public T this[int index]
+	{
+		get => List[index];
+		set => Assert.Fail("LINQ Operators should not be calling this method.");
+	}
+
+	public int IndexOf(T item)
+	{
+		Assert.Fail("LINQ Operators should not be calling this method.");
+		return -1;
+	}
+
+	public void Add(T item) => Assert.Fail("LINQ Operators should not be calling this method.");
+	public void Insert(int index, T item) => Assert.Fail("LINQ Operators should not be calling this method.");
+	public void Clear() => Assert.Fail("LINQ Operators should not be calling this method.");
+	public bool Contains(T item) => List.Contains(item);
+	public bool Remove(T item) { Assert.Fail("LINQ Operators should not be calling this method."); return false; }
+	public void RemoveAt(int index) => Assert.Fail("LINQ Operators should not be calling this method.");
+	public bool IsReadOnly => true;
+
+	public virtual void CopyTo(T[] array, int arrayIndex) => Assert.Fail("LINQ Operators should not be calling this method.");
+
+	public void Dispose() { }
+}

--- a/Tests/SuperLinq.Test/ScanRightTest.cs
+++ b/Tests/SuperLinq.Test/ScanRightTest.cs
@@ -56,6 +56,42 @@ public class ScanRightTest
 		_ = new BreakingSequence<int>().ScanRight(BreakingFunc.Of<int, int, int>());
 	}
 
+	[Fact]
+	public void ScanRightCollection()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
+
+		var result = seq.ScanRight((a, b) => a + b);
+		Assert.Equal(10, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(55, 54, 52, 49, 45, 40, 34, 27, 19, 10);
+		Assert.Equal(1, seq.CopyCount);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 55, 54, 52, 49, 45, 40, 34, 27, 19, 10, 0, 0, 0, 0, 0);
+		Assert.Equal(2, seq.CopyCount);
+	}
+
+	[Fact]
+	public void ScanRightList()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingList();
+
+		var result = seq.ScanRight((a, b) => a + b);
+		Assert.Equal(10, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(55, 54, 52, 49, 45, 40, 34, 27, 19, 10);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 55, 54, 52, 49, 45, 40, 34, 27, 19, 10, 0, 0, 0, 0, 0);
+	}
+
 	// ScanRight(source, seed, func)
 
 	[Theory]
@@ -107,5 +143,41 @@ public class ScanRightTest
 	public void ScanRightSeedIsLazy()
 	{
 		_ = new BreakingSequence<int>().ScanRight(string.Empty, BreakingFunc.Of<int, string, string>());
+	}
+
+	[Fact]
+	public void ScanRightSeedCollection()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
+
+		var result = seq.ScanRight(5, (a, b) => a + b);
+		Assert.Equal(11, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);
+		Assert.Equal(1, seq.CopyCount);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5, 0, 0, 0, 0);
+		Assert.Equal(2, seq.CopyCount);
+	}
+
+	[Fact]
+	public void ScanRightSeedList()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingList();
+
+		var result = seq.ScanRight(5, (a, b) => a + b);
+		Assert.Equal(11, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5, 0, 0, 0, 0);
 	}
 }


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `ScanRight` operator.

Fixes #386 



```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|          Method |               source |     N |           Mean |       Error |      StdDev |    Gen0 |   Gen1 | Allocated |
|---------------- |--------------------- |------ |---------------:|------------:|------------:|--------:|-------:|----------:|
|  ScanRightCount | Syste(...)nt32] [50] | 10000 |       9.686 ns |   0.1100 ns |   0.1029 ns |  0.0025 | 0.0000 |      32 B |
|  ScanRightCount | Syste(...)nt32] [47] | 10000 |      10.246 ns |   0.0946 ns |   0.0885 ns |  0.0025 | 0.0000 |      32 B |
|  ScanRightCount | Syste(...)nt32] [70] | 10000 |  88,253.740 ns | 307.4105 ns | 256.7017 ns |  6.3477 | 0.7324 |   80200 B |
| ScanRightCopyTo | Syste(...)nt32] [50] | 10000 |  38,673.586 ns | 158.7586 ns | 123.9483 ns |  3.1738 | 0.0610 |   40056 B |
| ScanRightCopyTo | Syste(...)nt32] [47] | 10000 |  29,826.876 ns | 206.6878 ns | 183.2234 ns |  3.1738 | 0.0305 |   40056 B |
| ScanRightCopyTo | Syste(...)nt32] [70] | 10000 | 101,039.215 ns | 472.9422 ns | 419.2510 ns | 14.7705 | 1.0986 |  186384 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList().Select(SuperEnumerable.Identity),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToHashSet(),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ScanRightCount(IEnumerable<int> source, int N)
{
	_ = source.ScanRight((a, b) => a + b).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ScanRightCopyTo(IEnumerable<int> source, int N)
{
	_ = source.ScanRight((a, b) => a + b).ToArray();
}

```
</details>