### PR TITLE
`CollectionIterator` improvements

### DIFF
--- a/Source/SuperLinq/Do.cs
+++ b/Source/SuperLinq/Do.cs
@@ -124,7 +124,7 @@ public partial class SuperEnumerable
 	}
 
 
-	private class DoIterator<T> : CollectionIterator<T>
+	private sealed class DoIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Action<T> _onNext;

--- a/Source/SuperLinq/Do.cs
+++ b/Source/SuperLinq/Do.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public partial class SuperEnumerable
 {
@@ -94,8 +96,8 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(onError);
 		Guard.IsNotNull(onCompleted);
 
-		if (source is ICollection<TSource> coll)
-			return new DoIterator<TSource>(coll, onNext, onError, onCompleted);
+		if (source.TryGetCollectionCount() != null)
+			return new DoIterator<TSource>(source, onNext, onError, onCompleted);
 
 		return DoCore(source, onNext, onError, onCompleted);
 	}
@@ -126,12 +128,12 @@ public partial class SuperEnumerable
 
 	private sealed class DoIterator<T> : CollectionIterator<T>
 	{
-		private readonly ICollection<T> _source;
+		private readonly IEnumerable<T> _source;
 		private readonly Action<T> _onNext;
 		private readonly Action<Exception>? _onError;
 		private readonly Action _onCompleted;
 
-		public DoIterator(ICollection<T> source, Action<T> onNext, Action<Exception>? onError, Action onCompleted)
+		public DoIterator(IEnumerable<T> source, Action<T> onNext, Action<Exception>? onError, Action onCompleted)
 		{
 			_source = source;
 			_onNext = onNext;
@@ -139,8 +141,9 @@ public partial class SuperEnumerable
 			_onCompleted = onCompleted;
 		}
 
-		public override int Count => _source.Count;
+		public override int Count => _source.GetCollectionCount();
 
+		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<T> GetEnumerable() =>
 			_onError != null
 			? DoCore(_source, _onNext, _onError, _onCompleted)

--- a/Source/SuperLinq/PreScan.cs
+++ b/Source/SuperLinq/PreScan.cs
@@ -72,7 +72,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class PreScanIterator<T> : CollectionIterator<T>
+	private sealed class PreScanIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, T, T> _transformation;

--- a/Source/SuperLinq/Rank.cs
+++ b/Source/SuperLinq/Rank.cs
@@ -166,8 +166,8 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		if (source is ICollection<TSource> coll)
-			return new RankIterator<TSource, TKey>(coll, keySelector, comparer, isDense: false);
+		if (source.TryGetCollectionCount() != null)
+			return new RankIterator<TSource, TKey>(source, keySelector, comparer, isDense: false);
 
 		return RankByCore(source, keySelector, comparer, isDense: false);
 	}
@@ -205,12 +205,12 @@ public static partial class SuperEnumerable
 
 	private sealed class RankIterator<TSource, TKey> : CollectionIterator<(TSource, int)>
 	{
-		private readonly ICollection<TSource> _source;
+		private readonly IEnumerable<TSource> _source;
 		private readonly Func<TSource, TKey> _keySelector;
 		private readonly IComparer<TKey>? _comparer;
 		private readonly bool _isDense;
 
-		public RankIterator(ICollection<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer, bool isDense)
+		public RankIterator(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer, bool isDense)
 		{
 			_source = source;
 			_keySelector = keySelector;
@@ -218,7 +218,7 @@ public static partial class SuperEnumerable
 			_isDense = isDense;
 		}
 
-		public override int Count => _source.Count;
+		public override int Count => _source.GetCollectionCount();
 
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<(TSource, int)> GetEnumerable() =>

--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -48,7 +48,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class ScanIterator<T> : CollectionIterator<T>
+	private sealed class ScanIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, T, T> _transformation;
@@ -149,7 +149,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class ScanStateIterator<TSource, TState> : CollectionIterator<TState>
+	private sealed class ScanStateIterator<TSource, TState> : CollectionIterator<TState>
 	{
 		private readonly ICollection<TSource> _source;
 		private readonly TState _state;

--- a/Source/SuperLinq/ScanBy.cs
+++ b/Source/SuperLinq/ScanBy.cs
@@ -75,9 +75,11 @@ public static partial class SuperEnumerable
 
 		comparer ??= EqualityComparer<TKey>.Default;
 
-		if (source is ICollection<TSource> coll)
+		if (source.TryGetCollectionCount() != null)
+		{
 			return new ScanByIterator<TSource, TKey, TState>(
-				coll, keySelector, seedSelector, accumulator, comparer);
+				source, keySelector, seedSelector, accumulator, comparer);
+		}
 
 		return ScanByCore(source, keySelector, seedSelector, accumulator, comparer);
 	}
