### PR TITLE
`Window`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -17,6 +19,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
+
+		if (source is IList<TSource> list)
+			return new WindowIterator<TSource>(list, size);
 
 		return Core(source, size);
 
@@ -47,6 +52,56 @@ public static partial class SuperEnumerable
 			}
 
 			yield return window;
+		}
+	}
+
+	private sealed class WindowIterator<T> : ListIterator<IList<T>>
+	{
+		private readonly IList<T> _source;
+		private readonly int _size;
+
+		public WindowIterator(IList<T> source, int size)
+		{
+			_source = source;
+			_size = size;
+		}
+
+		public override int Count => Math.Max(_source.Count - _size + 1, 0);
+
+		protected override IEnumerable<IList<T>> GetEnumerable()
+		{
+			if (Count < _size)
+				yield break;
+
+			var window = new T[_size];
+
+			for (var i = 0; i < _size; i++)
+				window[i] = _source[i];
+
+			var count = (uint)_source.Count;
+			for (var i = _size; i < count; i++)
+			{
+				var newWindow = new T[_size];
+				window.AsSpan()[1..].CopyTo(newWindow);
+				newWindow[^1] = _source[i];
+
+				yield return window;
+				window = newWindow;
+			}
+
+			yield return window;
+		}
+
+		protected override IList<T> ElementAt(int index)
+		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+
+			var arr = new T[_size];
+			var max = (uint)(index + _size);
+			for (int i = 0, j = index; i < _size && j < max; i++, j++)
+				arr[i] = _source[j];
+
+			return arr;
 		}
 	}
 }

--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace SuperLinq;
+﻿namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -33,8 +33,10 @@ internal static partial class TestExtensions
 	{
 		if (actual is ICollection<T> coll)
 		{
-			Assert.Equal(expected.Length, coll.Count);
-			Assert.Equal(expected, coll.ToArray());
+			var arr = new T[expected.Length];
+			var cnt = SuperEnumerable.CopyTo(actual, arr);
+			Assert.Equal(expected.Length, cnt);
+			Assert.Equal(expected, arr);
 		}
 		else
 		{

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -31,7 +31,7 @@ internal static partial class TestExtensions
 	/// </summary>
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected)
 	{
-		if (actual is ICollection<T> coll)
+		if (actual is ICollection<T>)
 		{
 			var arr = new T[expected.Length];
 			var cnt = SuperEnumerable.CopyTo(actual, arr);

--- a/Tests/SuperLinq.Test/WindowTest.cs
+++ b/Tests/SuperLinq.Test/WindowTest.cs
@@ -24,114 +24,131 @@ public partial class WindowTests
 			new BreakingSequence<int>().Window(-5));
 	}
 
-	[Fact]
-	public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow()
+	public static IEnumerable<object[]> GetThreeElementSequences() =>
+		Enumerable.Range(0, 3)
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.Window(2).GetEnumerator();
+		using (seq)
+		{
+			using var e = seq.Window(2).GetEnumerator();
 
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		window1[1] = -1;
-		_ = e.MoveNext();
-		var window2 = e.Current;
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			window1[1] = -1;
+			_ = e.MoveNext();
+			var window2 = e.Current;
 
-		Assert.Equal(1, window2[0]);
+			Assert.Equal(1, window2[0]);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var e = seq.Window(2).GetEnumerator();
+
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			_ = e.MoveNext();
+			window1[1] = -1;
+			var window2 = e.Current;
+
+			Assert.Equal(1, window2[0]);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedDoesNotAffectPreviousWindow(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var e = seq.Window(2).GetEnumerator();
+
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			_ = e.MoveNext();
+			var window2 = e.Current;
+			window2[0] = -1;
+
+			Assert.Equal(1, window1[1]);
+		}
+	}
+
+	public static IEnumerable<object[]> GetEmptySequences() =>
+		Enumerable.Empty<int>()
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetEmptySequences))]
+	public void TestWindowEmptySequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Window(5);
+			result.AssertSequenceEqual();
+		}
+	}
+
+	public static IEnumerable<object[]> GetHundredElementSequences() =>
+		Enumerable.Range(0, 100)
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void TestWindowOfSingleElement(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Window(1);
+
+			foreach (var (actual, expected) in result.Zip(Enumerable.Range(0, 100)))
+				Assert.Equal(SuperEnumerable.Return(expected), actual);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void TestWindowLargerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Window(101);
+			result.AssertSequenceEqual();
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void TestWindowSmallerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Window(33);
+
+			foreach (var (window, index) in result.Zip(Enumerable.Range(0, 100)))
+				window.AssertSequenceEqual(Enumerable.Range(0, 100).Skip(index).Take(33));
+		}
 	}
 
 	[Fact]
