### PR TITLE
`Replace`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -24,6 +24,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
+		if (source is IList<TSource> list)
+			return new ReplaceIterator<TSource>(list, value, index);
+
 		return Core(source, index, value);
 
 		static IEnumerable<TSource> Core(
@@ -59,6 +62,9 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 
+		if (source is IList<TSource> list)
+			return new ReplaceIterator<TSource>(list, value, index);
+
 		return Core(source, value, index);
 
 		static IEnumerable<TSource> Core(IEnumerable<TSource> source, TSource value, Index index)
@@ -78,7 +84,7 @@ public static partial class SuperEnumerable
 			}
 			else
 			{
-				var cnt = index.Value + 1;
+				var cnt = index.Value;
 				var queue = new Queue<TSource>();
 
 				foreach (var e in source)
@@ -100,6 +106,46 @@ public static partial class SuperEnumerable
 				while (queue.Count != 0)
 					yield return queue.Dequeue();
 			}
+		}
+	}
+
+	private sealed class ReplaceIterator<TSource> : ListIterator<TSource>
+	{
+		private readonly IList<TSource> _source;
+		private readonly TSource _value;
+		private readonly Index _index;
+
+		public ReplaceIterator(IList<TSource> source, TSource value, Index index)
+		{
+			_source = source;
+			_value = value;
+			_index = index;
+		}
+
+		public override int Count => _source.Count;
+
+		protected override IEnumerable<TSource> GetEnumerable()
+		{
+			var cnt = (uint)_source.Count;
+			var idx = _index.GetOffset(_source.Count);
+
+			for (var i = 0; i < cnt; i++)
+				yield return i == idx ? _value : _source[i];
+		}
+
+		public override void CopyTo(TSource[] array, int arrayIndex)
+		{
+			_source.CopyTo(array, arrayIndex);
+			array[arrayIndex + _index.GetOffset(_source.Count)] = _value;
+		}
+
+		protected override TSource ElementAt(int index)
+		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+
+			return index == _index.GetOffset(_source.Count)
+				? _value
+				: _source[index];
 		}
 	}
 }

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -136,7 +136,10 @@ public static partial class SuperEnumerable
 		public override void CopyTo(TSource[] array, int arrayIndex)
 		{
 			_source.CopyTo(array, arrayIndex);
-			array[arrayIndex + _index.GetOffset(_source.Count)] = _value;
+
+			var idx = _index.GetOffset(_source.Count);
+			if (idx >= 0 && idx < _source.Count)
+				array[arrayIndex + idx] = _value;
 		}
 
 		protected override TSource ElementAt(int index)

--- a/Tests/SuperLinq.Test/ReplaceTest.cs
+++ b/Tests/SuperLinq.Test/ReplaceTest.cs
@@ -37,7 +37,8 @@ public class ReplaceTest
 			result.AssertSequenceEqual(
 				Enumerable.Range(1, index)
 					.Append(30)
-					.Concat(Enumerable.Range(index + 2, 9 - index)));
+					.Concat(Enumerable.Range(index + 2, 9 - index)),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -50,7 +51,8 @@ public class ReplaceTest
 			result.AssertSequenceEqual(
 				Enumerable.Range(1, index)
 					.Append(30)
-					.Concat(Enumerable.Range(index + 2, 9 - index)));
+					.Concat(Enumerable.Range(index + 2, 9 - index)),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -64,7 +66,8 @@ public class ReplaceTest
 			result.AssertSequenceEqual(
 				Enumerable.Range(1, 9 - index)
 					.Append(30)
-					.Concat(Enumerable.Range(11 - index, index)));
+					.Concat(Enumerable.Range(11 - index, index)),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -80,7 +83,9 @@ public class ReplaceTest
 		using (seq)
 		{
 			var result = seq.Replace(10, 30);
-			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 10),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -91,7 +96,9 @@ public class ReplaceTest
 		using (seq)
 		{
 			var result = seq.Replace(new Index(10), 30);
-			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 10),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -102,7 +109,9 @@ public class ReplaceTest
 		using (seq)
 		{
 			var result = seq.Replace(^11, 30);
-			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 10),
+				testCollectionEnumerable: true);
 		}
 	}
 