@@ -109,14 +111,14 @@ public static partial class SuperEnumerable
 
 	private sealed class ScanByIterator<TSource, TKey, TState> : CollectionIterator<(TKey key, TState state)>
 	{
-		private readonly ICollection<TSource> _source;
+		private readonly IEnumerable<TSource> _source;
 		private readonly Func<TSource, TKey> _keySelector;
 		private readonly Func<TKey, TState> _seedSelector;
 		private readonly Func<TState, TKey, TSource, TState> _accumulator;
 		private readonly IEqualityComparer<TKey> _comparer;
 
 		public ScanByIterator(
-			ICollection<TSource> source,
+			IEnumerable<TSource> source,
 			Func<TSource, TKey> keySelector,
 			Func<TKey, TState> seedSelector,
 			Func<TState, TKey, TSource, TState> accumulator,
@@ -129,7 +131,7 @@ public static partial class SuperEnumerable
 			_comparer = comparer;
 		}
 
-		public override int Count => _source.Count;
+		public override int Count => _source.GetCollectionCount();
 
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<(TKey key, TState state)> GetEnumerable() =>

--- a/Source/SuperLinq/ScanBy.cs
+++ b/Source/SuperLinq/ScanBy.cs
@@ -107,7 +107,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class ScanByIterator<TSource, TKey, TState> : CollectionIterator<(TKey key, TState state)>
+	private sealed class ScanByIterator<TSource, TKey, TState> : CollectionIterator<(TKey key, TState state)>
 	{
 		private readonly ICollection<TSource> _source;
 		private readonly Func<TSource, TKey> _keySelector;

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -60,7 +60,7 @@ public static partial class SuperEnumerable
 			yield return item;
 	}
 
-	private class ScanRightIterator<T> : CollectionIterator<T>
+	private sealed class ScanRightIterator<T> : CollectionIterator<T>
 	{
 		private readonly ICollection<T> _source;
 		private readonly Func<T, T, T> _func;
@@ -147,7 +147,7 @@ public static partial class SuperEnumerable
 			yield return item;
 	}
 
-	private class ScanRightStateIterator<TSource, TAccumulate> : CollectionIterator<TAccumulate>
+	private sealed class ScanRightStateIterator<TSource, TAccumulate> : CollectionIterator<TAccumulate>
 	{
 		private readonly ICollection<TSource> _source;
 		private readonly TAccumulate _seed;

--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 /// <summary>
 /// Provides a set of static methods for querying objects that
@@ -6,6 +8,7 @@
 /// </summary>
 public static partial class SuperEnumerable
 {
+	[ExcludeFromCodeCoverage]
 	internal static int? TryGetCollectionCount<T>(this IEnumerable<T> source) =>
 #if NET6_0_OR_GREATER
 		source.TryGetNonEnumeratedCount(out var count) ? count : default(int?);
@@ -15,7 +18,23 @@ public static partial class SuperEnumerable
 			null => ThrowHelper.ThrowArgumentNullException<int?>(nameof(source)),
 			ICollection<T> collection => collection.Count,
 			System.Collections.ICollection collection => collection.Count,
-			_ => null
+			_ => null,
+		};
+#endif
+
+	[ExcludeFromCodeCoverage]
+	internal static int GetCollectionCount<T>(this IEnumerable<T> source) =>
+#if NET6_0_OR_GREATER
+		source.TryGetNonEnumeratedCount(out var count)
+			? count
+			: ThrowHelper.ThrowInvalidOperationException<int>("Expected valid non-enumerated count.");
+#else
+		source switch
+		{
+			null => ThrowHelper.ThrowArgumentNullException<int>(nameof(source)),
+			ICollection<T> collection => collection.Count,
+			System.Collections.ICollection collection => collection.Count,
+			_ => ThrowHelper.ThrowInvalidOperationException<int>("Expected valid non-enumerated count."),
 		};
 #endif
 


### PR DESCRIPTION
This PR updates a couple missed optimizations in the existing `CollectionIterator` improvements:
* Update a couple missed `sealed` classes
* Take advantage of `TryGetCollectionCount()` on certain iterators that don't use `CopyTo`, that is, they only implement `ICollection<>` for the `.Count` optimizations