### PR TITLE
`ZipMap`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/ListIterator.cs
+++ b/Source/SuperLinq/ListIterator.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
+
+public partial class SuperEnumerable
+{
+	[ExcludeFromCodeCoverage]
+	private abstract class ListIterator<T> : CollectionIterator<T>, IList<T>, IReadOnlyList<T>
+	{
+		public void Insert(int index, T item) =>
+			throw new NotSupportedException();
+		public void RemoveAt(int index) =>
+			throw new NotSupportedException();
+
+		public T this[int index]
+		{
+			get => ElementAt(index);
+			set => throw new NotSupportedException();
+		}
+
+		protected abstract T ElementAt(int index);
+		public virtual int IndexOf(T item) =>
+			GetEnumerable().IndexOf(item);
+	}
+}

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -22,12 +22,46 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(selector);
 
+		if (source is IList<TSource> list)
+			return new ZipMapIterator<TSource, TResult>(list, selector);
+
 		return Core(source, selector);
 
 		static IEnumerable<(TSource, TResult)> Core(IEnumerable<TSource> source, Func<TSource, TResult> selector)
 		{
 			foreach (var item in source)
 				yield return (item, selector(item));
+		}
+	}
+
+	private class ZipMapIterator<TSource, TResult> : ListIterator<(TSource, TResult)>
+	{
+		private readonly IList<TSource> _source;
+		private readonly Func<TSource, TResult> _selector;
+
+		public ZipMapIterator(IList<TSource> source, Func<TSource, TResult> selector)
+		{
+			_source = source;
+			_selector = selector;
+		}
+
+		public override int Count => _source.Count;
+
+		protected override IEnumerable<(TSource, TResult)> GetEnumerable()
+		{
+			var src = _source;
+			var cnt = (uint)src.Count;
+			for (var i = 0; i < cnt; i++)
+			{
+				var el = src[i];
+				yield return (el, _selector(el));
+			}
+		}
+
+		protected override (TSource, TResult) ElementAt(int index)
+		{
+			var el = _source[index];
+			return (el, _selector(el));
 		}
 	}
 }

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -34,7 +34,7 @@ public class AssertCountTest
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/AtLeastTest.cs
+++ b/Tests/SuperLinq.Test/AtLeastTest.cs
@@ -11,7 +11,7 @@ public class AtLeastTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/AtMostTest.cs
+++ b/Tests/SuperLinq.Test/AtMostTest.cs
@@ -11,7 +11,7 @@ public class AtMostTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -19,7 +19,7 @@ public class BatchTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -164,7 +164,7 @@ public class BatchTest
 
 	public static IEnumerable<object[]> GetCollection(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Where(x => x is not TestingSequence<int>)
 			.Select(x => new object[] { x });
 

--- a/Tests/SuperLinq.Test/CountBetweenTest.cs
+++ b/Tests/SuperLinq.Test/CountBetweenTest.cs
@@ -25,7 +25,7 @@ public class CountBetweenTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -38,7 +38,7 @@ public class CountBetweenTest
 
 	public static IEnumerable<object[]> GetTestData(int count, int min, int max, bool expecting) =>
 		Enumerable.Range(1, count)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x, min, max, expecting });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/ExactlyTest.cs
+++ b/Tests/SuperLinq.Test/ExactlyTest.cs
@@ -11,7 +11,7 @@ public class ExactlyTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -12,7 +12,7 @@ public class FillBackwardTest
 
 	public static IEnumerable<object[]> GetIntNullSequences() =>
 		Seq<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -41,7 +41,7 @@ public class FillBackwardTest
 
 	public static IEnumerable<object[]> GetIntSequences() =>
 		Enumerable.Range(1, 13)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/FillForwardTest.cs
+++ b/Tests/SuperLinq.Test/FillForwardTest.cs
@@ -14,7 +14,7 @@ public class FillForwardTest
 
 	public static IEnumerable<object[]> GetIntNullSequences() =>
 		Seq<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -43,7 +43,7 @@ public class FillForwardTest
 
 	public static IEnumerable<object[]> GetIntSequences() =>
 		Enumerable.Range(1, 13)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/MemoizeTest.cs
