### PR TITLE
`Pad`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/PadTest.cs
+++ b/Tests/SuperLinq.Test/PadTest.cs
@@ -13,89 +13,199 @@ public class PadTest
 	public void PadIsLazy()
 	{
 		_ = new BreakingSequence<object>().Pad(0);
-	}
-
-	[Fact]
-	public void PadWithFillerIsLazy()
-	{
 		_ = new BreakingSequence<object>().Pad(0, new object());
+		_ = new BreakingSequence<object>().Pad(0, BreakingFunc.Of<int, object>());
 	}
 
 	public class ValueTypeElements
 	{
-		[Fact]
-		public void PadWideSourceSequence()
+		public static IEnumerable<object[]> GetIntSequences() =>
+			Seq(123, 456, 789)
+				.GetListSequences()
+				.Select(x => new object[] { x });
+
+		[Theory]
+		[MemberData(nameof(GetIntSequences))]
+		public void PadWideSourceSequence(IDisposableEnumerable<int> seq)
 		{
-			using var sequence = TestingSequence.Of(123, 456, 789);
-			var result = sequence.Pad(2);
-			result.AssertSequenceEqual(123, 456, 789);
+			using (seq)
+			{
+				var result = seq.Pad(2);
+				result.AssertSequenceEqual(123, 456, 789);
+			}
 		}
 
 		[Fact]
-		public void PadEqualSourceSequence()
+		public void PadWideListBehavior()
 		{
-			using var sequence = TestingSequence.Of(123, 456, 789);
-			var result = sequence.Pad(3);
-			result.AssertSequenceEqual(123, 456, 789);
+			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+			var result = seq.Pad(5_000, x => x % 1_000);
+			Assert.Equal(10_000, result.Count());
+			Assert.Equal(1_200, result.ElementAt(1_200));
+			Assert.Equal(8_800, result.ElementAt(^1_200));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(10_001));
+		}
+
+		[Theory]
+		[MemberData(nameof(GetIntSequences))]
+		public void PadEqualSourceSequence(IDisposableEnumerable<int> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(3);
+				result.AssertSequenceEqual(123, 456, 789);
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetIntSequences))]
+		public void PadNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<int> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(5);
+				result.AssertSequenceEqual(123, 456, 789, 0, 0);
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetIntSequences))]
+		public void PadNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<int> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(5, -1);
+				result.AssertSequenceEqual(123, 456, 789, -1, -1);
+			}
 		}
 
 		[Fact]
-		public void PadNarrowSourceSequenceWithDefaultPadding()
+		public void PadNarrowListBehavior()
 		{
-			using var sequence = TestingSequence.Of(123, 456, 789);
-			var result = sequence.Pad(5);
-			result.AssertSequenceEqual(123, 456, 789, 0, 0);
+			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+			var result = seq.Pad(40_000, x => x % 1_000);
+			Assert.Equal(40_000, result.Count());
+			Assert.Equal(1_200, result.ElementAt(1_200));
+			Assert.Equal(200, result.ElementAt(11_200));
+			Assert.Equal(800, result.ElementAt(^1_200));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(40_001));
 		}
 
-		[Fact]
-		public void PadNarrowSourceSequenceWithNonDefaultPadding()
-		{
-			using var sequence = TestingSequence.Of(123, 456, 789);
-			var result = sequence.Pad(5, -1);
-			result.AssertSequenceEqual(123, 456, 789, -1, -1);
-		}
+		public static IEnumerable<object[]> GetCharSequences() =>
+			"hello"
+				.GetListSequences()
+				.Select(x => new object[] { x });
 
