### PR TITLE
`WindowLeft`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/WindowLeftTest.cs
+++ b/Tests/SuperLinq.Test/WindowLeftTest.cs
@@ -17,106 +17,133 @@ public partial class WindowLeftTest
 			sequence.WindowLeft(-5));
 	}
 
-	[Fact]
-	public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow()
+	public static IEnumerable<object[]> GetThreeElementSequences() =>
+		Enumerable.Range(0, 3)
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow(IDisposableEnumerable<int> seq)
 	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.WindowLeft(2).GetEnumerator();
+		using (seq)
+		{
+			using var e = seq.WindowLeft(2).GetEnumerator();
 
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		window1[1] = -1;
-		_ = e.MoveNext();
-		var window2 = e.Current;
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			window1[1] = -1;
+			_ = e.MoveNext();
+			var window2 = e.Current;
 
-		Assert.Equal(1, window2[0]);
+			Assert.Equal(1, window2[0]);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var e = seq.WindowLeft(2).GetEnumerator();
+
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			_ = e.MoveNext();
+			window1[1] = -1;
+			var window2 = e.Current;
+
+			Assert.Equal(1, window2[0]);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeElementSequences))]
+	public void WindowModifiedDoesNotAffectPreviousWindow(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			using var e = seq.WindowLeft(2).GetEnumerator();
+
+			_ = e.MoveNext();
+			var window1 = e.Current;
+			_ = e.MoveNext();
+			var window2 = e.Current;
+			window2[0] = -1;
+
+			Assert.Equal(1, window1[1]);
+		}
+	}
+
+	public static IEnumerable<object[]> GetEmptySequences() =>
+		Enumerable.Empty<int>()
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetEmptySequences))]
+	public void WindowLeftEmptySequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.WindowLeft(5);
+			result.AssertSequenceEqual();
+		}
+	}
+
+	public static IEnumerable<object[]> GetHundredElementSequences() =>
+		Enumerable.Range(0, 100)
+			.GetListSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void WindowLeftOfSingleElement(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.WindowLeft(1);
+
+			foreach (var (actual, expected) in result.Zip(Enumerable.Range(0, 100)))
+				Assert.Equal(SuperEnumerable.Return(expected), actual);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void WindowLeftWithWindowSizeLargerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.WindowLeft(10);
+			result.AssertSequenceEqual(
+				Enumerable.Range(0, 100)
+					.Select(i => Enumerable.Range(i, Math.Min(10, 100 - i))));
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetHundredElementSequences))]
+	public void WindowLeftWithWindowSizeSmallerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.WindowLeft(110);
+			result.AssertSequenceEqual(
+				Enumerable.Range(0, 100)
+					.Select(i => Enumerable.Range(i, 100 - i)));
+		}
 	}
 
 	[Fact]
