### PR TITLE
`ZipLongest`: `IList<>` implementation

### DIFF
--- a/Generators/SuperLinq.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipLongest.sbntxt
@@ -55,6 +55,18 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
+		if (
+			{{~ for $j in 1..$i ~}}
+			{{ $ordinals[$j] }} is global::System.Collections.Generic.IList<T{{ $j }}> list{{ $j }}{{ if !for.last }}&&{{ else }}){{ end }}
+			{{~ end ~}}
+		{
+			return new ZipLongestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult>(
+				{{~ for $j in 1..$i ~}}
+				list{{ $j }},
+				{{~ end ~}}
+				resultSelector);
+		}
+
 		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
@@ -112,5 +124,49 @@ public static partial class SuperEnumerable
 			global::System.Collections.Generic.IEnumerable<T{{ $j }}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
 			{{~ end ~}}) =>
 		ZipLongest({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
+
+	private class ZipLongestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
+	{
+		{{~ for $j in 1..$i ~}}
+		private readonly global::System.Collections.Generic.IList<T{{ $j }}> _list{{ $j }};
+		{{~ end ~}}
+		private readonly global::System.Func<{{ for $j in 1..$i }}T{{ $j }}?, {{ end }}TResult> _resultSelector;
+		
+		public ZipLongestIterator(
+			{{~ for $j in 1..$i ~}}
+			global::System.Collections.Generic.IList<T{{ $j }}> {{ $ordinals[$j] }},
+			{{~ end ~}}
+			global::System.Func<{{ for $j in 1..$i }}T{{ $j }}?, {{ end }}TResult> resultSelector)
+		{
+			{{~ for $j in 1..$i ~}}
+			_list{{ $j }} = {{ $ordinals[$j] }};
+			{{~ end ~}}
+			_resultSelector	= resultSelector;
+		}
+
+		public override int Count => Max({{ for $j in 1..$i }}_list{{ $j }}.Count{{ if !for.last }}, {{ end }}{{ end }});
+
+		protected override IEnumerable<TResult> GetEnumerable()
+		{
+			var cnt = (uint)Count;
+			for (var i = 0; i < cnt; i++)
+			{
+				yield return _resultSelector(
+					{{~ for $j in 1..$i ~}}
+					i < _list{{ $j }}.Count ? _list{{ $j }}[i] : default{{ if !for.last }}, {{ end }}
+					{{~ end ~}});
+			}
+		}
+
+		protected override TResult ElementAt(int index)
+		{
+			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+
+			return _resultSelector(
+				{{~ for $j in 1..$i ~}}
+				index < _list{{ $j }}.Count ? _list{{ $j }}[index] : default{{ if !for.last }}, {{ end }}
+				{{~ end ~}});
+		}
+	}
 	{{ end ~}}
 }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
@@ -39,6 +39,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2)
+        {
+            return new ZipLongestIterator<T1, T2, TResult>(list1, list2, resultSelector);
+        }
+
         return Core(first, second, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
         {
@@ -72,6 +77,35 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T2">The type of the elements of <paramref name = "second"/>.</typeparam>
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? )> ZipLongest<T1, T2>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second) => ZipLongest(first, second, global::System.ValueTuple.Create);
+    private class ZipLongestIterator<T1, T2, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Func<T1?, T2?, TResult> _resultSelector;
+        public ZipLongestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Max(_list1.Count, _list2.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(i < _list1.Count ? _list1[i] : default, i < _list2.Count ? _list2[i] : default);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default);
+        }
+    }
+
     /// <summary>
     /// Returns a projection of tuples, where each tuple contains the N-th
     /// element from each of the argument sequences. The resulting sequence
@@ -100,6 +134,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2 && third is global::System.Collections.Generic.IList<T3> list3)
+        {
+            return new ZipLongestIterator<T1, T2, T3, TResult>(list1, list2, list3, resultSelector);
+        }
+
         return Core(first, second, third, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
         {
@@ -137,6 +176,37 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T3">The type of the elements of <paramref name = "third"/>.</typeparam>
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? , T3? )> ZipLongest<T1, T2, T3>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third) => ZipLongest(first, second, third, global::System.ValueTuple.Create);
+    private class ZipLongestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Func<T1?, T2?, T3?, TResult> _resultSelector;
+        public ZipLongestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Max(_list1.Count, _list2.Count, _list3.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(i < _list1.Count ? _list1[i] : default, i < _list2.Count ? _list2[i] : default, i < _list3.Count ? _list3[i] : default);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default);
+        }
+    }
+
     /// <summary>
     /// Returns a projection of tuples, where each tuple contains the N-th
     /// element from each of the argument sequences. The resulting sequence
