### PR TITLE
`PadStart`: `ICollection<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/PadStartTest.cs
+++ b/Tests/SuperLinq.Test/PadStartTest.cs
@@ -17,217 +17,127 @@ public class PadStartTest
 		_ = new BreakingSequence<object>().PadStart(0, BreakingFunc.Of<int, object>());
 	}
 
-	public class ValueTypeElements
+	public static IEnumerable<object[]> GetIntSequences() =>
+		Seq(123, 456, 789)
+			.GetAllSequences()
+			.Select(x => new object[] { x, });
+
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadStartWideSourceSequence(IDisposableEnumerable<int> seq)
 	{
-		public static IEnumerable<object[]> GetIntSequences()
+		using (seq)
 		{
-			var seq = Seq(123, 456, 789);
-			yield return new object[] { new LinkedList<int>(seq), false, };
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadStartWideSourceSequence(IEnumerable<int> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<int>)
-			{
-				var result = seq.PadStart(2);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789);
-			}
-		}
-
-		[Fact]
-		public void PadStartWideListBehavior()
-		{
-			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
-
-			var result = seq.PadStart(5_000, x => x % 1_000);
-			Assert.Equal(10_000, result.Count());
-			Assert.Equal(1_200, result.ElementAt(1_200));
-			Assert.Equal(8_800, result.ElementAt(^1_200));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(10_001));
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadStartEqualSourceSequence(IEnumerable<int> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<int>)
-			{
-				var result = seq.PadStart(3);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<int> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<int>)
-			{
-				var result = seq.PadStart(5);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(0, 0, 123, 456, 789);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<int> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<int>)
-			{
-				var result = seq.PadStart(5, -1);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(-1, -1, 123, 456, 789);
-			}
-		}
-
-		[Fact]
-		public void PadStartNarrowListBehavior()
-		{
-			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
-
-			var result = seq.PadStart(40_000, x => x % 1_000);
-			Assert.Equal(40_000, result.Count());
-			Assert.Equal(200, result.ElementAt(1_200));
-			Assert.Equal(1_200, result.ElementAt(31_200));
-			Assert.Equal(8_800, result.ElementAt(^1_200));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(40_001));
-		}
-
-		public static IEnumerable<object[]> GetCharSequences()
-		{
-			var seq = "hello".AsEnumerable();
-			yield return new object[] { new LinkedList<char>(seq), false, };
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
-		}
-
-		[Theory]
-		[MemberData(nameof(GetCharSequences))]
-		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<char> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<char>)
-			{
-				var result = seq.PadStart(15, i => i % 2 == 0 ? '+' : '-');
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("+-+-+-+-+-hello".ToCharArray());
-			}
+			var result = seq.PadStart(2);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789),
+				testCollectionEnumerable: true);
 		}
 	}
 
-	public class ReferenceTypeElements
+	[Fact]
+	public void PadStartWideCollectionBehavior()
 	{
-		public static IEnumerable<object[]> GetStringSequences()
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.PadStart(5_000, x => x % 1_000);
+		Assert.Equal(10_000, result.Count());
+	}
+
+	[Fact]
+	public void PadStartWideListBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.PadStart(5_000, x => x % 1_000);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(10_001));
+	}
+
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadStartEqualSourceSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			var seq = Seq("foo", "bar", "baz");
-			yield return new object[] { new LinkedList<string>(seq), false, };
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
+			var result = seq.PadStart(3);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadStartWideSourceSequence(IEnumerable<string> seq, bool select)
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadStartNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			using (seq as IDisposableEnumerable<string>)
-			{
-				var result = seq.PadStart(2);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz");
-			}
+			var result = seq.PadStart(5);
+			result.AssertSequenceEqual(
+				Seq(0, 0, 123, 456, 789),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Fact]
-		public void PadStartWideListBehavior()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
-
-			var result = seq.PadStart(2, x => $"Extra{x}");
-			Assert.Equal(3, result.Count());
-			Assert.Equal("bar", result.ElementAt(1));
-			Assert.Equal("baz", result.ElementAt(^1));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(3));
+			var result = seq.PadStart(5, -1);
+			result.AssertSequenceEqual(
+				Seq(-1, -1, 123, 456, 789),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadStartEqualSourceSequence(IEnumerable<string> seq, bool select)
+	[Fact]
+	public void PadStartNarrowCollectionBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.PadStart(40_000, x => x % 1_000);
+		Assert.Equal(40_000, result.Count());
+	}
+
+	[Fact]
+	public void PadStartNarrowListBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.PadStart(40_000, x => x % 1_000);
+		Assert.Equal(40_000, result.Count());
+		Assert.Equal(200, result.ElementAt(1_200));
+		Assert.Equal(1_200, result.ElementAt(31_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(40_001));
+	}
+
+	public static IEnumerable<object[]> GetCharSequences() =>
+		"hello".AsEnumerable()
+			.GetAllSequences()
+			.Select(x => new object[] { x, });
+
+	[Theory]
+	[MemberData(nameof(GetCharSequences))]
+	public void PadStartNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<char> seq)
+	{
+		using (seq)
 		{
-			using (seq as IDisposableEnumerable<string>)
-			{
-				var result = seq.PadStart(3);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz");
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithDefaultPadding(IEnumerable<string> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<string>)
-			{
-				var result = seq.PadStart(5);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(default(string), null, "foo", "bar", "baz");
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithNonDefaultPadding(IEnumerable<string> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<string>)
-			{
-				var result = seq.PadStart(5, string.Empty);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(string.Empty, string.Empty, "foo", "bar", "baz");
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadStartNarrowSourceSequenceWithDynamicPadding(IEnumerable<string> seq, bool select)
-		{
-			using (seq as IDisposableEnumerable<string>)
-			{
-				var result = seq.PadStart(5, x => $"Extra{x}");
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("Extra0", "Extra1", "foo", "bar", "baz");
-			}
-		}
-
-		[Fact]
-		public void PadStartNarrowListBehavior()
-		{
-			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
-
-			var result = seq.PadStart(5, x => $"Extra{x}");
-			Assert.Equal(5, result.Count());
-			Assert.Equal("Extra1", result.ElementAt(1));
-			Assert.Equal("baz", result.ElementAt(^1));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(5));
+			var result = seq.PadStart(15, i => i % 2 == 0 ? '+' : '-');
+			result.AssertSequenceEqual(
+				"+-+-+-+-+-hello",
+				testCollectionEnumerable: true);
 		}
 	}
 


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `PadStart` operator. 

Fixes #451 