--- a/Tests/SuperLinq.Test/ReplaceTest.cs
+++ b/Tests/SuperLinq.Test/ReplaceTest.cs
@@ -23,81 +23,104 @@ public class ReplaceTest
 	}
 
 	public static IEnumerable<object[]> Indices() =>
-		Enumerable.Range(0, 10).Select(i => new object[] { i, });
+		Enumerable.Range(0, 10)
+			.SelectMany(
+				_ => Enumerable.Range(1, 10).GetAllSequences(),
+				(i, s) => new object[] { i, s, });
 
 	[Theory, MemberData(nameof(Indices))]
-	public void ReplaceIntIndex(int index)
+	public void ReplaceIntIndex(int index, IDisposableEnumerable<int> seq)
 	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
-
-		var result = seq.Replace(index, 30);
-		result.AssertSequenceEqual(
-			Enumerable.Range(1, index)
-				.Append(30)
-				.Concat(Enumerable.Range(index + 2, 9 - index)));
+		using (seq)
+		{
+			var result = seq.Replace(index, 30);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, index)
+					.Append(30)
+					.Concat(Enumerable.Range(index + 2, 9 - index)));
+		}
 	}
 
 	[Theory, MemberData(nameof(Indices))]
-	public void ReplaceStartIndex(int index)
+	public void ReplaceStartIndex(int index, IDisposableEnumerable<int> seq)
 	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
-
-		var result = seq.Replace(new Index(index), 30);
-		result.AssertSequenceEqual(
-			Enumerable.Range(1, index)
-				.Append(30)
-				.Concat(Enumerable.Range(index + 2, 9 - index)));
+		using (seq)
+		{
+			var result = seq.Replace(new Index(index), 30);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, index)
+					.Append(30)
+					.Concat(Enumerable.Range(index + 2, 9 - index)));
+		}
 	}
 
 	[Theory, MemberData(nameof(Indices))]
-	public void ReplaceEndIndex(int index)
+	public void ReplaceEndIndex(int index, IDisposableEnumerable<int> seq)
 	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
-
-		var result = seq.Replace(^index, 30);
-		result.AssertSequenceEqual(
-			Enumerable.Range(1, 9 - index)
-				.Append(30)
-				.Concat(Enumerable.Range(11 - index, index)));
+		using (seq)
+		{
+			// offset by one because 0..9 is less useful than 1..10
+			var result = seq.Replace(^(index + 1), 30);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 9 - index)
+					.Append(30)
+					.Concat(Enumerable.Range(11 - index, index)));
+		}
 	}
 