@@ -168,6 +238,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2 && third is global::System.Collections.Generic.IList<T3> list3 && fourth is global::System.Collections.Generic.IList<T4> list4)
+        {
+            return new ZipLongestIterator<T1, T2, T3, T4, TResult>(list1, list2, list3, list4, resultSelector);
+        }
+
         return Core(first, second, third, fourth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
         {
@@ -209,4 +284,36 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T4">The type of the elements of <paramref name = "fourth"/>.</typeparam>
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? , T3? , T4? )> ZipLongest<T1, T2, T3, T4>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth) => ZipLongest(first, second, third, fourth, global::System.ValueTuple.Create);
+    private class ZipLongestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Collections.Generic.IList<T4> _list4;
+        private readonly global::System.Func<T1?, T2?, T3?, T4?, TResult> _resultSelector;
+        public ZipLongestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Collections.Generic.IList<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _list4 = fourth;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Max(_list1.Count, _list2.Count, _list3.Count, _list4.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(i < _list1.Count ? _list1[i] : default, i < _list2.Count ? _list2[i] : default, i < _list3.Count ? _list3[i] : default, i < _list4.Count ? _list4[i] : default);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default, index < _list4.Count ? _list4[index] : default);
+        }
+    }
 }

--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -18,4 +18,8 @@ public static partial class SuperEnumerable
 			_ => null
 		};
 #endif
+
+	private static int Max(int val1, int val2) => Math.Max(val1, val2);
+	private static int Max(int val1, int val2, int val3) => Math.Max(val1, Math.Max(val2, val3));
+	private static int Max(int val1, int val2, int val3, int val4) => Math.Max(Math.Max(val1, val2), Math.Max(val3, val4));
 }

--- a/Tests/SuperLinq.Test/ZipLongestTest.cs
+++ b/Tests/SuperLinq.Test/ZipLongestTest.cs
@@ -59,6 +59,23 @@ public class ZipLongestTest
 	}
 
 	[Fact]
+	public void TwoParamsListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.ZipLongest(seq2);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 0), result.ElementAt(^50));
+
+		result = seq2.ZipLongest(seq1);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((0, 9_950), result.ElementAt(^50));
+	}
+
+	[Fact]
 	public void ThreeParamsDisposesInnerSequencesCaseGetEnumeratorThrows()
 	{
 		using var s1 = TestingSequence.Of(1, 2);
@@ -145,6 +162,24 @@ public class ZipLongestTest
 						shortSeq == 1 ? 0 : 3,
 						shortSeq == 2 ? 0 : 3)));
 		}
+	}
+
+	[Fact]
+	public void ThreeParamsListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.ZipLongest(seq2, seq3);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 0, 0), result.ElementAt(^50));
+
+		result = seq2.ZipLongest(seq1, seq3);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((0, 9_950, 0), result.ElementAt(^50));
 	}
 
 	[Fact]
@@ -252,5 +287,24 @@ public class ZipLongestTest
 						shortSeq == 2 ? 0 : 3,
 						shortSeq == 3 ? 0 : 3)));
 		}
+	}
+
+	[Fact]
+	public void FourParamsListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq4 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.ZipLongest(seq2, seq3, seq4);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10, 10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50, 50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 0, 0, 0), result.ElementAt(^50));
+
+		result = seq2.ZipLongest(seq1, seq3, seq4);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((0, 9_950, 0, 0), result.ElementAt(^50));
 	}
 }

--- a/Tests/SuperLinq.Test/ZipLongestTest.cs
+++ b/Tests/SuperLinq.Test/ZipLongestTest.cs
@@ -19,21 +19,43 @@ public class ZipLongestTest
 			s1.ZipLongest(new BreakingSequence<int>()).Consume());
 	}
 
