### PR TITLE
`PadStart`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -145,11 +145,10 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			if (index < _source.Count)
-				return _source[index];
-
 			Guard.IsLessThan(index, Count);
-			return _paddingSelector(index);
+			return index < _source.Count
+				? _source[index]
+				: _paddingSelector(index);
 		}
 	}
 }

--- a/Tests/SuperLinq.Test/BreakingList.cs
+++ b/Tests/SuperLinq.Test/BreakingList.cs
@@ -35,7 +35,7 @@ internal class BreakingList<T> : BreakingSequence<T>, IList<T>, IDisposableEnume
 	public void RemoveAt(int index) => Assert.Fail("LINQ Operators should not be calling this method.");
 	public bool IsReadOnly => true;
 
-	public virtual void CopyTo(T[] array, int arrayIndex) => Assert.Fail("LINQ Operators should not be calling this method.");
+	public virtual void CopyTo(T[] array, int arrayIndex) => List.CopyTo(array, arrayIndex);
 
 	public void Dispose() { }
 }

--- a/Tests/SuperLinq.Test/PadStartTest.cs
+++ b/Tests/SuperLinq.Test/PadStartTest.cs
@@ -19,18 +19,23 @@ public class PadStartTest
 
 	public class ValueTypeElements
 	{
-		public static IEnumerable<object[]> GetIntSequences() =>
-			new LinkedList<int>(Seq(123, 456, 789))
-				.GetListSequencesWithSelf()
-				.Select(x => new object[] { x });
+		public static IEnumerable<object[]> GetIntSequences()
+		{
+			var seq = Seq(123, 456, 789);
+			yield return new object[] { new LinkedList<int>(seq), false, };
+			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
+			yield return new object[] { seq.AsBreakingList(), false, };
+			yield return new object[] { seq.AsBreakingList(), true, };
+		}
 
 		[Theory]
 		[MemberData(nameof(GetIntSequences))]
-		public void PadStartWideSourceSequence(IEnumerable<int> seq)
+		public void PadStartWideSourceSequence(IEnumerable<int> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<int>)
 			{
 				var result = seq.PadStart(2);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(123, 456, 789);
 			}
 		}
@@ -52,33 +57,36 @@ public class PadStartTest
 
 		[Theory]
 		[MemberData(nameof(GetIntSequences))]
-		public void PadStartEqualSourceSequence(IEnumerable<int> seq)
+		public void PadStartEqualSourceSequence(IEnumerable<int> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<int>)
 			{
 				var result = seq.PadStart(3);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(123, 456, 789);
 			}
 		}
 
 		[Theory]
 		[MemberData(nameof(GetIntSequences))]
-		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<int> seq)
+		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<int> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<int>)
 			{
 				var result = seq.PadStart(5);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(0, 0, 123, 456, 789);
 			}
 		}
 
 		[Theory]
 		[MemberData(nameof(GetIntSequences))]
-		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<int> seq)
+		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<int> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<int>)
 			{
 				var result = seq.PadStart(5, -1);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(-1, -1, 123, 456, 789);
 			}
 		}
@@ -99,18 +107,23 @@ public class PadStartTest
 				() => result.ElementAt(40_001));
 		}
 
-		public static IEnumerable<object[]> GetCharSequences() =>
-			new LinkedList<char>("hello")
-				.GetListSequencesWithSelf()
-				.Select(x => new object[] { x });
+		public static IEnumerable<object[]> GetCharSequences()
+		{
+			var seq = "hello".AsEnumerable();
+			yield return new object[] { new LinkedList<char>(seq), false, };
+			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
+			yield return new object[] { seq.AsBreakingList(), false, };
+			yield return new object[] { seq.AsBreakingList(), true, };
+		}
 
 		[Theory]
 		[MemberData(nameof(GetCharSequences))]
-		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<char> seq)
+		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<char> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<char>)
 			{
 				var result = seq.PadStart(15, i => i % 2 == 0 ? '+' : '-');
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual("+-+-+-+-+-hello".ToCharArray());
 			}
 		}
