### PR TITLE
Fix array reuse bug in `Batch`

### DIFF
--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -58,11 +58,12 @@ public static partial class SuperEnumerable
 			foreach (var item in source)
 			{
 				(array ??= new TSource[size])[n++] = item;
-				if (n == size)
-				{
-					yield return array;
-					n = 0;
-				}
+				if (n != size)
+					continue;
+
+				yield return array;
+				array = null;
+				n = 0;
 			}
 
 			if (n != 0)


### PR DESCRIPTION
This PR addresses a bug in the `Batch` operator where it reuses the array initially allocated. 

Fixes #436 