### PR TITLE
`Lag`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/LagTest.cs
+++ b/Tests/SuperLinq.Test/LagTest.cs
@@ -149,4 +149,15 @@ public class LagTests
 				new { A = "qux", B = "bar" });
 		}
 	}
+
+	[Fact]
+	public void ZipMapListBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.Lag(20);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((50, 30), result.ElementAt(50));
+		Assert.Equal((9_950, 9_930), result.ElementAt(^50));
+	}
 }

--- a/Tests/SuperLinq.Test/LagTest.cs
+++ b/Tests/SuperLinq.Test/LagTest.cs
@@ -157,6 +157,7 @@ public class LagTests
 
 		var result = seq.Lag(20);
 		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 0), result.ElementAt(10));
 		Assert.Equal((50, 30), result.ElementAt(50));
 		Assert.Equal((9_950, 9_930), result.ElementAt(^50));
 	}

--- a/Tests/SuperLinq.Test/LagTest.cs
+++ b/Tests/SuperLinq.Test/LagTest.cs
@@ -35,108 +35,118 @@ public class LagTests
 			new BreakingSequence<int>().Lag(0, (val, lagVal) => val + lagVal));
 	}
 
-	/// <summary>
-	/// Verify that lag can accept an propagate a default value passed to it.
-	/// </summary>
-	[Fact]
-	public void TestLagExplicitDefaultValue()
-	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
+	public static IEnumerable<object[]> GetIntSequences() =>
+		Enumerable.Range(1, 100)
+			.GetListSequences()
+			.Select(x => new object[] { x });
 
-		var result = sequence.Lag(10, -1, (val, lagVal) => lagVal).ToList();
-		Assert.Equal(100, result.Count);
-		Assert.Equal(Enumerable.Repeat(-1, 10), result.Take(10));
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagExplicitDefaultValue(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Lag(10, -1, (val, lagVal) => lagVal);
+			result.AssertSequenceEqual(
+				Enumerable.Repeat(-1, 10).Concat(Enumerable.Range(1, 90)));
+		}
 	}
 
-	[Fact]
-	public void TestLagTuple()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagTuple(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
-
-		var result = sequence.Lag(10).ToList();
-		Assert.Equal(100, result.Count);
-		result.AssertSequenceEqual(
-			Enumerable.Range(1, 100).Select(x => (x, x <= 10 ? default : x - 10)));
+		using (seq)
+		{
+			var result = seq.Lag(10);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 100).Select(x => (x, x <= 10 ? default : x - 10)));
+		}
 	}
 
-	/// <summary>
-	/// Verify that lag will use default(T) if a specific default value is not supplied for the lag value.
-	/// </summary>
-	[Fact]
-	public void TestLagImplicitDefaultValue()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagImplicitDefaultValue(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
-
-		var result = sequence.Lag(10, (val, lagVal) => lagVal).ToList();
-		Assert.Equal(100, result.Count);
-		Assert.Equal(Enumerable.Repeat(default(int), 10), result.Take(10));
+		using (seq)
+		{
+			var result = seq.Lag(10, (val, lagVal) => lagVal);
+			result.AssertSequenceEqual(
+				Enumerable.Repeat(default(int), 10)
+					.Concat(Enumerable.Range(1, 90)));
+		}
 	}
 
-	/// <summary>
-	/// Verify that if the lag offset is greater than the sequence length lag
-	/// still yields all of the elements of the source sequence.
-	/// </summary>
-	[Fact]
-	public void TestLagOffsetGreaterThanSequenceLength()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagOffsetGreaterThanSequenceLength(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
-
-		var result = sequence.Lag(100 + 1, (a, b) => a).ToList();
-		Assert.Equal(100, result.Count);
-		Assert.Equal(Enumerable.Range(1, 100), result);
+		using (seq)
+		{
+			var result = seq.Lag(100 + 1, (a, b) => a);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 100));
+		}
 	}
 
-	/// <summary>
-	/// Verify that lag actually yields the correct pair of values from the sequence
-	/// when offsetting by a single item.
-	/// </summary>
-	[Fact]
-	public void TestLagPassesCorrectLagValueOffsetBy1()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagPassesCorrectLagValueOffsetBy1(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
-
-		var result = sequence.Lag(1, (a, b) => new { A = a, B = b }).ToList();
-		Assert.Equal(100, result.Count);
-		Assert.True(result.All(x => x.B == (x.A - 1)));
+		using (seq)
+		{
+			var result = seq.Lag(1);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 100)
+					.Select(x => (x, x - 1)));
+		}
 	}
 
