### PR TITLE
`TagFirstLast`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/TagFirstLastTest.cs
+++ b/Tests/SuperLinq.Test/TagFirstLastTest.cs
@@ -9,44 +9,35 @@ public class TagFirstLastTest
 		_ = new BreakingSequence<object>().TagFirstLast(BreakingFunc.Of<object, bool, bool, object>());
 	}
 
-	[Fact]
-	public void TagFirstLastEmptySequence()
-	{
-		using var sequence = TestingSequence.Of<int>();
+	public static IEnumerable<object[]> GetSourceSequences() =>
+		Enumerable.Range(0, 4)
+			.SelectMany(n =>
+				Enumerable.Range(0, n)
+					.GetListSequences()
+					.Select(x => new object[] { x, n }));
 
-		var result = sequence.TagFirstLast();
-		result.AssertSequenceEqual();
+	[Theory]
+	[MemberData(nameof(GetSourceSequences))]
+	public void TagFirstLastVaryingLengths(IDisposableEnumerable<int> seq, int n)
+	{
+		using (seq)
+		{
+			var result = seq.TagFirstLast();
+			result.AssertSequenceEqual(
+				Enumerable.Range(0, n)
+					.Select(x => (x, x == 0, x == n - 1)));
+		}
 	}
 
 	[Fact]
-	public void TagFirstLastWithSourceSequenceOfOne()
+	public void TagFirstLastListBehavior()
 	{
-		using var sequence = TestingSequence.Of(123);
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		var result = sequence.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
-		result.AssertSequenceEqual(new { Item = 123, IsFirst = true, IsLast = true });
-	}
-
-	[Fact]
-	public void TagFirstLastWithSourceSequenceOfTwo()
-	{
-		using var sequence = TestingSequence.Of(123, 456);
-
-		var result = sequence.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
-		result.AssertSequenceEqual(
-			new { Item = 123, IsFirst = true, IsLast = false },
-			new { Item = 456, IsFirst = false, IsLast = true });
-	}
-
-	[Fact]
-	public void TagFirstLastWithSourceSequenceOfThree()
-	{
-		using var sequence = TestingSequence.Of(123, 456, 789);
-
-		var result = sequence.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
-		result.AssertSequenceEqual(
-			new { Item = 123, IsFirst = true, IsLast = false },
-			new { Item = 456, IsFirst = false, IsLast = false },
-			new { Item = 789, IsFirst = false, IsLast = true });
+		var result = seq.TagFirstLast();
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((0, true, false), result.ElementAt(0));
+		Assert.Equal((30, false, false), result.ElementAt(30));
+		Assert.Equal((9_999, false, true), result.ElementAt(^1));
 	}
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `TagFirstLast`, which reduces memory usage and improves performance.

Fixes #407 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|                Method |               source |     N |          Mean |      Error |     StdDev |    Gen0 |   Gen1 | Allocated |
|---------------------- |--------------------- |------ |--------------:|-----------:|-----------:|--------:|-------:|----------:|
|     TagFirstLastCount | Syste(...)nt32] [47] | 10000 |      10.04 ns |   0.092 ns |   0.086 ns |  0.0025 | 0.0000 |      32 B |
|     TagFirstLastCount | Syste(...)nt32] [62] | 10000 | 107,083.41 ns | 252.544 ns | 223.874 ns |       - |      - |     168 B |
|    TagFirstLastCopyTo | Syste(...)nt32] [47] | 10000 |  78,637.78 ns | 646.245 ns | 604.498 ns |  6.3477 | 1.0986 |   80104 B |
|    TagFirstLastCopyTo | Syste(...)nt32] [62] | 10000 | 132,709.80 ns | 836.973 ns | 782.906 ns | 16.6016 | 2.1973 |  211904 B |
| TagFirstLastElementAt | Syste(...)nt32] [47] | 10000 |      18.74 ns |   0.122 ns |   0.115 ns |  0.0025 | 0.0000 |      32 B |
| TagFirstLastElementAt | Syste(...)nt32] [62] | 10000 |  84,293.48 ns | 353.597 ns | 330.755 ns |       - |      - |     168 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void TagFirstLastCount(IEnumerable<int> source, int N)
{
	_ = source.TagFirstLast().Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void TagFirstLastCopyTo(IEnumerable<int> source, int N)
{
	_ = source.TagFirstLast().ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void TagFirstLastElementAt(IEnumerable<int> source, int N)
{
	_ = source.TagFirstLast().ElementAt(8_000);
}

```
</details>