-		[Fact]
-		public void PadNarrowSourceSequenceWithDynamicPadding()
+		[Theory]
+		[MemberData(nameof(GetCharSequences))]
+		public void PadNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<char> seq)
 		{
-			using var sequence = "hello".AsTestingSequence();
-			var result = sequence.Pad(15, i => i % 2 == 0 ? '+' : '-');
-			result.AssertSequenceEqual("hello-+-+-+-+-+".ToCharArray());
+			using (seq)
+			{
+				var result = seq.Pad(15, i => i % 2 == 0 ? '+' : '-');
+				result.AssertSequenceEqual("hello-+-+-+-+-+".ToCharArray());
+			}
 		}
 	}
 
 	public class ReferenceTypeElements
 	{
-		[Fact]
-		public void PadWideSourceSequence()
+		public static IEnumerable<object[]> GetStringSequences() =>
+			Seq("foo", "bar", "baz")
+				.GetListSequences()
+				.Select(x => new object[] { x });
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadWideSourceSequence(IDisposableEnumerable<string> seq)
 		{
-			using var sequence = TestingSequence.Of("foo", "bar", "baz");
-			var result = sequence.Pad(2);
-			result.AssertSequenceEqual("foo", "bar", "baz");
+			using (seq)
+			{
+				var result = seq.Pad(2);
+				result.AssertSequenceEqual("foo", "bar", "baz");
+			}
 		}
 
 		[Fact]
-		public void PadEqualSourceSequence()
+		public void PadWideListBehavior()
 		{
-			using var sequence = TestingSequence.Of("foo", "bar", "baz");
-			var result = sequence.Pad(3);
-			result.AssertSequenceEqual("foo", "bar", "baz");
+			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
+
+			var result = seq.Pad(2, x => $"Extra{x}");
+			Assert.Equal(3, result.Count());
+			Assert.Equal("bar", result.ElementAt(1));
+			Assert.Equal("baz", result.ElementAt(^1));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(3));
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadEqualSourceSequence(IDisposableEnumerable<string> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(3);
+				result.AssertSequenceEqual("foo", "bar", "baz");
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<string> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(5);
+				result.AssertSequenceEqual("foo", "bar", "baz", null, null);
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<string> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(5, string.Empty);
+				result.AssertSequenceEqual("foo", "bar", "baz", string.Empty, string.Empty);
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<string> seq)
+		{
+			using (seq)
+			{
+				var result = seq.Pad(5, x => $"Extra{x}");
+				result.AssertSequenceEqual("foo", "bar", "baz", "Extra3", "Extra4");
+			}
 		}
 
 		[Fact]
-		public void PadNarrowSourceSequenceWithDefaultPadding()
+		public void PadNarrowListBehavior()
 		{
-			using var sequence = TestingSequence.Of("foo", "bar", "baz");
-			var result = sequence.Pad(5);
-			result.AssertSequenceEqual("foo", "bar", "baz", null, null);
-		}
+			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
 
-		[Fact]
-		public void PadNarrowSourceSequenceWithNonDefaultPadding()
-		{
-			using var sequence = TestingSequence.Of("foo", "bar", "baz");
-			var result = sequence.Pad(5, string.Empty);
-			result.AssertSequenceEqual("foo", "bar", "baz", string.Empty, string.Empty);
+			var result = seq.Pad(5, x => $"Extra{x}");
+			Assert.Equal(5, result.Count());
+			Assert.Equal("bar", result.ElementAt(1));
+			Assert.Equal("Extra4", result.ElementAt(^1));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(5));
 		}
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -34,11 +34,7 @@ internal static partial class TestExtensions
 		if (actual is ICollection<T> coll)
 		{
 			Assert.Equal(expected.Length, coll.Count);
-
-			var arr = new T[expected.Length];
-			_ = actual.CopyTo(arr);
-
-			Assert.Equal(expected, arr);
+			Assert.Equal(expected, coll.ToArray());
 		}
 		else
 		{


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `Pad`, which reduces memory usage and improves performance.

Fixes #396 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|       Method |               source |     N |          Mean |      Error |     StdDev |    Gen0 |   Gen1 | Allocated |
|------------- |--------------------- |------ |--------------:|-----------:|-----------:|--------:|-------:|----------:|
|     PadCount | Syste(...)nt32] [47] | 10000 |      14.83 ns |   0.100 ns |   0.093 ns |  0.0102 | 0.0000 |     128 B |
|     PadCount | Syste(...)nt32] [70] | 10000 | 117,821.95 ns | 280.925 ns | 234.585 ns |       - |      - |     240 B |
|    PadCopyTo | Syste(...)nt32] [47] | 10000 |  99,810.15 ns | 363.505 ns | 340.023 ns |  6.3477 | 1.0986 |   80208 B |
|    PadCopyTo | Syste(...)nt32] [70] | 10000 | 159,929.11 ns | 817.435 ns | 764.629 ns | 16.6016 | 4.1504 |  211984 B |
| PadElementAt | Syste(...)nt32] [47] | 10000 |      21.78 ns |   0.119 ns |   0.099 ns |  0.0102 | 0.0000 |     128 B |
| PadElementAt | Syste(...)nt32] [70] | 10000 | 105,916.06 ns | 334.862 ns | 279.625 ns |       - |      - |     240 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList().Select(SuperEnumerable.Identity),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadCount(IEnumerable<int> source, int N)
{
	_ = source.Pad(20_000).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadCopyTo(IEnumerable<int> source, int N)
{
	_ = source.Pad(20_000).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadElementAt(IEnumerable<int> source, int N)
{
	_ = source.Pad(20_000).ElementAt(18_000);
}
```
</details