-	/// <summary>
-	/// Verify that lag yields the correct pair of values from the sequence when
-	/// offsetting by more than a single item.
-	/// </summary>
-	[Fact]
-	public void TestLagPassesCorrectLagValuesOffsetBy2()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void TestLagPassesCorrectLagValuesOffsetBy2(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(1, 100).AsTestingSequence();
-
-		var result = sequence.Lag(2, (a, b) => new { A = a, B = b }).ToList();
-		Assert.Equal(100, result.Count);
-		Assert.True(result.Skip(2).All(x => x.B == (x.A - 2)));
-		Assert.True(result.Take(2).All(x => (x.A - x.B) == x.A));
+		using (seq)
+		{
+			var result = seq.Lag(2);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 100)
+					.Select(x => (x, x <= 2 ? 0 : x - 2)));
+		}
 	}
 
-	[Fact]
-	public void TestLagWithNullableReferences()
+	public static IEnumerable<object[]> GetStringSequences() =>
+		Seq("foo", "bar", "baz", "qux")
+			.GetListSequences()
+			.Select(x => new object[] { x, });
+
+	[Theory]
+	[MemberData(nameof(GetStringSequences))]
+	public void TestLagWithNullableReferences(IDisposableEnumerable<string> seq)
 	{
-		using var words = TestingSequence.Of("foo", "bar", "baz", "qux");
-		var result = words.Lag(2, (a, b) => new { A = a, B = b });
-		result.AssertSequenceEqual(
-			new { A = "foo", B = (string?)null },
-			new { A = "bar", B = (string?)null },
-			new { A = "baz", B = (string?)"foo" },
-			new { A = "qux", B = (string?)"bar" });
+		using (seq)
+		{
+			var result = seq.Lag(2, (a, b) => new { A = a, B = b });
+			result.AssertSequenceEqual(
+				new { A = "foo", B = (string?)null },
+				new { A = "bar", B = (string?)null },
+				new { A = "baz", B = (string?)"foo" },
+				new { A = "qux", B = (string?)"bar" });
+		}
 	}
 
-	[Fact]
-	public void TestLagWithNonNullableReferences()
+	[Theory]
+	[MemberData(nameof(GetStringSequences))]
+	public void TestLagWithNonNullableReferences(IDisposableEnumerable<string> seq)
 	{
-		using var words = TestingSequence.Of("foo", "bar", "baz", "qux");
-		var empty = string.Empty;
-		var result = words.Lag(2, empty, (a, b) => new { A = a, B = b });
-		result.AssertSequenceEqual(
-			new { A = "foo", B = empty },
-			new { A = "bar", B = empty },
-			new { A = "baz", B = "foo" },
-			new { A = "qux", B = "bar" });
+		using (seq)
+		{
+			var result = seq.Lag(2, string.Empty, (a, b) => new { A = a, B = b });
+			result.AssertSequenceEqual(
+				new { A = "foo", B = string.Empty, },
+				new { A = "bar", B = string.Empty, },
+				new { A = "baz", B = "foo" },
+				new { A = "qux", B = "bar" });
+		}
 	}
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `Lag`, which reduces memory usage and improves performance.

Fixes #403 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|       Method |               source |     N |           Mean |         Error |        StdDev |    Gen0 |   Gen1 | Allocated |
|------------- |--------------------- |------ |---------------:|--------------:|--------------:|--------:|-------:|----------:|
|     LagCount | Syste(...)nt32] [47] | 10000 |       9.776 ns |     0.1670 ns |     0.1394 ns |  0.0032 | 0.0000 |      40 B |
|     LagCount | Syste(...)nt32] [62] | 10000 | 127,925.439 ns |   925.8349 ns |   773.1141 ns |       - |      - |     464 B |
|    LagCopyTo | Syste(...)nt32] [47] | 10000 |  84,319.089 ns |   448.5254 ns |   419.5509 ns |  6.3477 | 1.0986 |   80112 B |
|    LagCopyTo | Syste(...)nt32] [62] | 10000 | 159,364.525 ns | 3,112.8400 ns | 3,057.2251 ns | 16.8457 | 2.9297 |  212200 B |
| LagElementAt | Syste(...)nt32] [47] | 10000 |      16.877 ns |     0.0723 ns |     0.0641 ns |  0.0032 | 0.0000 |      40 B |
| LagElementAt | Syste(...)nt32] [62] | 10000 | 101,622.887 ns |   906.5200 ns |   847.9594 ns |       - |      - |     464 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LagCount(IEnumerable<int> source, int N)
{
	_ = source.Lag(50).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LagCopyTo(IEnumerable<int> source, int N)
{
	_ = source.Lag(50).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LagElementAt(IEnumerable<int> source, int N)
{
	_ = source.Lag(50).ElementAt(8_000);
}
```
</details>