### PR TITLE
`CountDown`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/CountDownTest.cs
+++ b/Tests/SuperLinq.Test/CountDownTest.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using CommunityToolkit.Diagnostics;
-
-namespace Test;
+﻿namespace Test;
 
 public class CountDownTest
 {
@@ -20,74 +17,31 @@ public class CountDownTest
 			new BreakingSequence<int>().CountDown(param));
 	}
 
-	public static IEnumerable<T> GetData<T>(Func<int[], int, int?[], T> selector)
+	public static IEnumerable<object[]> GetTheoryData()
 	{
-		var xs = Enumerable.Range(0, 5).ToArray();
-		yield return selector(xs, 1, new int?[] { null, null, null, null, 0 });
-		yield return selector(xs, 2, new int?[] { null, null, null, 1, 0 });
-		yield return selector(xs, 3, new int?[] { null, null, 2, 1, 0 });
-		yield return selector(xs, 4, new int?[] { null, 3, 2, 1, 0 });
-		yield return selector(xs, 5, new int?[] { 4, 3, 2, 1, 0 });
-		yield return selector(xs, 6, new int?[] { 4, 3, 2, 1, 0 });
-		yield return selector(xs, 7, new int?[] { 4, 3, 2, 1, 0 });
-	}
+		var xs = Enumerable.Range(0, 5).ToList();
 
-	public static IEnumerable<object[]> SequenceData { get; } =
-		from e in GetData((xs, count, countdown) => new
+		for (var i = 1; i <= 7; i++)
 		{
-			Source = xs,
-			Count = count,
-			Countdown = countdown,
-		})
-		select new object[] { e.Source, e.Count, e.Source.Zip(e.Countdown, ValueTuple.Create), };
+			var countdown = i < 5
+				? Enumerable.Repeat<int?>(null, 5 - i).Concat(Enumerable.Range(0, i).Select(x => (int?)x).Reverse())
+				: Enumerable.Range(0, 5).Select(x => (int?)x).Reverse();
 
-	[Theory, MemberData(nameof(SequenceData))]
-	public void WithSequence(int[] xs, int count, IEnumerable<(int, int?)> expected)
-	{
-		using var ts = xs.Select(SuperEnumerable.Identity).AsTestingSequence();
-		Assert.Equal(expected, ts.CountDown(count, ValueTuple.Create));
-	}
-
-	public static IEnumerable<object[]> CollectionData { get; } =
-		from e in GetData((xs, count, countdown) => new
-		{
-			Source = xs,
-			Count = count,
-			Countdown = countdown,
-		})
-		select new object[] { e.Source, e.Count, e.Source.Zip(e.Countdown, ValueTuple.Create), };
-
-	[Theory, MemberData(nameof(CollectionData))]
-	public void WithCollection(int[] xs, int count, IEnumerable<(int, int?)> expected)
-	{
-		var moves = 0;
-		var disposed = false;
-
-		IEnumerator<T> Watch<T>(IEnumerator<T> e)
-		{
-			moves = 0;
-			disposed = false;
-			var te = e.AsWatchable();
-			te.Disposed += delegate { disposed = true; };
-			te.MoveNextCalled += delegate { moves++; };
-			return te;
+			foreach (var seq in xs.GetAllSequences())
+			{
+				yield return new object[] { seq, i, xs.EquiZip(countdown), };
+			}
 		}
+	}
 
-		var ts = TestCollection.Create(xs, Watch).AsEnumerable();
-
-		var result =
-			ts.CountDown(count, ValueTuple.Create).Index(1)
-				.Do(e =>
-				{
-					// For a collection, CountDown doesn't do any buffering
-					// so check that as each result becomes available, the
-					// source hasn't been "pulled" on more.
-					Assert.Equal(e.index, moves);
-				})
-				.Select(x => x.item);
-
-		Assert.Equal(expected, result);
-		Assert.True(disposed);
+	[Theory, MemberData(nameof(GetTheoryData))]
+	public void WithSequence(IDisposableEnumerable<int> seq, int count, IEnumerable<(int, int?)> expected)
+	{
+		using (seq)
+		{
+			var result = seq.CountDown(count);
+			result.AssertSequenceEqual(expected);
+		}
 	}
 
 	[Fact]
@@ -100,46 +54,24 @@ public class CountDownTest
 		result.AssertSequenceEqual(default(int?), null, 1, 0);
 	}
 
-	private static class TestCollection
+	[Fact]
+	public void CountDownCollectionBehavior()
 	{
-		public static Collection<T> Create<T>(
-			ICollection<T> collection,
-			Func<IEnumerator<T>, IEnumerator<T>>? em = null)
-		{
-			return new Collection<T>(collection, em);
-		}
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.CountDown(20);
+		Assert.Equal(10_000, result.Count());
 	}
 