-	public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow()
+	public void WindowLeftListBehavior()
 	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.WindowLeft(2).GetEnumerator();
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		_ = e.MoveNext();
-		window1[1] = -1;
-		var window2 = e.Current;
-
-		Assert.Equal(1, window2[0]);
-	}
-
-	[Fact]
-	public void WindowModifiedDoesNotAffectPreviousWindow()
-	{
-		using var sequence = Enumerable.Range(0, 3).AsTestingSequence();
-		using var e = sequence.WindowLeft(2).GetEnumerator();
-
-		_ = e.MoveNext();
-		var window1 = e.Current;
-		_ = e.MoveNext();
-		var window2 = e.Current;
-		window2[0] = -1;
-
-		Assert.Equal(1, window1[1]);
-	}
-
-	/// <summary>
-	/// Verify that a sliding window of an any size over an empty sequence
-	/// is an empty sequence
-	/// </summary>
-	[Fact]
-	public void WindowLeftEmptySequence()
-	{
-		using var sequence = TestingSequence.Of<int>();
-
-		var result = sequence.WindowLeft(5).ToList();
-		Assert.Empty(result);
-	}
-
-	/// <summary>
-	/// Verify that decomposing a sequence into windows of a single item
-	/// degenerates to the original sequence.
-	/// </summary>
-	[Fact]
-	public void WindowLeftSingleElement()
-	{
-		using var xs = Enumerable.Range(1, 100).AsTestingSequence();
-		var result = xs.WindowLeft(1).ToList();
-
-		// number of windows should be equal to the source sequence length
-		Assert.Equal(100, result.Count);
-		// each window should contain single item consistent of element at that offset
-		foreach (var (actual, expected) in result.Zip(Enumerable.Range(1, 100)))
-			Assert.Equal(SuperEnumerable.Return(expected), actual);
-	}
-
-	[Fact]
-	public void WindowLeftWithWindowSizeLargerThanSequence()
-	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
-
-		using var reader = sequence.WindowLeft(10).Read();
-		reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
-		reader.Read().AssertSequenceEqual(2, 3, 4, 5);
-		reader.Read().AssertSequenceEqual(3, 4, 5);
-		reader.Read().AssertSequenceEqual(4, 5);
-		reader.Read().AssertSequenceEqual(5);
-		reader.ReadEnd();
-	}
-
-	[Fact]
-	public void WindowLeftWithWindowSizeSmallerThanSequence()
-	{
-		using var sequence = Enumerable.Range(1, 5).AsTestingSequence();
-
-		using var reader = sequence.WindowLeft(3).Read();
-		reader.Read().AssertSequenceEqual(1, 2, 3);
-		reader.Read().AssertSequenceEqual(2, 3, 4);
-		reader.Read().AssertSequenceEqual(3, 4, 5);
-		reader.Read().AssertSequenceEqual(4, 5);
-		reader.Read().AssertSequenceEqual(5);
-		reader.ReadEnd();
+		var result = seq.WindowLeft(20);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal(Enumerable.Range(50, 20), result.ElementAt(50));
+		Assert.Equal(Enumerable.Range(9_999, 1), result.ElementAt(^1));
 	}
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `WindowLeft`, which reduces memory usage and improves performance.

Fixes #420 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|              Method |              source1 |     N |           Mean |         Error |        StdDev |    Gen0 |    Gen1 | Allocated |
|-------------------- |--------------------- |------ |---------------:|--------------:|--------------:|--------:|--------:|----------:|
|     WindowLeftCount | Syste(...)nt32] [47] | 10000 |       9.578 ns |     0.1552 ns |     0.1376 ns |  0.0025 |  0.0000 |      32 B |
|     WindowLeftCount | Syste(...)nt32] [62] | 10000 | 192,044.128 ns | 2,388.0988 ns | 2,233.8291 ns | 82.7637 |  0.2441 | 1039448 B |
|    WindowLeftCopyTo | Syste(...)nt32] [47] | 10000 | 198,564.141 ns | 2,202.1525 ns | 1,838.8971 ns | 89.1113 | 51.5137 | 1119392 B |
|    WindowLeftCopyTo | Syste(...)nt32] [62] | 10000 | 276,862.553 ns | 2,095.5898 ns | 1,749.9124 ns | 99.6094 | 59.0820 | 1251185 B |
| WindowLeftElementAt | Syste(...)nt32] [47] | 10000 |      50.092 ns |     0.4634 ns |     0.4108 ns |  0.0108 |  0.0001 |     136 B |
| WindowLeftElementAt | Syste(...)nt32] [62] | 10000 | 155,226.362 ns | 2,605.7654 ns | 2,437.4345 ns | 66.1621 |  0.2441 |  832376 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowLeftCount(IEnumerable<int> source1, int N)
{
	_ = source1.WindowLeft(20).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowLeftCopyTo(IEnumerable<int> source1, int N)
{
	_ = source1.WindowLeft(20).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void WindowLeftElementAt(IEnumerable<int> source1, int N)
{
	_ = source1.WindowLeft(20).ElementAt(8_000);
}
```
</details>