### PR TITLE
Add `TestingCollection`

### DIFF
--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -22,14 +22,8 @@ public class AssertCountTest
 		data.AssertCount(3).Consume();
 		using (var xs = data.AsTestingSequence())
 			xs.AssertCount(3).Consume();
-		using (var xs = new BreakingCollection<string>(data))
-		{
-			// expect a `TestException` as we try to enumerate the list
-			// but should _not_ get an `ArgumentException` as the 
-			// count is correct for the sequence
-			_ = Assert.Throws<TestException>(
-				() => xs.AssertCount(3).Consume());
-		}
+		using (var xs = data.AsTestingCollection())
+			xs.AssertCount(3).Consume();
 	}
 
 	public static IEnumerable<object[]> GetSequences() =>

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -28,7 +28,7 @@ public class AssertCountTest
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/AtLeastTest.cs
+++ b/Tests/SuperLinq.Test/AtLeastTest.cs
@@ -11,7 +11,7 @@ public class AtLeastTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/AtMostTest.cs
+++ b/Tests/SuperLinq.Test/AtMostTest.cs
@@ -11,7 +11,7 @@ public class AtMostTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -78,7 +78,7 @@ public class BatchTest
 	}
 
 	public static IEnumerable<object[]> GetEmptySequences() =>
-		Enumerable.Empty<int>()
+		Array.Empty<int>()
 			.GetAllSequences()
 			.Select(x => new object[] { x });
 
@@ -269,12 +269,6 @@ public class BatchTest
 		using var seq = new BreakingCollection<int>(Enumerable.Range(1, 9));
 		seq.Batch(10, i => i.Sum()).Consume();
 	}
-
-	public static IEnumerable<object[]> GetCollection(IEnumerable<int> seq) =>
-		seq
-			.GetCollectionSequences()
-			.Where(x => x is not TestingSequence<int>)
-			.Select(x => new object[] { x });
 
 	[Fact]
 	public void BatchBufferedUsesCollectionCountAtIterationTime()

--- a/Tests/SuperLinq.Test/CountBetweenTest.cs
+++ b/Tests/SuperLinq.Test/CountBetweenTest.cs
@@ -25,7 +25,7 @@ public class CountBetweenTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -38,7 +38,7 @@ public class CountBetweenTest
 
 	public static IEnumerable<object[]> GetTestData(int count, int min, int max, bool expecting) =>
 		Enumerable.Range(1, count)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x, min, max, expecting });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/ExactlyTest.cs
+++ b/Tests/SuperLinq.Test/ExactlyTest.cs
@@ -11,7 +11,7 @@ public class ExactlyTest
 
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -12,7 +12,7 @@ public class FillBackwardTest
 
 	public static IEnumerable<object[]> GetIntNullSequences() =>
 		Seq<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -41,7 +41,7 @@ public class FillBackwardTest
 
 	public static IEnumerable<object[]> GetIntSequences() =>
 		Enumerable.Range(1, 13)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/FillForwardTest.cs
+++ b/Tests/SuperLinq.Test/FillForwardTest.cs
@@ -14,7 +14,7 @@ public class FillForwardTest
 
 	public static IEnumerable<object[]> GetIntNullSequences() =>
 		Seq<int?>(null, null, 1, 2, null, null, null, 3, 4, null, null)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -43,7 +43,7 @@ public class FillForwardTest
 
 	public static IEnumerable<object[]> GetIntSequences() =>
 		Enumerable.Range(1, 13)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/MemoizeTest.cs
+++ b/Tests/SuperLinq.Test/MemoizeTest.cs
@@ -13,7 +13,7 @@ public class MemoizeTest
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -1,6 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
-
-namespace Test;
+﻿namespace Test;
 
 public enum SourceKind
 {
@@ -84,12 +82,4 @@ internal static partial class TestExtensions
 		yield return input.AsTestingCollection(maxEnumerations: 2);
 		yield return input.AsBreakingList();
 	}