-	[Theory, MemberData(nameof(Indices))]
-	public void ReplaceEndIndexWithCollection(int index)
-	{
-		var seq = Enumerable.Range(1, 10).ToArray();
+	public static IEnumerable<object[]> GetSequences() =>
+		Enumerable.Range(1, 10)
+			.GetListSequences()
+			.Select(x => new object[] { x });
 
-		// offset by one because 0..9 is less useful than 1..10
-		var result = seq.Replace(^(index + 1), 30);
-		result.AssertSequenceEqual(
-			Enumerable.Range(1, 9 - index)
-				.Append(30)
-				.Concat(Enumerable.Range(11 - index, index)));
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void ReplaceIntIndexPastSequenceLength(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Replace(10, 30);
+			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void ReplaceStartIndexPastSequenceLength(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Replace(new Index(10), 30);
+			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void ReplaceEndIndexPastSequenceLength(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Replace(^11, 30);
+			result.AssertSequenceEqual(Enumerable.Range(1, 10));
+		}
 	}
 
 	[Fact]
-	public void ReplaceIntIndexPastSequenceLength()
+	public void ReplaceListBehavior()
 	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
-		var result = seq.Replace(10, 30);
-		result.AssertSequenceEqual(Enumerable.Range(1, 10));
-	}
+		var result = seq.Replace(20, -1);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal(10, result.ElementAt(10));
+		Assert.Equal(-1, result.ElementAt(20));
+		Assert.Equal(9_950, result.ElementAt(^50));
 
-	[Fact]
-	public void ReplaceStartIndexPastSequenceLength()
-	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
-
-		var result = seq.Replace(new Index(10), 30);
-		result.AssertSequenceEqual(Enumerable.Range(1, 10));
-	}
-
-	[Fact]
-	public void ReplaceEndIndexPastSequenceLength()
-	{
-		using var seq = Enumerable.Range(1, 10).AsTestingSequence();
-
-		var result = seq.Replace(^10, 30);
-		result.AssertSequenceEqual(Enumerable.Range(1, 10));
+		result.ToList()
+			.AssertSequenceEqual(
+				Enumerable.Range(0, 20)
+					.Append(-1)
+					.Concat(Enumerable.Range(21, 9_979)));
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -20,8 +20,8 @@ internal static partial class TestExtensions
 	/// <summary>
 	/// Just to make our testing easier so we can chain the assertion call.
 	/// </summary>
-	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected) =>
-		actual.AssertSequenceEqual(expected as IList<T> ?? expected.ToList());
+	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool testCollectionEnumerable = false) =>
+		actual.AssertSequenceEqual(expected as IList<T> ?? expected.ToList(), testCollectionEnumerable);
 
 	/// <summary>
 	/// Make testing even easier - a params array makes for readable tests :)
@@ -30,7 +30,7 @@ internal static partial class TestExtensions
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected) =>
 		actual.AssertSequenceEqual((IList<T>)expected);
 
-	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IList<T> expected)
+	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IList<T> expected, bool testCollectionEnumerable = false)
 	{
 		if (actual is ICollection<T>)
 		{
@@ -38,6 +38,9 @@ internal static partial class TestExtensions
 			var cnt = SuperEnumerable.CopyTo(actual, arr);
 			Assert.Equal(expected.Count, cnt);
 			Assert.Equal(expected, arr);
+
+			if (testCollectionEnumerable)
+				Assert.Equal(expected, actual);
 		}
 		else
 		{


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `Replace`, which improves memory usage and performance. Also, a bug in `Replace` using `^x` indices is fixed.

Fixes #437

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|           Method |              source1 |     N |           Mean |       Error |      StdDev |   Gen0 |   Gen1 | Allocated |
|----------------- |--------------------- |------ |---------------:|------------:|------------:|-------:|-------:|----------:|
|     ReplaceCount | Syste(...)nt32] [47] | 10000 |       8.273 ns |   0.1330 ns |   0.1244 ns | 0.0025 | 0.0000 |      32 B |
|     ReplaceCount | Syste(...)nt32] [62] | 10000 |  96,727.650 ns | 662.4417 ns | 619.6484 ns |      - |      - |     168 B |
|    ReplaceCopyTo | Syste(...)nt32] [47] | 10000 |   1,987.191 ns |  27.4487 ns |  24.3326 ns | 3.1815 | 0.0038 |   40056 B |
|    ReplaceCopyTo | Syste(...)nt32] [62] | 10000 | 118,530.481 ns | 818.7933 ns | 765.8998 ns | 8.4229 | 0.8545 |  106352 B |
| ReplaceElementAt | Syste(...)nt32] [47] | 10000 |      15.284 ns |   0.2302 ns |   0.2154 ns | 0.0025 | 0.0000 |      32 B |
| ReplaceElementAt | Syste(...)nt32] [62] | 10000 |  74,150.606 ns | 270.0764 ns | 225.5261 ns |      - |      - |     168 B |

<details>
<summary>Code</summary>

```cs
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ReplaceCount(IEnumerable<int> source1, int N)
{
	_ = source1.Replace(20, -30).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ReplaceCopyTo(IEnumerable<int> source1, int N)
{
	_ = source1.Replace(20, -30).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void ReplaceElementAt(IEnumerable<int> source1, int N)
{
	_ = source1.Replace(20, -30).ElementAt(8_000);
}
```
</details>