### PR TITLE
`Lead`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -18,6 +18,4 @@ public static partial class SuperEnumerable
 			_ => null
 		};
 #endif
-
-	internal static (bool HasValue, T Value) Some<T>(T value) => (true, value);
 }

--- a/Tests/SuperLinq.Test/LagTest.cs
+++ b/Tests/SuperLinq.Test/LagTest.cs
@@ -83,9 +83,9 @@ public class LagTests
 	{
 		using (seq)
 		{
-			var result = seq.Lag(100 + 1, (a, b) => a);
+			var result = seq.Lag(100 + 1, -1, ValueTuple.Create);
 			result.AssertSequenceEqual(
-				Enumerable.Range(1, 100));
+				Enumerable.Range(1, 100).Select(x => (x, -1)));
 		}
 	}
 
@@ -151,7 +151,7 @@ public class LagTests
 	}
 
 	[Fact]
-	public void ZipMapListBehavior()
+	public void LagListBehavior()
 	{
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `Lead`, which reduces memory usage and improves performance.


Fixes #405 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|        Method |               source |     N |          Mean |      Error |     StdDev |    Gen0 |   Gen1 | Allocated |
|-------------- |--------------------- |------ |--------------:|-----------:|-----------:|--------:|-------:|----------:|
|     LeadCount | Syste(...)nt32] [47] | 10000 |      11.11 ns |   0.101 ns |   0.090 ns |  0.0032 | 0.0000 |      40 B |
|     LeadCount | Syste(...)nt32] [62] | 10000 | 130,990.59 ns | 679.288 ns | 635.406 ns |       - |      - |     464 B |
|    LeadCopyTo | Syste(...)nt32] [47] | 10000 |  82,063.31 ns | 416.850 ns | 389.922 ns |  6.3477 | 1.0986 |   80120 B |
|    LeadCopyTo | Syste(...)nt32] [62] | 10000 | 150,546.04 ns | 845.796 ns | 791.158 ns | 16.8457 | 2.9297 |  212200 B |
| LeadElementAt | Syste(...)nt32] [47] | 10000 |      18.10 ns |   0.381 ns |   0.509 ns |  0.0032 | 0.0000 |      40 B |
| LeadElementAt | Syste(...)nt32] [62] | 10000 | 101,688.96 ns | 928.388 ns | 822.991 ns |       - |      - |     464 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LeadCount(IEnumerable<int> source, int N)
{
	_ = source.Lead(50).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LeadCopyTo(IEnumerable<int> source, int N)
{
	_ = source.Lead(50).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void LeadElementAt(IEnumerable<int> source, int N)
{
	_ = source.Lead(50).ElementAt(8_000);
}
```
</details>