### PR TITLE
`EquiZip`: `IList<>` implementation

### DIFF
--- a/Generators/SuperLinq.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Generator/EquiZip.sbntxt
@@ -47,6 +47,18 @@ public static partial class SuperEnumerable
 
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
 
+		if (
+			{{~ for $j in 1..$i ~}}
+			{{ $ordinals[$j] }} is global::System.Collections.Generic.IList<T{{ $cardinals[$j] }}> list{{ $j }}{{ if !for.last }}&&{{ else }}){{ end }}
+			{{~ end ~}}
+		{
+			return new EquiZipIterator<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult>(
+				{{~ for $j in 1..$i ~}}
+				list{{ $j }},
+				{{~ end ~}}
+				resultSelector);
+		}
+
 		return Core(
 			{{~ for $j in 1..$i ~}}
 			{{ $ordinals[$j] }},
@@ -121,5 +133,65 @@ public static partial class SuperEnumerable
 			global::System.Collections.Generic.IEnumerable<T{{ $cardinals[$j] }}> {{ $ordinals[$j] }}{{ if !for.last }},{{ end }}
 			{{~ end ~}}) =>
 		EquiZip({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
+
+	private class EquiZipIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
+	{
+		{{~ for $j in 1..$i ~}}
+		private readonly global::System.Collections.Generic.IList<T{{ $j }}> _list{{ $j }};
+		{{~ end ~}}
+		private readonly global::System.Func<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> _resultSelector;
+		
+		public EquiZipIterator(
+			{{~ for $j in 1..$i ~}}
+			global::System.Collections.Generic.IList<T{{ $j }}> {{ $ordinals[$j] }},
+			{{~ end ~}}
+			global::System.Func<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> resultSelector)
+		{
+			{{~ for $j in 1..$i ~}}
+			_list{{ $j }} = {{ $ordinals[$j] }};
+			{{~ end ~}}
+			_resultSelector	= resultSelector;
+		}
+
+		public override int Count
+		{
+			get
+			{
+				var count = _list1.Count;
+
+				{{~ for $j in 2..$i ~}}
+				if (_list{{ $j }}.Count != count)
+				{
+					global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
+						(count < _list{{ $j }}.Count ? "First" : "{{ $cardinals[$j] }}") + " sequence too short.");
+				}
+				{{~ end ~}}
+
+				return count;
+			}
+		}
+
+		protected override IEnumerable<TResult> GetEnumerable()
+		{
+			var cnt = (uint)Count;
+			for (var i = 0; i < cnt; i++)
+			{
+				yield return _resultSelector(
+					{{~ for $j in 1..$i ~}}
+					_list{{ $j }}[i]{{ if !for.last }}, {{ end }}
+					{{~ end ~}});
+			}
+		}
+
+		protected override TResult ElementAt(int index)
+		{
+			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+
+			return _resultSelector(
+				{{~ for $j in 1..$i ~}}
+				_list{{ $j }}[index]{{ if !for.last }}, {{ end }}
+				{{~ end ~}});
+		}
+	}
 	{{ end ~}}
 }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
@@ -31,6 +31,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2)
+        {
+            return new EquiZipIterator<TFirst, TSecond, TResult>(list1, list2, resultSelector);
+        }
+
         return Core(first, second, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
         {
@@ -74,6 +79,48 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TSecond">The type of the elements of <paramref name = "second"/>.</typeparam>
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond)> EquiZip<TFirst, TSecond>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second) => EquiZip(first, second, global::System.ValueTuple.Create);
+    private class EquiZipIterator<T1, T2, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Func<T1, T2, TResult> _resultSelector;
+        public EquiZipIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count
+        {
+            get
+            {
+                var count = _list1.Count;
+                if (_list2.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                }
+
+                return count;
+            }
+        }
+
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index]);
+        }
+    }
+
     /// <summary>
     /// <para>
     /// Applies a specified function to the corresponding elements of third sequences,
@@ -106,6 +153,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3)
+        {
+            return new EquiZipIterator<TFirst, TSecond, TThird, TResult>(list1, list2, list3, resultSelector);
+        }
+
         return Core(first, second, third, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
         {
@@ -154,6 +206,55 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TThird">The type of the elements of <paramref name = "third"/>.</typeparam>
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird)> EquiZip<TFirst, TSecond, TThird>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third) => EquiZip(first, second, third, global::System.ValueTuple.Create);
+    private class EquiZipIterator<T1, T2, T3, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Func<T1, T2, T3, TResult> _resultSelector;
+        public EquiZipIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count
+        {
+            get
+            {
+                var count = _list1.Count;
+                if (_list2.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                }
+
+                if (_list3.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
+                }
+
+                return count;
+            }
+        }
+
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i], _list3[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index], _list3[index]);
+        }
+    }
+
     /// <summary>
     /// <para>
     /// Applies a specified function to the corresponding elements of fourth sequences,