-
-	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
-		sourceKind switch
-		{ 
-			SourceKind.Sequence => input.AsTestingSequence(),
-			SourceKind.BreakingCollection => new BreakingCollection<T>(input),
-			_ => ThrowHelper.ThrowArgumentException<IDisposableEnumerable<T>>(nameof(sourceKind)),
-		};
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -60,7 +60,14 @@ internal static partial class TestExtensions
 	{
 		// UI will consume one enumeration
 		yield return input.AsTestingSequence(maxEnumerations: 2);
-		yield return new BreakingCollection<T>(input);
+		yield return input.AsTestingCollection(maxEnumerations: 2);
+	}
+
+	internal static IEnumerable<IDisposableEnumerable<T>> GetBreakingCollectionSequences<T>(this IEnumerable<T> input)
+	{
+		// UI will consume one enumeration
+		yield return input.AsTestingSequence(maxEnumerations: 2);
+		yield return input.AsBreakingCollection();
 	}
 
 	internal static IEnumerable<IDisposableEnumerable<T>> GetListSequences<T>(this IEnumerable<T> input)
@@ -74,13 +81,13 @@ internal static partial class TestExtensions
 	{
 		// UI will consume one enumeration
 		yield return input.AsTestingSequence(maxEnumerations: 2);
-		yield return new BreakingCollection<T>(input);
-		yield return new BreakingList<T>(input);
+		yield return input.AsTestingCollection(maxEnumerations: 2);
+		yield return input.AsBreakingList();
 	}
 
 	internal static IDisposableEnumerable<T> ToSourceKind<T>(this IList<T> input, SourceKind sourceKind) =>
 		sourceKind switch
-		{
+		{ 
 			SourceKind.Sequence => input.AsTestingSequence(),
 			SourceKind.BreakingCollection => new BreakingCollection<T>(input),
 			_ => ThrowHelper.ThrowArgumentException<IDisposableEnumerable<T>>(nameof(sourceKind)),

--- a/Tests/SuperLinq.Test/TestingCollection.cs
+++ b/Tests/SuperLinq.Test/TestingCollection.cs
@@ -1,0 +1,37 @@
+﻿using static Test.TestingSequence;
+
+namespace Test;
+
+internal static class TestingCollection
+{
+	internal static TestingCollection<T> AsTestingCollection<T>(
+		this IEnumerable<T> source, Options options = Options.None, int maxEnumerations = 1) =>
+			new(source as IList<T> ?? source.ToList(), options, maxEnumerations);
+}
+
+internal class TestingCollection<T> : TestingSequence<T>, ICollection<T>
+{
+	private readonly ICollection<T> _collection;
+
+	internal TestingCollection(
+		ICollection<T> sequence, Options options, int maxEnumerations)
+		: base(sequence, options, maxEnumerations)
+	{
+		_collection = sequence;
+	}
+
+	public int Count => _collection.Count;
+
+	public void Add(T item) => Assert.Fail("LINQ Operators should not be calling this method.");
+	public void Clear() => Assert.Fail("LINQ Operators should not be calling this method.");
+	public bool Contains(T item) => _collection.Contains(item);
+	public bool Remove(T item) { Assert.Fail("LINQ Operators should not be calling this method."); return false; }
+	public bool IsReadOnly => true;
+
+	public int CopyCount { get; private set; }
+	public virtual void CopyTo(T[] array, int arrayIndex)
+	{
+		_collection.CopyTo(array, arrayIndex);
+		CopyCount++;
+	}
+}

--- a/Tests/SuperLinq.Test/TestingSequence.cs
+++ b/Tests/SuperLinq.Test/TestingSequence.cs
@@ -58,7 +58,7 @@ public class TestingSequenceException : Exception
 /// when it is disposed itself and also whether GetEnumerator() is
 /// called exactly once or not.
 /// </summary>
-internal sealed class TestingSequence<T> : IDisposableEnumerable<T>
+internal class TestingSequence<T> : IDisposableEnumerable<T>
 {
 	private readonly IEnumerable<T> _sequence;
 	private readonly Options _options;

--- a/Tests/SuperLinq.Test/TrySingleTest.cs
+++ b/Tests/SuperLinq.Test/TrySingleTest.cs
@@ -6,7 +6,7 @@ public class TrySingleTest
 {
 	public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
 		seq.Select(x => (int?)x)
-			.GetCollectionSequences()
+			.GetBreakingCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -25,7 +25,6 @@ public class TrySingleTest
 	public static IEnumerable<object[]> GetSingletonSequences(IEnumerable<int> seq) =>
 		seq.Select(x => (int?)x)
 			.GetCollectionSequences()
-			.Where(x => x is not BreakingCollection<int?>)
 			.Select(x => new object[] { x });
 
 	[Theory]


### PR DESCRIPTION
This PR adds a new `TestingCollection` to allow testing operators that use `foreach` on `ICollection<>`.