### PR TITLE
`ZipShortest`: `IList<>` implementation

### DIFF
--- a/Generators/SuperLinq.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipShortest.sbntxt
@@ -41,6 +41,18 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
+		if (
+			{{~ for $j in 1..$i ~}}
+			{{ $ordinals[$j] }} is global::System.Collections.Generic.IList<T{{ $cardinals[$j] }}> list{{ $j }}{{ if !for.last }}&&{{ else }}){{ end }}
+			{{~ end ~}}
+		{
+			return new ZipShortestIterator<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult>(
+				{{~ for $j in 1..$i ~}}
+				list{{ $j }},
+				{{~ end ~}}
+				resultSelector);
+		}
+
 		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
@@ -97,5 +109,49 @@ public static partial class SuperEnumerable
 			global::System.Collections.Generic.IEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
 			{{~ end ~}}) =>
 		ZipShortest({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
+
+	private class ZipShortestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
+	{
+		{{~ for $j in 1..$i ~}}
+		private readonly global::System.Collections.Generic.IList<T{{ $j }}> _list{{ $j }};
+		{{~ end ~}}
+		private readonly global::System.Func<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> _resultSelector;
+		
+		public ZipShortestIterator(
+			{{~ for $j in 1..$i ~}}
+			global::System.Collections.Generic.IList<T{{ $j }}> {{ $ordinals[$j] }},
+			{{~ end ~}}
+			global::System.Func<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> resultSelector)
+		{
+			{{~ for $j in 1..$i ~}}
+			_list{{ $j }} = {{ $ordinals[$j] }};
+			{{~ end ~}}
+			_resultSelector	= resultSelector;
+		}
+
+		public override int Count => Min({{ for $j in 1..$i }}_list{{ $j }}.Count{{ if !for.last }}, {{ end }}{{ end }});
+
+		protected override IEnumerable<TResult> GetEnumerable()
+		{
+			var cnt = (uint)Count;
+			for (var i = 0; i < cnt; i++)
+			{
+				yield return _resultSelector(
+					{{~ for $j in 1..$i ~}}
+					_list{{ $j }}[i]{{ if !for.last }}, {{ end }}
+					{{~ end ~}});
+			}
+		}
+
+		protected override TResult ElementAt(int index)
+		{
+			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+
+			return _resultSelector(
+				{{~ for $j in 1..$i ~}}
+				_list{{ $j }}[index]{{ if !for.last }}, {{ end }}
+				{{~ end ~}});
+		}
+	}
 	{{ end ~}}
 }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
@@ -25,6 +25,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2)
+        {
+            return new ZipShortestIterator<TFirst, TSecond, TResult>(list1, list2, resultSelector);
+        }
+
         return Core(first, second, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
         {
@@ -56,6 +61,35 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TSecond">The type of the elements of <paramref name = "second"/>.</typeparam>
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond)> ZipShortest<TFirst, TSecond>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second) => ZipShortest(first, second, global::System.ValueTuple.Create);
+    private class ZipShortestIterator<T1, T2, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Func<T1, T2, TResult> _resultSelector;
+        public ZipShortestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Min(_list1.Count, _list2.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index]);
+        }
+    }
+
     /// <summary>
     /// Returns a projection of tuples, where each tuple contains the N-th
     /// element from each of the argument sequences. The resulting sequence
@@ -82,6 +116,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3)
+        {
+            return new ZipShortestIterator<TFirst, TSecond, TThird, TResult>(list1, list2, list3, resultSelector);
+        }
+
         return Core(first, second, third, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
         {
@@ -116,6 +155,37 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TThird">The type of the elements of <paramref name = "third"/>.</typeparam>
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird)> ZipShortest<TFirst, TSecond, TThird>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third) => ZipShortest(first, second, third, global::System.ValueTuple.Create);
+    private class ZipShortestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Func<T1, T2, T3, TResult> _resultSelector;
+        public ZipShortestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Min(_list1.Count, _list2.Count, _list3.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i], _list3[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index], _list3[index]);
+        }
+    }
+
     /// <summary>
     /// Returns a projection of tuples, where each tuple contains the N-th
     /// element from each of the argument sequences. The resulting sequence
@@ -145,6 +215,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3 && fourth is global::System.Collections.Generic.IList<TFourth> list4)
+        {
+            return new ZipShortestIterator<TFirst, TSecond, TThird, TFourth, TResult>(list1, list2, list3, list4, resultSelector);
+        }
+
         return Core(first, second, third, fourth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
         {
@@ -182,4 +257,36 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TFourth">The type of the elements of <paramref name = "fourth"/>.</typeparam>
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird, TFourth)> ZipShortest<TFirst, TSecond, TThird, TFourth>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth) => ZipShortest(first, second, third, fourth, global::System.ValueTuple.Create);
+    private class ZipShortestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Collections.Generic.IList<T4> _list4;
+        private readonly global::System.Func<T1, T2, T3, T4, TResult> _resultSelector;
+        public ZipShortestIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Collections.Generic.IList<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _list4 = fourth;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count => Min(_list1.Count, _list2.Count, _list3.Count, _list4.Count);
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i], _list3[i], _list4[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
+        }
+    }
 }

--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -41,4 +41,8 @@ public static partial class SuperEnumerable
 	private static int Max(int val1, int val2) => Math.Max(val1, val2);
 	private static int Max(int val1, int val2, int val3) => Math.Max(val1, Math.Max(val2, val3));
 	private static int Max(int val1, int val2, int val3, int val4) => Math.Max(Math.Max(val1, val2), Math.Max(val3, val4));
+
+	private static int Min(int val1, int val2) => Math.Min(val1, val2);
+	private static int Min(int val1, int val2, int val3) => Math.Min(val1, Math.Min(val2, val3));
+	private static int Min(int val1, int val2, int val3, int val4) => Math.Min(Math.Min(val1, val2), Math.Min(val3, val4));
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation for `ZipShortest`, which improves memory usage and performance.

Fixes #414 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|               Method |              source1 |              source2 |     N |          Mean |        Error |       StdDev |    Gen0 |   Gen1 | Allocated |
|--------------------- |--------------------- |--------------------- |------ |--------------:|-------------:|-------------:|--------:|-------:|----------:|
|     ZipShortestCount | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 20000 |      16.15 ns |     0.191 ns |     0.179 ns |  0.0032 | 0.0000 |      40 B |
|     ZipShortestCount | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 20000 | 196,853.97 ns |   906.537 ns |   847.975 ns |       - |      - |     288 B |
|    ZipShortestCopyTo | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 20000 |  85,644.68 ns |   568.697 ns |   531.960 ns |  6.3477 | 1.0986 |   80112 B |
|    ZipShortestCopyTo | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 20000 | 225,560.32 ns | 1,250.051 ns | 1,169.299 ns | 16.8457 | 2.9297 |  212024 B |
| ZipShortestElementAt | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 20000 |      25.36 ns |     0.177 ns |     0.165 ns |  0.0032 | 0.0000 |      40 B |
| ZipShortestElementAt | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 20000 | 153,127.18 ns |   891.006 ns |   833.448 ns |       - |      - |     288 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 20_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			Enumerable.Range(1, i / 2).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			Enumerable.Range(1, i / 2).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipShortestCount(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipShortest(source2).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipShortestCopyTo(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipShortest(source2).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ZipShortestElementAt(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.ZipShortest(source2).ElementAt(8_000);
}
```
</details>