@@ -189,6 +290,11 @@ public static partial class SuperEnumerable
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
         global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3 && fourth is global::System.Collections.Generic.IList<TFourth> list4)
+        {
+            return new EquiZipIterator<TFirst, TSecond, TThird, TFourth, TResult>(list1, list2, list3, list4, resultSelector);
+        }
+
         return Core(first, second, third, fourth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
         {
@@ -242,4 +348,59 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TFourth">The type of the elements of <paramref name = "fourth"/>.</typeparam>
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird, TFourth)> EquiZip<TFirst, TSecond, TThird, TFourth>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth) => EquiZip(first, second, third, fourth, global::System.ValueTuple.Create);
+    private class EquiZipIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
+    {
+        private readonly global::System.Collections.Generic.IList<T1> _list1;
+        private readonly global::System.Collections.Generic.IList<T2> _list2;
+        private readonly global::System.Collections.Generic.IList<T3> _list3;
+        private readonly global::System.Collections.Generic.IList<T4> _list4;
+        private readonly global::System.Func<T1, T2, T3, T4, TResult> _resultSelector;
+        public EquiZipIterator(global::System.Collections.Generic.IList<T1> first, global::System.Collections.Generic.IList<T2> second, global::System.Collections.Generic.IList<T3> third, global::System.Collections.Generic.IList<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
+        {
+            _list1 = first;
+            _list2 = second;
+            _list3 = third;
+            _list4 = fourth;
+            _resultSelector = resultSelector;
+        }
+
+        public override int Count
+        {
+            get
+            {
+                var count = _list1.Count;
+                if (_list2.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                }
+
+                if (_list3.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
+                }
+
+                if (_list4.Count != count)
+                {
+                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list4.Count ? "First" : "Fourth") + " sequence too short.");
+                }
+
+                return count;
+            }
+        }
+
+        protected override IEnumerable<TResult> GetEnumerable()
+        {
+            var cnt = (uint)Count;
+            for (var i = 0; i < cnt; i++)
+            {
+                yield return _resultSelector(_list1[i], _list2[i], _list3[i], _list4[i]);
+            }
+        }
+
+        protected override TResult ElementAt(int index)
+        {
+            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
+        }
+    }
 }

--- a/Tests/SuperLinq.Test/EquiZipTest.cs
+++ b/Tests/SuperLinq.Test/EquiZipTest.cs
@@ -61,7 +61,7 @@ public class EquiZipTest
 		using var s1 = TestingSequence.Of(1, 2);
 
 		_ = Assert.Throws<TestException>(() =>
-			s1.ZipLongest(new BreakingSequence<int>()).Consume());
+			s1.EquiZip(new BreakingSequence<int>()).Consume());
 	}
 
 	public static IEnumerable<object[]> GetTwoParamEqualSequences()
@@ -152,7 +152,7 @@ public class EquiZipTest
 		using var s2 = TestingSequence.Of(1, 2);
 
 		_ = Assert.Throws<TestException>(() =>
-			s1.ZipLongest(s2, new BreakingSequence<int>()).Consume());
+			s1.EquiZip(s2, new BreakingSequence<int>()).Consume());
 	}
 
 	public static IEnumerable<object[]> GetThreeParamEqualSequences()
@@ -194,7 +194,7 @@ public class EquiZipTest
 		using (seq2 as IDisposableEnumerable<int>)
 		using (seq3 as IDisposableEnumerable<int>)
 		{
-			var result = seq1.ZipLongest(seq2, seq3);
+			var result = seq1.EquiZip(seq2, seq3);
 			result.AssertSequenceEqual(
 				Enumerable.Range(1, 3)
 					.Select(x => (x, x, x)));
@@ -282,7 +282,7 @@ public class EquiZipTest
 		using var s3 = TestingSequence.Of(1, 2);
 
 		_ = Assert.Throws<TestException>(() =>
-			s1.ZipLongest(s2, s3, new BreakingSequence<int>()).Consume());
+			s1.EquiZip(s2, s3, new BreakingSequence<int>()).Consume());
 	}
 
 	public static IEnumerable<object[]> GetFourParamEqualSequences()