+++ b/Tests/SuperLinq.Test/MemoizeTest.cs
@@ -14,7 +14,7 @@ public class MemoizeTest
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -65,6 +65,13 @@ internal static partial class TestExtensions
 		yield return new BreakingCollection<T>(input);
 	}
 
+	internal static IEnumerable<IDisposableEnumerable<T>> GetListSequences<T>(this IEnumerable<T> input)
+	{
+		// UI will consume one enumeration
+		yield return input.AsTestingSequence(maxEnumerations: 2);
+		yield return new BreakingList<T>(input);
+	}
+
 	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
 		sourceKind switch
 		{

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -58,7 +58,7 @@ internal static partial class TestExtensions
 	internal static void AssertCollectionEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T>? comparer) =>
 		Assert.True(actual.CollectionEqual(expected, comparer));
 
-	internal static IEnumerable<IDisposableEnumerable<T>> ArrangeCollectionInlineDatas<T>(this IEnumerable<T> input)
+	internal static IEnumerable<IDisposableEnumerable<T>> GetCollectionSequences<T>(this IEnumerable<T> input)
 	{
 		// UI will consume one enumeration
 		yield return input.AsTestingSequence(maxEnumerations: 2);

--- a/Tests/SuperLinq.Test/TrySingleTest.cs
+++ b/Tests/SuperLinq.Test/TrySingleTest.cs
@@ -6,7 +6,7 @@ public class TrySingleTest
 {
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq.Select(x => (int?)x)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -24,7 +24,7 @@ public class TrySingleTest
 
 	public static IEnumerable<object[]> GetSingletonSequences(IEnumerable<int> seq) =>
 		seq.Select(x => (int?)x)
-			.ArrangeCollectionInlineDatas()
+			.GetCollectionSequences()
 			.Where(x => x is not BreakingCollection<int?>)
 			.Select(x => new object[] { x });
 


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `ZipMap`, which reduces memory usage and improves performance.

Fixes #394 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|          Method |               source |     N |          Mean |        Error |     StdDev |    Gen0 |   Gen1 | Allocated |
|---------------- |--------------------- |------ |--------------:|-------------:|-----------:|--------:|-------:|----------:|
|     ZipMapCount | Syste(...)nt32] [47] | 10000 |      12.06 ns |     0.132 ns |   0.123 ns |  0.0025 | 0.0000 |      32 B |
|     ZipMapCount | Syste(...)nt32] [70] | 10000 |  90,405.75 ns |   660.109 ns | 585.170 ns |       - |      - |     144 B |
|    ZipMapCopyTo | Syste(...)nt32] [47] | 10000 |  65,551.56 ns | 1,006.544 ns | 941.522 ns |  6.3477 | 1.0986 |   80112 B |
|    ZipMapCopyTo | Syste(...)nt32] [70] | 10000 | 116,888.09 ns |   617.397 ns | 547.306 ns | 16.7236 | 2.1973 |  211880 B |
| ZipMapElementAt | Syste(...)nt32] [47] | 10000 |      14.57 ns |     0.158 ns |   0.148 ns |  0.0025 | 0.0000 |      32 B |
| ZipMapElementAt | Syste(...)nt32] [70] | 10000 |  70,195.31 ns |   280.730 ns | 262.595 ns |       - |      - |     144 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList().Select(SuperEnumerable.Identity),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipMapCount(IEnumerable<int> source, int N)
{
	_ = source.ZipMap(a => a + 10).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipMapCopyTo(IEnumerable<int> source, int N)
{
	_ = source.ZipMap(a => a + 10).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipMapElementAt(IEnumerable<int> source, int N)
{
	_ = source.ZipMap(a => a + 10).ElementAt(8_000);
}
```
</details>