@@ -118,18 +131,23 @@ public class PadStartTest
 
 	public class ReferenceTypeElements
 	{
-		public static IEnumerable<object[]> GetStringSequences() =>
-			new LinkedList<string>(Seq("foo", "bar", "baz"))
-				.GetListSequencesWithSelf()
-				.Select(x => new object[] { x });
+		public static IEnumerable<object[]> GetStringSequences()
+		{
+			var seq = Seq("foo", "bar", "baz");
+			yield return new object[] { new LinkedList<string>(seq), false, };
+			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
+			yield return new object[] { seq.AsBreakingList(), false, };
+			yield return new object[] { seq.AsBreakingList(), true, };
+		}
 
 		[Theory]
 		[MemberData(nameof(GetStringSequences))]
-		public void PadStartWideSourceSequence(IEnumerable<string> seq)
+		public void PadStartWideSourceSequence(IEnumerable<string> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<string>)
 			{
 				var result = seq.PadStart(2);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual("foo", "bar", "baz");
 			}
 		}
@@ -151,44 +169,48 @@ public class PadStartTest
 
 		[Theory]
 		[MemberData(nameof(GetStringSequences))]
-		public void PadStartEqualSourceSequence(IEnumerable<string> seq)
+		public void PadStartEqualSourceSequence(IEnumerable<string> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<string>)
 			{
 				var result = seq.PadStart(3);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual("foo", "bar", "baz");
 			}
 		}
 
 		[Theory]
 		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<string> seq)
+		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<string> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<string>)
 			{
 				var result = seq.PadStart(5);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(default(string), null, "foo", "bar", "baz");
 			}
 		}
 
 		[Theory]
 		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<string> seq)
+		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<string> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<string>)
 			{
 				var result = seq.PadStart(5, string.Empty);
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual(string.Empty, string.Empty, "foo", "bar", "baz");
 			}
 		}
 
 		[Theory]
 		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<string> seq)
+		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<string> seq, bool select)
 		{
 			using (seq as IDisposableEnumerable<string>)
 			{
 				var result = seq.PadStart(5, x => $"Extra{x}");
+				if (select) result = result.Select(SuperEnumerable.Identity);
 				result.AssertSequenceEqual("Extra0", "Extra1", "foo", "bar", "baz");
 			}
 		}

--- a/Tests/SuperLinq.Test/PadStartTest.cs
+++ b/Tests/SuperLinq.Test/PadStartTest.cs
@@ -2,121 +2,210 @@
 
 public class PadStartTest
 {
-	// PadStart(source, width)
-
 	[Fact]
-	public void PadStartWithNegativeWidth()
+	public void PadStartNegativeWidth()
 	{
 		_ = Assert.Throws<ArgumentOutOfRangeException>(() =>
-			Array.Empty<int>().PadStart(-1));
+			new BreakingSequence<object>().PadStart(-1));
 	}
 
 	[Fact]
 	public void PadStartIsLazy()
 	{
-		_ = new BreakingSequence<int>().PadStart(0);
+		_ = new BreakingSequence<object>().PadStart(0);
+		_ = new BreakingSequence<object>().PadStart(0, new object());
+		_ = new BreakingSequence<object>().PadStart(0, BreakingFunc.Of<int, object>());
 	}
 