@@ -336,7 +336,7 @@ public class EquiZipTest
 		using (seq3 as IDisposableEnumerable<int>)
 		using (seq4 as IDisposableEnumerable<int>)
 		{
-			var result = seq1.ZipLongest(seq2, seq3, seq4);
+			var result = seq1.EquiZip(seq2, seq3, seq4);
 			result.AssertSequenceEqual(
 				Enumerable.Range(1, 3)
 					.Select(x => (x, x, x, x)));
@@ -400,7 +400,7 @@ public class EquiZipTest
 		using var seq3 = Enumerable.Range(0, 10_000).AsBreakingList();
 		using var seq4 = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		var result = seq1.ZipLongest(seq2, seq3, seq4);
+		var result = seq1.EquiZip(seq2, seq3, seq4);
 		Assert.Equal(10_000, result.Count());
 		Assert.Equal((10, 10, 10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50, 50, 50), result.ElementAt(50));

--- a/Tests/SuperLinq.Test/EquiZipTest.cs
+++ b/Tests/SuperLinq.Test/EquiZipTest.cs
@@ -2,6 +2,19 @@
 
 public class EquiZipTest
 {
+	private static readonly string[] s_cardinals = new[]
+	{
+		"Zeroth" ,
+		"First"  ,
+		"Second" ,
+		"Third"  ,
+		"Fourth" ,
+		"Fifth"  ,
+		"Sixth"  ,
+		"Seventh",
+		"Eighth" ,
+	};
+
 	[Fact]
 	public void EquiZipIsLazy()
 	{
@@ -16,12 +29,7 @@ public class EquiZipTest
 	{
 		using var s1 = TestingSequence.Of(1, 2);
 		using var s2 = TestingSequence.Of(1, 2, 3);
-		using var s3 = SuperEnumerable
-			.From(
-				() => 1,
-				() => 2,
-				BreakingFunc.Of<int>())
-			.AsTestingSequence();
+		using var s3 = SeqExceptionAt(3).AsTestingSequence();
 
 		// `TestException` from `BreakingFunc` should not be thrown
 		_ = Assert.Throws<InvalidOperationException>(() =>
@@ -46,93 +54,370 @@ public class EquiZipTest
 			s1.EquiZip(s2, s3, s4).Consume());
 	}
 
+	#region Two
 	[Fact]
-	public void TwoParamsWorksCorrectly()
-	{
-		using var seq1 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, 3).AsTestingSequence();
-
-		seq1.EquiZip(seq2)
-			.AssertSequenceEqual(
-				Enumerable.Range(1, 3).Select(x => (x, x)));
-	}
-
-	[Theory]
-	[InlineData(1, "First")]
-	[InlineData(2, "Second")]
-	public void TwoParamsThrowsOnCorrectSequence(int shortSequence, string cardinal)
-	{
-		using var seq1 = Enumerable.Range(1, shortSequence == 1 ? 2 : 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, shortSequence == 2 ? 2 : 3).AsTestingSequence();
-
-		var ex = Assert.Throws<InvalidOperationException>(() =>
-			seq1.EquiZip(seq2).Consume());
-		Assert.Equal($"{cardinal} sequence too short.", ex.Message);
-	}
-
-	[Fact]
-	public void ThreeParamsWorksCorrectly()
-	{
-		using var seq1 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq3 = Enumerable.Range(1, 3).AsTestingSequence();
-
-		seq1.EquiZip(seq2, seq3)
-			.AssertSequenceEqual(
-				Enumerable.Range(1, 3).Select(x => (x, x, x)));
-	}
-
-	[Theory]
-	[InlineData(1, "First")]
-	[InlineData(2, "Second")]
-	[InlineData(3, "Third")]
-	public void ThreeParamsThrowsOnCorrectSequence(int shortSequence, string cardinal)
-	{
-		using var seq1 = Enumerable.Range(1, shortSequence == 1 ? 2 : 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, shortSequence == 2 ? 2 : 3).AsTestingSequence();
-		using var seq3 = Enumerable.Range(1, shortSequence == 3 ? 2 : 3).AsTestingSequence();
-
-		var ex = Assert.Throws<InvalidOperationException>(() =>
-			seq1.EquiZip(seq2, seq3).Consume());
-		Assert.Equal($"{cardinal} sequence too short.", ex.Message);
-	}
-
-	[Fact]
-	public void FourParamsWorksCorrectly()
-	{
-		using var seq1 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq3 = Enumerable.Range(1, 3).AsTestingSequence();
-		using var seq4 = Enumerable.Range(1, 3).AsTestingSequence();
-
-		seq1.EquiZip(seq2, seq3, seq4)
-			.AssertSequenceEqual(
-				Enumerable.Range(1, 3).Select(x => (x, x, x, x)));
-	}
-
-	[Theory]
-	[InlineData(1, "First")]
-	[InlineData(2, "Second")]
-	[InlineData(3, "Third")]
-	[InlineData(4, "Fourth")]
-	public void FourParamsThrowsOnCorrectSequence(int shortSequence, string cardinal)
-	{
-		using var seq1 = Enumerable.Range(1, shortSequence == 1 ? 2 : 3).AsTestingSequence();
-		using var seq2 = Enumerable.Range(1, shortSequence == 2 ? 2 : 3).AsTestingSequence();
-		using var seq3 = Enumerable.Range(1, shortSequence == 3 ? 2 : 3).AsTestingSequence();
-		using var seq4 = Enumerable.Range(1, shortSequence == 4 ? 2 : 3).AsTestingSequence();
-
-		var ex = Assert.Throws<InvalidOperationException>(() =>
-			seq1.EquiZip(seq2, seq3, seq4).Consume());
-		Assert.Equal($"{cardinal} sequence too short.", ex.Message);
-	}
-
-	[Fact]
-	public void ZipDisposesInnerSequencesCaseGetEnumeratorThrows()
+	public void TwoParamsDisposesInnerSequencesCaseGetEnumeratorThrows()
 	{
 		using var s1 = TestingSequence.Of(1, 2);
 
 		_ = Assert.Throws<TestException>(() =>
-			s1.EquiZip(new BreakingSequence<int>(), Tuple.Create).Consume());
+			s1.ZipLongest(new BreakingSequence<int>()).Consume());
 	}
+
+	public static IEnumerable<object[]> GetTwoParamEqualSequences()
+	{
+		return new List<object[]>
+		{
+			new object[] { Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), },
+			new object[] { Enumerable.Range(1, 3).ToList(), Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2), },
+			new object[] { Enumerable.Range(1, 3).AsBreakingList(), Enumerable.Range(1, 3).AsBreakingList(), },
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(GetTwoParamEqualSequences))]
+	public void TwoParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.EquiZip(seq2);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 3)
+					.Select(x => (x, x)));
+		}
+	}
+
+	public static IEnumerable<object[]> GetTwoParamInequalSequences()
+	{
+		var parameters = new List<object[]>();
+
+		for (var i = 0; i < 2; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			parameters.Add(
+				new object[] { first.AsBreakingList(), second.AsBreakingList(), s_cardinals[i + 1], });
+			parameters.Add(
+				new object[] { first.AsTestingSequence(maxEnumerations: 2), second.AsTestingSequence(maxEnumerations: 2), s_cardinals[i + 1], });
+		}
+
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetTwoParamInequalSequences))]
+	public void TwoParamsThrowsProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, string cardinal)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.EquiZip(seq2);
+			var ex = Assert.Throws<InvalidOperationException>(() =>
+				result.Consume());
+			Assert.Equal($"{cardinal} sequence too short.", ex.Message);
+		}
+	}
+
+	[Fact]
+	public void TwoParamsEqualListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.EquiZip(seq2);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 9_950), result.ElementAt(^50));
+	}
+
+	[Fact]
+	public void TwoParamsInequalListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.EquiZip(seq2);
+		_ = Assert.Throws<InvalidOperationException>(() => result.Count());
+		_ = Assert.Throws<InvalidOperationException>(() => result.ElementAt(10));
+	}
+	#endregion
+
+	#region Three
+	[Fact]
+	public void ThreeParamsDisposesInnerSequencesCaseGetEnumeratorThrows()
+	{
+		using var s1 = TestingSequence.Of(1, 2);
+		using var s2 = TestingSequence.Of(1, 2);
+
+		_ = Assert.Throws<TestException>(() =>
+			s1.ZipLongest(s2, new BreakingSequence<int>()).Consume());
+	}
+
+	public static IEnumerable<object[]> GetThreeParamEqualSequences()
+	{
+		return new List<object[]>
+		{
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+			},
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeParamEqualSequences))]
+	public void ThreeParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.ZipLongest(seq2, seq3);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 3)
+					.Select(x => (x, x, x)));
+		}
+	}
+
+	public static IEnumerable<object[]> GetThreeParamInequalSequences()
+	{
+		var parameters = new List<object[]>();
+
+		for (var i = 0; i < 3; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			var third = Enumerable.Range(1, 3 - (i == 2 ? 1 : 0));
+			parameters.Add(
+				new object[]
+				{
+					first.AsBreakingList(),
+					second.AsBreakingList(),
+					third.AsBreakingList(),
+					s_cardinals[i + 1],
+				});
+			parameters.Add(
+				new object[]
+				{
+					first.AsTestingSequence(maxEnumerations: 2),
+					second.AsTestingSequence(maxEnumerations: 2),
+					third.AsTestingSequence(maxEnumerations: 2),
+					s_cardinals[i + 1],
+				});
+		}
+
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetThreeParamInequalSequences))]
+	public void ThreeParamsThrowsProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3, string cardinal)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.EquiZip(seq2, seq3);
+			var ex = Assert.Throws<InvalidOperationException>(() =>
+				result.Consume());
+			Assert.Equal($"{cardinal} sequence too short.", ex.Message);
+		}
+	}
+
+	[Fact]
+	public void ThreeParamsListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.EquiZip(seq2, seq3);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 9_950, 9_950), result.ElementAt(^50));
+	}
+
+	[Fact]
+	public void ThreeParamsInequalListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.EquiZip(seq2, seq3);
+		_ = Assert.Throws<InvalidOperationException>(() => result.Count());
+		_ = Assert.Throws<InvalidOperationException>(() => result.ElementAt(10));
+	}
+	#endregion
+
+	#region Four
+	[Fact]
+	public void FourParamsDisposesInnerSequencesCaseGetEnumeratorThrows()
+	{
+		using var s1 = TestingSequence.Of(1, 2);
+		using var s2 = TestingSequence.Of(1, 2);
+		using var s3 = TestingSequence.Of(1, 2);
+
+		_ = Assert.Throws<TestException>(() =>
+			s1.ZipLongest(s2, s3, new BreakingSequence<int>()).Consume());
+	}
+
+	public static IEnumerable<object[]> GetFourParamEqualSequences()
+	{
+		return new List<object[]>
+		{
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).ToList(),
+				Enumerable.Range(1, 3).AsTestingSequence(maxEnumerations: 2),
+			},
+			new object[]
+			{
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+				Enumerable.Range(1, 3).AsBreakingList(),
+			},
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(GetFourParamEqualSequences))]
+	public void FourParamsWorksProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3, IEnumerable<int> seq4)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		using (seq4 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.ZipLongest(seq2, seq3, seq4);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 3)
+					.Select(x => (x, x, x, x)));
+		}
+	}
+
+	public static IEnumerable<object[]> GetFourParamInequalSequences()
+	{
+		var parameters = new List<object[]>();
+
+		for (var i = 0; i < 4; i++)
+		{
+			var first = Enumerable.Range(1, 3 - (i == 0 ? 1 : 0));
+			var second = Enumerable.Range(1, 3 - (i == 1 ? 1 : 0));
+			var third = Enumerable.Range(1, 3 - (i == 2 ? 1 : 0));
+			var fourth = Enumerable.Range(1, 3 - (i == 3 ? 1 : 0));
+			parameters.Add(
+				new object[]
+				{
+					first.AsBreakingList(),
+					second.AsBreakingList(),
+					third.AsBreakingList(),
+					fourth.AsBreakingList(),
+					s_cardinals[i + 1],
+				});
+			parameters.Add(
+				new object[]
+				{
+					first.AsTestingSequence(maxEnumerations: 2),
+					second.AsTestingSequence(maxEnumerations: 2),
+					third.AsTestingSequence(maxEnumerations: 2),
+					fourth.AsTestingSequence(maxEnumerations: 2),
+					s_cardinals[i + 1],
+				});
+		}
+
+		return parameters;
+	}
+
+	[Theory]
+	[MemberData(nameof(GetFourParamInequalSequences))]
+	public void FourParamsThrowsProperly(IEnumerable<int> seq1, IEnumerable<int> seq2, IEnumerable<int> seq3, IEnumerable<int> seq4, string cardinal)
+	{
+		using (seq1 as IDisposableEnumerable<int>)
+		using (seq2 as IDisposableEnumerable<int>)
+		using (seq3 as IDisposableEnumerable<int>)
+		using (seq4 as IDisposableEnumerable<int>)
+		{
+			var result = seq1.EquiZip(seq2, seq3, seq4);
+			var ex = Assert.Throws<InvalidOperationException>(() =>
+				result.Consume());
+			Assert.Equal($"{cardinal} sequence too short.", ex.Message);
+		}
+	}
+
+	[Fact]
+	public void FourParamsListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq4 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.ZipLongest(seq2, seq3, seq4);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, 10, 10, 10), result.ElementAt(10));
+		Assert.Equal((50, 50, 50, 50), result.ElementAt(50));
+		Assert.Equal((9_950, 9_950, 9_950, 9_950), result.ElementAt(^50));
+	}
+
+	[Fact]
+	public void FourParamsInequalListBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
+		using var seq4 = Enumerable.Range(0, 5_000).AsBreakingList();
+
+		var result = seq1.EquiZip(seq2, seq3, seq4);
+		_ = Assert.Throws<InvalidOperationException>(() => result.Count());
+		_ = Assert.Throws<InvalidOperationException>(() => result.ElementAt(10));
+	}
+	#endregion
 }