-	/// <summary>
-	/// A collection that wraps another but which also permits its
-	/// enumerator to be substituted for another.
-	/// </summary>
-	private sealed class Collection<T> : ICollection<T>
+	[Fact]
+	public void CountDownListBehavior()
 	{
-		private readonly Func<IEnumerator<T>, IEnumerator<T>> _em;
-		private readonly ICollection<T> _collection;
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		public Collection(
-			ICollection<T> collection,
-			Func<IEnumerator<T>, IEnumerator<T>>? em = null)
-		{
-			_collection = collection ?? ThrowHelper.ThrowArgumentNullException<ICollection<T>>(nameof(collection));
-			_em = em ?? SuperEnumerable.Identity;
-		}
-
-		public int Count => _collection.Count;
-		public bool IsReadOnly => _collection.IsReadOnly;
-
-		public IEnumerator<T> GetEnumerator() =>
-			_em(_collection.GetEnumerator());
-
-		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-		public bool Contains(T item) => _collection.Contains(item);
-		public void CopyTo(T[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
-
-		public void Add(T item) => throw new NotImplementedException();
-		public void Clear() => throw new NotImplementedException();
-		public bool Remove(T item) => throw new NotImplementedException();
+		var result = seq.CountDown(20);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal((10, default(int?)), result.ElementAt(10));
+		Assert.Equal((50, default(int?)), result.ElementAt(50));
+		Assert.Equal((9_995, 4), result.ElementAt(^5));
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -21,19 +21,22 @@ internal static partial class TestExtensions
 	/// Just to make our testing easier so we can chain the assertion call.
 	/// </summary>
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected) =>
-		Assert.Equal(expected, actual);
+		actual.AssertSequenceEqual(expected as IList<T> ?? expected.ToList());
 
 	/// <summary>
 	/// Make testing even easier - a params array makes for readable tests :)
 	/// The sequence should be evaluated exactly once.
 	/// </summary>
-	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected)
+	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected) =>
+		actual.AssertSequenceEqual((IList<T>)expected);
+
+	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IList<T> expected)
 	{
 		if (actual is ICollection<T>)
 		{
-			var arr = new T[expected.Length];
+			var arr = new T[expected.Count];
 			var cnt = SuperEnumerable.CopyTo(actual, arr);
-			Assert.Equal(expected.Length, cnt);
+			Assert.Equal(expected.Count, cnt);
 			Assert.Equal(expected, arr);
 		}
 		else


### PR DESCRIPTION
This PR adds an `IList<>` implementation for `CountDown`, which improves memory usage and performance.

Fixes #434

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|             Method |              source1 |     N |          Mean |        Error |       StdDev |    Gen0 |    Gen1 |    Gen2 | Allocated |
|------------------- |--------------------- |------ |--------------:|-------------:|-------------:|--------:|--------:|--------:|----------:|
|     CountDownCount | Syste(...)nt32] [47] | 10000 |      13.36 ns |     0.169 ns |     0.150 ns |  0.0032 |  0.0000 |       - |      40 B |
|     CountDownCount | Syste(...)nt32] [62] | 10000 | 160,909.15 ns | 1,319.372 ns | 1,169.589 ns |       - |       - |       - |     344 B |
|    CountDownCopyTo | Syste(...)nt32] [47] | 10000 | 245,207.07 ns | 3,485.105 ns | 2,720.941 ns | 49.8047 | 49.8047 | 49.8047 |  160210 B |
|    CountDownCopyTo | Syste(...)nt32] [62] | 10000 | 414,980.08 ns | 8,279.715 ns | 8,502.657 ns | 90.8203 | 90.8203 | 90.8203 |  423333 B |
| CountDownElementAt | Syste(...)nt32] [47] | 10000 |      20.35 ns |     0.167 ns |     0.148 ns |  0.0032 |  0.0000 |       - |      40 B |
| CountDownElementAt | Syste(...)nt32] [62] | 10000 | 129,655.82 ns | 1,399.232 ns | 1,308.843 ns |       - |       - |       - |     344 B |

<details>
<summary>Code</summary>

```cs
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void CountDownCount(IEnumerable<int> source1, int N)
{
	_ = source1.CountDown(20).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void CountDownCopyTo(IEnumerable<int> source1, int N)
{
	_ = source1.CountDown(20).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void CountDownElementAt(IEnumerable<int> source1, int N)
{
	_ = source1.CountDown(20).ElementAt(8_000);
}
```

</details>