-	public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow()
+	public void WindowListBehavior()
 	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.Window(2).GetEnumerator();
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		_ = e.MoveNext();
-		window1[1] = -1;
-		var window2 = e.Current;
-
-		Assert.Equal(1, window2[0]);
-	}
-
-	[Fact]
-	public void WindowModifiedDoesNotAffectPreviousWindow()
-	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.Window(2).GetEnumerator();
-
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		_ = e.MoveNext();
-		var window2 = e.Current;
-		window2[0] = -1;
-
-		Assert.Equal(1, window1[1]);
-	}
-
-	/// <summary>
-	/// Verify that a sliding window of an any size over an empty sequence
-	/// is an empty sequence
-	/// </summary>
-	[Fact]
-	public void TestWindowEmptySequence()
-	{
-		using var sequence = TestingSequence.Of<int>();
-
-		var result = sequence.Window(5);
-		Assert.Empty(result);
-	}
-
-	/// <summary>
-	/// Verify that decomposing a sequence into windows of a single item
-	/// degenerates to the original sequence.
-	/// </summary>
-	[Fact]
-	public void TestWindowOfSingleElement()
-	{
-		using var sequence = Enumerable.Range(0, 100).AsTestingSequence();
-
-		var result = sequence.Window(1).ToList();
-
-		// number of windows should be equal to the source sequence length
-		Assert.Equal(100, result.Count);
-		// each window should contain single item consistent of element at that offset
-		foreach (var (actual, expected) in result.Zip(Enumerable.Range(0, 100)))
-			Assert.Equal(SuperEnumerable.Return(expected), actual);
-	}
-
-	/// <summary>
-	/// Verify that asking for a window large than the source sequence results
-	/// in a empty sequence.
-	/// </summary>
-	[Fact]
-	public void TestWindowLargerThanSequence()
-	{
-		using var sequence = Enumerable.Range(0, 10).AsTestingSequence(TestingSequence.Options.AllowRepeatedMoveNexts);
-
-		var result = sequence.Window(11).ToList();
-
-		// there should only be one window whose contents is the same
-		// as the source sequence
-		Assert.Empty(result);
-	}
-
-	/// <summary>
-	/// Verify that asking for a window smaller than the source sequence results
-	/// in N sequences, where N = (source.Count() - windowSize) + 1.
-	/// </summary>
-	[Fact]
-	public void TestWindowSmallerThanSequence()
-	{
-		using var sequence = Enumerable.Range(0, 100).AsTestingSequence();
-
-		var result = sequence.Window(33).ToList();
-
-		// ensure that the number of windows is correct
-		Assert.Equal(100 - 33 + 1, result.Count);
-		// ensure each window contains the correct set of items
-		var index = 0;
-		foreach (var window in result)
-			Assert.Equal(Enumerable.Range(0, 100).Skip(index++).Take(33), window);
+		var result = seq.Window(20);
+		Assert.Equal(10_000 - 20 + 1, result.Count());
+		Assert.Equal(Enumerable.Range(50, 20), result.ElementAt(50));
+		Assert.Equal(Enumerable.Range(9_980, 20), result.ElementAt(^1));
 	}
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation of the `Window` operator.

Fixes #419 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|          Method |              source1 |     N |           Mean |         Error |        StdDev |    Gen0 |    Gen1 | Allocated |
|---------------- |--------------------- |------ |---------------:|--------------:|--------------:|--------:|--------:|----------:|
|     WindowCount | Syste(...)nt32] [47] | 10000 |       9.149 ns |     0.0447 ns |     0.0418 ns |  0.0025 |  0.0000 |      32 B |
|     WindowCount | Syste(...)nt32] [62] | 10000 | 190,218.615 ns | 1,082.6772 ns |   904.0845 ns | 82.5195 |  0.2441 | 1038192 B |
|    WindowCopyTo | Syste(...)nt32] [47] | 10000 | 218,147.174 ns | 1,371.7392 ns | 1,145.4644 ns | 88.8672 | 48.8281 | 1117984 B |
|    WindowCopyTo | Syste(...)nt32] [62] | 10000 | 287,875.178 ns | 3,067.1661 ns | 2,718.9628 ns | 99.1211 | 58.1055 | 1249777 B |
| WindowElementAt | Syste(...)nt32] [47] | 10000 |      45.165 ns |     0.4497 ns |     0.3986 ns |  0.0108 |  0.0001 |     136 B |
| WindowElementAt | Syste(...)nt32] [62] | 10000 | 153,205.796 ns | 1,012.1909 ns |   946.8040 ns | 66.1621 |  0.2441 |  832376 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowCount(IEnumerable<int> source1, int N)
{
	_ = source1.Window(20).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowCopyTo(IEnumerable<int> source1, int N)
{
	_ = source1.Window(20).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowElementAt(IEnumerable<int> source1, int N)
{
	_ = source1.Window(20).ElementAt(8_000);
}
```
</details>