-	[Theory]
-	[InlineData(1), InlineData(2)]
-	public void TwoParamsWorksProperly(int offset)
+	public static IEnumerable<object[]> GetTwoParamSequences()
 	{
-		var o1 = ((offset + 0) % 2) + 2;
-		var o2 = ((offset + 1) % 2) + 2;
+		var parameters = new List<object[]>
+		{
+			new object[] { Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), 9, },
+			new object[] { Enumerable.Range(1, 3).ToList(), Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), 9, },
+			new object[] { Enumerable.Range(1, 3).AsBreakingList(), Enumerable.Range(1, 3).AsBreakingList(), 9, },
+		};
 
-		using var ts1 = Enumerable.Range(1, o1).AsTestingSequence();
-		using var ts2 = Enumerable.Range(1, o2).AsTestingSequence();
+		for (var i = 0; i < 2; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			parameters.Add(
+				new object[] { first.AsBreakingList(), second.AsBreakingList(), i, });
+			parameters.Add(
+				new object[] { first.AsTestingSequence(maxEnumerations: 2), second.AsTestingSequence(maxEnumerations: 2), i, });
+		}
 
-		ts1.ZipLongest(ts2).AssertSequenceEqual(
-			Enumerable.Range(1, 3)
-				.Select(x => (
-					x > o1 ? 0 : x,
-					x > o2 ? 0 : x)));
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetTwoParamSequences))]
+	public void TwoParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, int shortSeq)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.ZipLongest(seq2);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 2)
+					.Select(x => (x, x))
+					.Append((
+						shortSeq == 0 ? 0 : 3,
+						shortSeq == 1 ? 0 : 3)));
+		}
 	}
 
 	[Fact]
@@ -46,24 +68,83 @@ public class ZipLongestTest
 			s1.ZipLongest(s2, new BreakingSequence<int>()).Consume());
 	}
 
-	[Theory]
-	[InlineData(1), InlineData(2), InlineData(3)]
-	public void ThreeParamsWorksProperly(int offset)
+	public static IEnumerable<object[]> GetThreeParamSequences()
 	{
-		var o1 = ((offset + 0) % 3) + 2;
-		var o2 = ((offset + 1) % 3) + 2;
-		var o3 = ((offset + 2) % 3) + 2;
+		var parameters = new List<object[]>
+		{
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				9,
+			},
+		};
 
-		using var ts1 = Enumerable.Range(1, o1).AsTestingSequence();
-		using var ts2 = Enumerable.Range(1, o2).AsTestingSequence();
-		using var ts3 = Enumerable.Range(1, o3).AsTestingSequence();
+		for (var i = 0; i < 3; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			var third = Enumerable.Range(1, 3 - (i == 2 ? 1 : 0));
+			parameters.Add(
+				new object[] 
+				{
+					first.AsBreakingList(),
+					second.AsBreakingList(),
+					third.AsBreakingList(), 
+					i, 
+				});
+			parameters.Add(
+				new object[]
+				{
+					first.AsTestingSequence(maxEnumerations: 2),
+					second.AsTestingSequence(maxEnumerations: 2),
+					third.AsTestingSequence(maxEnumerations: 2),
+					i,
+				});
+		}
 
-		ts1.ZipLongest(ts2, ts3).AssertSequenceEqual(
-			Enumerable.Range(1, 4)
-				.Select(x => (
-					x > o1 ? 0 : x,
-					x > o2 ? 0 : x,
-					x > o3 ? 0 : x)));
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeParamSequences))]
+	public void ThreeParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3, int shortSeq)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.ZipLongest(seq2, seq3);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 2)
+					.Select(x => (x, x, x))
+					.Append((
+						shortSeq == 0 ? 0 : 3,
+						shortSeq == 1 ? 0 : 3,
+						shortSeq == 2 ? 0 : 3)));
+		}
 	}
 
 	[Fact]
@@ -77,26 +158,99 @@ public class ZipLongestTest
 			s1.ZipLongest(s2, s3, new BreakingSequence<int>()).Consume());
 	}
 
-	[Theory]
-	[InlineData(1), InlineData(2), InlineData(3), InlineData(4)]
-	public void FourParamsWorksProperly(int offset)
+	public static IEnumerable<object[]> GetFourParamSequences()
 	{
-		var o1 = ((offset + 0) % 4) + 2;
-		var o2 = ((offset + 1) % 4) + 2;
-		var o3 = ((offset + 2) % 4) + 2;
-		var o4 = ((offset + 3) % 4) + 2;
+		var parameters = new List<object[]>
+		{
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				9,
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				9,
+			},
+		};
 