--- a/Tests/SuperLinq.Test/ZipShortestTest.cs
+++ b/Tests/SuperLinq.Test/ZipShortestTest.cs
@@ -11,6 +11,34 @@ public class ZipShortestTest
 	}
 
 	[Fact]
+	public void MoveNextIsNotCalledUnnecessarily3()
+	{
+		using var s1 = TestingSequence.Of(1, 2);
+		using var s2 = TestingSequence.Of(1, 2, 3);
+		using var s3 = SeqExceptionAt(3).AsTestingSequence();
+
+		// `TestException` from `BreakingFunc` should not be thrown
+		s1.ZipShortest(s2, s3).Consume();
+	}
+
+	[Fact]
+	public void MoveNextIsNotCalledUnnecessarily4()
+	{
+		using var s1 = TestingSequence.Of(1, 2);
+		using var s2 = TestingSequence.Of(1, 2, 3);
+		using var s3 = SuperEnumerable
+			.From(
+				() => 1,
+				() => 2,
+				BreakingFunc.Of<int>())
+			.AsTestingSequence();
+		using var s4 = TestingSequence.Of(1, 2, 3);
+
+		// `TestException` from `BreakingFunc` should not be thrown
+		s1.ZipShortest(s2, s3, s4).Consume();
+	}
+
+	[Fact]
 	public void TwoParamsDisposesInnerSequencesCaseGetEnumeratorThrows()
 	{
 		using var s1 = TestingSequence.Of(1, 2);


### PR DESCRIPTION
This PR adds an `IList<>` implementation for `EquiZip`, which improves memory usage and performance.

Fixes #410 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|           Method |              source1 |              source2 |     N |          Mean |        Error |       StdDev |    Gen0 |   Gen1 | Allocated |
|----------------- |--------------------- |--------------------- |------ |--------------:|-------------:|-------------:|--------:|-------:|----------:|
|     EquiZipCount | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 |      17.83 ns |     0.165 ns |     0.138 ns |  0.0032 | 0.0000 |      40 B |
|     EquiZipCount | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 194,728.78 ns | 1,181.364 ns | 1,047.249 ns |       - |      - |     288 B |
|    EquiZipCopyTo | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 |  85,086.34 ns |   641.740 ns |   600.284 ns |  6.3477 | 1.0986 |   80112 B |
|    EquiZipCopyTo | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 222,949.18 ns | 1,170.050 ns |   977.044 ns | 16.8457 | 2.9297 |  212024 B |
| EquiZipElementAt | Syste(...)nt32] [47] | Syste(...)nt32] [47] | 10000 |      25.31 ns |     0.457 ns |     0.427 ns |  0.0032 | 0.0000 |      40 B |
| EquiZipElementAt | Syste(...)nt32] [62] | Syste(...)nt32] [62] | 10000 | 153,161.77 ns |   647.435 ns |   540.637 ns |       - |      - |     288 B |

<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void EquiZipCount(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.EquiZip(source2).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void EquiZipCopyTo(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.EquiZip(source2).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void EquiZipElementAt(IEnumerable<int> source1, IEnumerable<int> source2, int N)
{
	_ = source1.EquiZip(source2).ElementAt(8_000);
}
```
</details>