-	public class PadStartWithDefaultPadding
+	public class ValueTypeElements
 	{
+		public static IEnumerable<object[]> GetIntSequences() =>
+			new LinkedList<int>(Seq(123, 456, 789))
+				.GetListSequencesWithSelf()
+				.Select(x => new object[] { x });
+
 		[Theory]
-		[InlineData(new[] { 123, 456, 789 }, 2, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 3, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 4, new[] { 0, 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 5, new[] { 0, 0, 123, 456, 789 })]
-		public void ValueTypeElements(ICollection<int> source, int width, IEnumerable<int> expected)
+		[MemberData(nameof(GetIntSequences))]
+		public void PadStartWideSourceSequence(IEnumerable<int> seq)
 		{
-			AssertEqual(source, x => x.PadStart(width), expected);
+			using (seq as IDisposableEnumerable<int>)
+			{
+				var result = seq.PadStart(2);
+				result.AssertSequenceEqual(123, 456, 789);
+			}
+		}
+
+		[Fact]
+		public void PadStartWideListBehavior()
+		{
+			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+			var result = seq.PadStart(5_000, x => x % 1_000);
+			Assert.Equal(10_000, result.Count());
+			Assert.Equal(1_200, result.ElementAt(1_200));
+			Assert.Equal(8_800, result.ElementAt(^1_200));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(10_001));
 		}
 
 		[Theory]
-		[InlineData(new[] { "foo", "bar", "baz" }, 2, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 3, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 4, new[] { null, "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 5, new[] { null, null, "foo", "bar", "baz" })]
-		public void ReferenceTypeElements(ICollection<string?> source, int width, IEnumerable<string?> expected)
+		[MemberData(nameof(GetIntSequences))]
+		public void PadStartEqualSourceSequence(IEnumerable<int> seq)
 		{
-			AssertEqual(source, x => x.PadStart(width), expected);
-		}
-	}
-
-	// PadStart(source, width, padding)
-
-	[Fact]
-	public void PadStartWithPaddingWithNegativeWidth()
-	{
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			() => Array.Empty<int>().PadStart(-1, 1));
-	}
-
-	[Fact]
-	public void PadStartWithPaddingIsLazy()
-	{
-		_ = new BreakingSequence<int>().PadStart(0, -1);
-	}
-
-	public class PadStartWithPadding
-	{
-		[Theory]
-		[InlineData(new[] { 123, 456, 789 }, 2, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 3, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 4, new[] { -1, 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 5, new[] { -1, -1, 123, 456, 789 })]
-		public void ValueTypeElements(ICollection<int> source, int width, IEnumerable<int> expected)
-		{
-			AssertEqual(source, x => x.PadStart(width, -1), expected);
+			using (seq as IDisposableEnumerable<int>)
+			{
+				var result = seq.PadStart(3);
+				result.AssertSequenceEqual(123, 456, 789);
+			}
 		}
 
 		[Theory]
-		[InlineData(new[] { "foo", "bar", "baz" }, 2, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 3, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 4, new[] { "", "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 5, new[] { "", "", "foo", "bar", "baz" })]
-		public void ReferenceTypeElements(ICollection<string> source, int width, IEnumerable<string> expected)
+		[MemberData(nameof(GetIntSequences))]
+		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<int> seq)
 		{
-			AssertEqual(source, x => x.PadStart(width, string.Empty), expected);
-		}
-	}
-
-	// PadStart(source, width, paddingSelector)
-
-	[Fact]
-	public void PadStartWithSelectorWithNegativeWidth()
-	{
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			() => Array.Empty<int>().PadStart(-1, SuperEnumerable.Identity));
-	}
-
-	[Fact]
-	public void PadStartWithSelectorIsLazy()
-	{
-		_ = new BreakingSequence<int>().PadStart(0, BreakingFunc.Of<int, int>());
-	}
-
-	public class PadStartWithSelector
-	{
-		[Theory]
-		[InlineData(new[] { 123, 456, 789 }, 2, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 3, new[] { 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 4, new[] { 0, 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 5, new[] { 0, -1, 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 6, new[] { 0, -1, -4, 123, 456, 789 })]
-		[InlineData(new[] { 123, 456, 789 }, 7, new[] { 0, -1, -4, -9, 123, 456, 789 })]
-		public void ValueTypeElements(ICollection<int> source, int width, IEnumerable<int> expected)
-		{
-			AssertEqual(source, x => x.PadStart(width, y => y * -y), expected);
+			using (seq as IDisposableEnumerable<int>)
+			{
+				var result = seq.PadStart(5);
+				result.AssertSequenceEqual(0, 0, 123, 456, 789);
+			}
 		}
 
 		[Theory]
-		[InlineData(new[] { "foo", "bar", "baz" }, 2, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 3, new[] { "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 4, new[] { "+", "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 5, new[] { "+", "++", "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 6, new[] { "+", "++", "+++", "foo", "bar", "baz" })]
-		[InlineData(new[] { "foo", "bar", "baz" }, 7, new[] { "+", "++", "+++", "++++", "foo", "bar", "baz" })]
-		public void ReferenceTypeElements(ICollection<string> source, int width, IEnumerable<string> expected)
+		[MemberData(nameof(GetIntSequences))]
+		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<int> seq)
 		{
-			AssertEqual(source, x => x.PadStart(width, y => new string('+', y + 1)), expected);
+			using (seq as IDisposableEnumerable<int>)
+			{
+				var result = seq.PadStart(5, -1);
+				result.AssertSequenceEqual(-1, -1, 123, 456, 789);
+			}
+		}
+
+		[Fact]
+		public void PadStartNarrowListBehavior()
+		{
+			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+			var result = seq.PadStart(40_000, x => x % 1_000);
+			Assert.Equal(40_000, result.Count());
+			Assert.Equal(200, result.ElementAt(1_200));
+			Assert.Equal(1_200, result.ElementAt(31_200));
+			Assert.Equal(8_800, result.ElementAt(^1_200));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(40_001));
+		}
+
+		public static IEnumerable<object[]> GetCharSequences() =>
+			new LinkedList<char>("hello")
+				.GetListSequencesWithSelf()
+				.Select(x => new object[] { x });
+
+		[Theory]
+		[MemberData(nameof(GetCharSequences))]
+		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<char> seq)
+		{
+			using (seq as IDisposableEnumerable<char>)
+			{
+				var result = seq.PadStart(15, i => i % 2 == 0 ? '+' : '-');
+				result.AssertSequenceEqual("+-+-+-+-+-hello".ToCharArray());
+			}
+		}
+	}
+
+	public class ReferenceTypeElements
+	{
+		public static IEnumerable<object[]> GetStringSequences() =>
+			new LinkedList<string>(Seq("foo", "bar", "baz"))
+				.GetListSequencesWithSelf()
+				.Select(x => new object[] { x });
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadStartWideSourceSequence(IEnumerable<string> seq)
+		{
+			using (seq as IDisposableEnumerable<string>)
+			{
+				var result = seq.PadStart(2);
+				result.AssertSequenceEqual("foo", "bar", "baz");
+			}
+		}
+
+		[Fact]
+		public void PadStartWideListBehavior()
+		{
+			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
+
+			var result = seq.PadStart(2, x => $"Extra{x}");
+			Assert.Equal(3, result.Count());
+			Assert.Equal("bar", result.ElementAt(1));
+			Assert.Equal("baz", result.ElementAt(^1));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(3));
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadStartEqualSourceSequence(IEnumerable<string> seq)
+		{
+			using (seq as IDisposableEnumerable<string>)
+			{
+				var result = seq.PadStart(3);
+				result.AssertSequenceEqual("foo", "bar", "baz");
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<string> seq)
+		{
+			using (seq as IDisposableEnumerable<string>)
+			{
+				var result = seq.PadStart(5);
+				result.AssertSequenceEqual(default(string), null, "foo", "bar", "baz");
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<string> seq)
+		{
+			using (seq as IDisposableEnumerable<string>)
+			{
+				var result = seq.PadStart(5, string.Empty);
+				result.AssertSequenceEqual(string.Empty, string.Empty, "foo", "bar", "baz");
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(GetStringSequences))]
+		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<string> seq)
+		{
+			using (seq as IDisposableEnumerable<string>)
+			{
+				var result = seq.PadStart(5, x => $"Extra{x}");
+				result.AssertSequenceEqual("Extra0", "Extra1", "foo", "bar", "baz");
+			}
+		}
+
+		[Fact]
+		public void PadStartNarrowListBehavior()
+		{
+			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
+
+			var result = seq.PadStart(5, x => $"Extra{x}");
+			Assert.Equal(5, result.Count());
+			Assert.Equal("Extra1", result.ElementAt(1));
+			Assert.Equal("baz", result.ElementAt(^1));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(5));
 		}
 	}
 
@@ -128,16 +217,5 @@ public class PadStartTest
 		result.AssertSequenceEqual(-1, -1, 1, 2, 3);
 		queue.Enqueue(4);
 		result.AssertSequenceEqual(-1, 1, 2, 3, 4);
-	}
-
-	private static void AssertEqual<T>(ICollection<T> input, Func<IEnumerable<T>, IEnumerable<T>> op, IEnumerable<T> expected)
-	{
-		// Test that the behaviour does not change whether a collection
-		// or a sequence is used as the source.
-
-		op(input).AssertSequenceEqual(expected);
-
-		using var xs = input.AsTestingSequence();
-		op(xs).AssertSequenceEqual(expected);
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -68,6 +68,14 @@ internal static partial class TestExtensions
 		yield return new BreakingList<T>(input);
 	}
 
+	internal static IEnumerable<IEnumerable<T>> GetListSequencesWithSelf<T>(this ICollection<T> input)
+	{
+		// UI will consume one enumeration
+		yield return input;
+		yield return input.AsTestingSequence(maxEnumerations: 2);
+		yield return new BreakingList<T>(input);
+	}
+
 	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
 		sourceKind switch
 		{

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -68,14 +68,6 @@ internal static partial class TestExtensions
 		yield return new BreakingList<T>(input);
 	}
 
-	internal static IEnumerable<IEnumerable<T>> GetListSequencesWithSelf<T>(this ICollection<T> input)
-	{
-		// UI will consume one enumeration
-		yield return input;
-		yield return input.AsTestingSequence(maxEnumerations: 2);
-		yield return new BreakingList<T>(input);
-	}
-
 	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
 		sourceKind switch
 		{


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `PadStart`, which reduces memory usage and improves performance.

Fixes #400 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|            Method |               source |     N |          Mean |        Error |       StdDev |    Gen0 |   Gen1 | Allocated |
|------------------ |--------------------- |------ |--------------:|-------------:|-------------:|--------:|-------:|----------:|
|     PadStartCount | Syste(...)nt32] [47] | 10000 |      15.38 ns |     0.127 ns |     0.106 ns |  0.0102 | 0.0000 |     128 B |
|     PadStartCount | Syste(...)nt32] [53] | 10000 | 138,451.90 ns |   496.296 ns |   439.953 ns |       - |      - |     240 B |
|     PadStartCount | Syste(...)nt32] [62] | 10000 | 145,656.51 ns |   737.074 ns |   689.460 ns |  6.3477 | 1.2207 |   80312 B |
|    PadStartCopyTo | Syste(...)nt32] [47] | 10000 |  16,386.90 ns |    94.944 ns |    88.811 ns |  6.3477 | 0.0305 |   80152 B |
|    PadStartCopyTo | Syste(...)nt32] [53] | 10000 | 178,593.94 ns | 1,236.853 ns | 1,156.953 ns | 16.6016 | 4.1504 |  211984 B |
|    PadStartCopyTo | Syste(...)nt32] [62] | 10000 | 183,011.02 ns |   962.035 ns |   751.093 ns | 23.1934 | 5.8594 |  292056 B |
| PadStartElementAt | Syste(...)nt32] [47] | 10000 |      21.14 ns |     0.154 ns |     0.144 ns |  0.0102 | 0.0000 |     128 B |
| PadStartElementAt | Syste(...)nt32] [53] | 10000 | 111,413.92 ns |   220.316 ns |   183.974 ns |       - |      - |     240 B |
| PadStartElementAt | Syste(...)nt32] [62] | 10000 | 131,518.00 ns |   963.744 ns |   854.334 ns |  6.3477 | 1.4648 |   80312 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			new LinkedList<int>(Enumerable.Range(1, i)),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadStartCount(IEnumerable<int> source, int N)
{
	_ = source.PadStart(20_000).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadStartCopyTo(IEnumerable<int> source, int N)
{
	_ = source.PadStart(20_000).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void PadStartElementAt(IEnumerable<int> source, int N)
{
	_ = source.PadStart(20_000).ElementAt(18_000);
}
```
</details>