-		using var ts1 = Enumerable.Range(1, o1).AsTestingSequence();
-		using var ts2 = Enumerable.Range(1, o2).AsTestingSequence();
-		using var ts3 = Enumerable.Range(1, o3).AsTestingSequence();
-		using var ts4 = Enumerable.Range(1, o4).AsTestingSequence();
+		for (var i = 0; i < 4; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			var third = Enumerable.Range(1, 3 - (i == 2 ? 1 : 0));
+			var fourth = Enumerable.Range(1, 3 - (i == 3 ? 1 : 0));
+			parameters.Add(
+				new object[]
+				{
+					first.AsBreakingList(),
+					second.AsBreakingList(),
+					third.AsBreakingList(),
+					fourth.AsBreakingList(),
+					i,
+				});
+			parameters.Add(
+				new object[]
+				{
+					first.AsTestingSequence(maxEnumerations: 2),
+					second.AsTestingSequence(maxEnumerations: 2),
+					third.AsTestingSequence(maxEnumerations: 2),
+					fourth.AsTestingSequence(maxEnumerations: 2),
+					i,
+				});
+		}
 
-		ts1.ZipLongest(ts2, ts3, ts4).AssertSequenceEqual(
-			Enumerable.Range(1, 5)
-				.Select(x => (
-					x > o1 ? 0 : x,
-					x > o2 ? 0 : x,
-					x > o3 ? 0 : x,
-					x > o4 ? 0 : x)));
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetFourParamSequences))]
+	public void FourParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3, IEnumerable<int> seq4, int shortSeq)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		using (seq4 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.ZipLongest(seq2, seq3, seq4);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 2)
+					.Select(x => (x, x, x, x))
+					.Append((
+						shortSeq == 0 ? 0 : 3,
+						shortSeq == 1 ? 0 : 3,
+						shortSeq == 2 ? 0 : 3,
+						shortSeq == 3 ? 0 : 3)));
+		}
 	}
 }

--- a/Tests/SuperLinq.Test/ZipLongestTest.cs
+++ b/Tests/SuperLinq.Test/ZipLongestTest.cs
@@ -108,12 +108,12 @@ public class ZipLongestTest
 			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
 			var third = Enumerable.Range(1, 3 - (i == 2 ? 1 : 0));
 			parameters.Add(
-				new object[] 
+				new object[]
 				{
 					first.AsBreakingList(),
 					second.AsBreakingList(),
-					third.AsBreakingList(), 
-					i, 
+					third.AsBreakingList(),
+					i,
 				});
 			parameters.Add(
 				new object[]


### PR DESCRIPTION
This PR adds an `IList<>` implementation for `ZipLongest`, which improves memory usage and performance.

Fixes #411 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|              Method |              source1 |              source2 |     N |          Mean |        Error |       StdDev |    Gen0 |   Gen1 | Allocated |
|-------------------- |--------------------- |--------------------- |------ |--------------:|-------------:|-------------:|--------:|-------:|----------:|
|     ZipLongestCount | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 |      15.97 ns |     0.157 ns |     0.131 ns |  0.0032 | 0.0000 |      40 B |
|     ZipLongestCount | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 159,520.55 ns |   667.403 ns |   591.635 ns |       - |      - |     296 B |
|    ZipLongestCopyTo | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 | 109,703.55 ns |   577.051 ns |   511.541 ns |  6.3477 | 1.0986 |   80112 B |
|    ZipLongestCopyTo | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 187,554.54 ns | 1,372.398 ns | 1,283.742 ns | 16.8457 | 2.9297 |  212032 B |
| ZipLongestElementAt | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 |      26.30 ns |     0.223 ns |     0.197 ns |  0.0032 | 0.0000 |      40 B |
| ZipLongestElementAt | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 130,856.39 ns |   813.885 ns |   721.488 ns |       - |      - |     296 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			Enumerable.Range(1, i / 2).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			Enumerable.Range(1, i / 2).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipLongestCount(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipLongest(source2).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipLongestCopyTo(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipLongest(source2).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipLongestElementAt(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipLongest(source2).ElementAt(8_000);
}
```
</details>