### PR TITLE
Improve `Scan` `ICollection<>` performance

### DIFF
--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -64,6 +64,23 @@ public static partial class SuperEnumerable
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<T> GetEnumerable() =>
 			ScanCore(_source, _transformation);
+
+		public override void CopyTo(T[] array, int arrayIndex)
+		{
+			var (sList, b, cnt) = _source is IList<T> s
+				? (s, 0, s.Count)
+				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));
+
+			var i = 0;
+			var state = sList[b + i];
+			array[arrayIndex + i] = state;
+
+			for (i++; i < cnt; i++)
+			{
+				state = _transformation(state, sList[b + i]);
+				array[arrayIndex + i] = state;
+			}
+		}
 	}
 
 	/// <summary>
@@ -153,6 +170,20 @@ public static partial class SuperEnumerable
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<TState> GetEnumerable() =>
 			ScanCore(_source, _state, _transformation);
+
+		public override void CopyTo(TState[] array, int arrayIndex)
+		{
+			var list = _source is IList<TSource> l ? l : _source.ToList();
+
+			var state = _state;
+			array[arrayIndex] = state;
+
+			for (var i = 0; i < list.Count; i++)
+			{
+				state = _transformation(state, list[i]);
+				array[arrayIndex + i] = state;
+			}
+		}
 	}
 
 	/// <summary>
@@ -173,9 +204,9 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	[Obsolete("Method renamed back to `Scan`.")]
 	public static IEnumerable<TState> ScanEx<TSource, TState>(
-		this IEnumerable<TSource> source,
-		TState seed,
-		Func<TState, TSource, TState> transformation)
+	this IEnumerable<TSource> source,
+	TState seed,
+	Func<TState, TSource, TState> transformation)
 	{
 		return Scan(source, seed, transformation);
 	}

--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -181,7 +181,7 @@ public static partial class SuperEnumerable
 			for (var i = 0; i < list.Count; i++)
 			{
 				state = _transformation(state, list[i]);
-				array[arrayIndex + i] = state;
+				array[arrayIndex + i + 1] = state;
 			}
 		}
 	}

--- a/Tests/SuperLinq.Test/ScanTest.cs
+++ b/Tests/SuperLinq.Test/ScanTest.cs
@@ -38,13 +38,39 @@ public class ScanTest
 	}
 
 	[Fact]
-	public void ScanCount()
+	public void ScanCollection()
 	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
+		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
-		var result = sequence.Scan((a, b) => a + b);
-		Assert.Equal(10_000, result.Count());
+		var result = seq.Scan((a, b) => a + b);
+		Assert.Equal(10, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
+		Assert.Equal(1, seq.CopyCount);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 0, 0, 0, 0, 0);
+		Assert.Equal(2, seq.CopyCount);
+	}
+
+	[Fact]
+	public void ScanList()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingList();
+
+		var result = seq.Scan((a, b) => a + b);
+		Assert.Equal(10, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 0, 0, 0, 0, 0);
 	}
 
 	[Fact]
@@ -84,12 +110,38 @@ public class ScanTest
 	}
 
 	[Fact]
-	public void SeededScanCount()
+	public void SeededScanCollection()
 	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
+		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
-		var result = sequence.Scan(23, (a, b) => a + b);
-		Assert.Equal(10_001, result.Count());
+		var result = seq.Scan(5, (a, b) => a + b);
+		Assert.Equal(11, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);
+		Assert.Equal(1, seq.CopyCount);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60, 0, 0, 0, 0);
+		Assert.Equal(2, seq.CopyCount);
+	}
+
+	[Fact]
+	public void SeededScanList()
+	{
+		using var seq = Enumerable.Range(1, 10).AsBreakingList();
+
+		var result = seq.Scan(5, (a, b) => a + b);
+		Assert.Equal(11, result.Count());
+
+		result.ToArray()
+			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);
+
+		var arr = new int[20];
+		_ = result.CopyTo(arr, 5);
+		arr
+			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60, 0, 0, 0, 0);
 	}
 }


### PR DESCRIPTION
This PR updates the `ICollection<>` implementation of `Scan` to use a `for`-loop during `CopyTo()` to improve performance.

Fixes #384 