### PR TITLE
`Pad`: `ICollection<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/PadTest.cs
+++ b/Tests/SuperLinq.Test/PadTest.cs
@@ -17,214 +17,118 @@ public class PadTest
 		_ = new BreakingSequence<object>().Pad(0, BreakingFunc.Of<int, object>());
 	}
 
-	public class ValueTypeElements
+	public static IEnumerable<object[]> GetIntSequences() =>
+		Seq(123, 456, 789)
+			.GetAllSequences()
+			.Select(x => new object[] { x, });
+
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadWideSourceSequence(IDisposableEnumerable<int> seq)
 	{
-		public static IEnumerable<object[]> GetIntSequences()
+		using (seq)
 		{
-			var seq = Seq(123, 456, 789);
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadWideSourceSequence(IDisposableEnumerable<int> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(2);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789);
-			}
-		}
-
-		[Fact]
-		public void PadWideListBehavior()
-		{
-			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
-
-			var result = seq.Pad(5_000, x => x % 1_000);
-			Assert.Equal(10_000, result.Count());
-			Assert.Equal(1_200, result.ElementAt(1_200));
-			Assert.Equal(8_800, result.ElementAt(^1_200));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(10_001));
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadEqualSourceSequence(IDisposableEnumerable<int> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(3);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<int> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(5);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789, 0, 0);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetIntSequences))]
-		public void PadNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<int> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(5, -1);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual(123, 456, 789, -1, -1);
-			}
-		}
-
-		[Fact]
-		public void PadNarrowListBehavior()
-		{
-			using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
-
-			var result = seq.Pad(40_000, x => x % 1_000);
-			Assert.Equal(40_000, result.Count());
-			Assert.Equal(1_200, result.ElementAt(1_200));
-			Assert.Equal(200, result.ElementAt(11_200));
-			Assert.Equal(800, result.ElementAt(^1_200));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(40_001));
-		}
-
-		public static IEnumerable<object[]> GetCharSequences()
-		{
-			var seq = "hello".AsEnumerable();
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
-		}
-
-		[Theory]
-		[MemberData(nameof(GetCharSequences))]
-		public void PadNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<char> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(15, i => i % 2 == 0 ? '+' : '-');
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("hello-+-+-+-+-+".ToCharArray());
-			}
+			var result = seq.Pad(2);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789),
+				testCollectionEnumerable: true);
 		}
 	}
 
-	public class ReferenceTypeElements
+	[Fact]
+	public void PadWideListBehavior()
 	{
-		public static IEnumerable<object[]> GetStringSequences()
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.Pad(5_000, x => x % 1_000);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(10_001));
+	}
+
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadEqualSourceSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			var seq = Seq("foo", "bar", "baz");
-			yield return new object[] { seq.AsTestingSequence(maxEnumerations: 2), false, };
-			yield return new object[] { seq.AsBreakingList(), false, };
-			yield return new object[] { seq.AsBreakingList(), true, };
+			var result = seq.Pad(3);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadWideSourceSequence(IDisposableEnumerable<string> seq, bool select)
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			using (seq)
-			{
-				var result = seq.Pad(2);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz");
-			}
+			var result = seq.Pad(5);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789, 0, 0),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Fact]
-		public void PadWideListBehavior()
+	[Theory]
+	[MemberData(nameof(GetIntSequences))]
+	public void PadNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
 		{
-			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
-
-			var result = seq.Pad(2, x => $"Extra{x}");
-			Assert.Equal(3, result.Count());
-			Assert.Equal("bar", result.ElementAt(1));
-			Assert.Equal("baz", result.ElementAt(^1));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(3));
+			var result = seq.Pad(5, -1);
+			result.AssertSequenceEqual(
+				Seq(123, 456, 789, -1, -1),
+				testCollectionEnumerable: true);
 		}
+	}
 
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadEqualSourceSequence(IDisposableEnumerable<string> seq, bool select)
+	[Fact]
+	public void PadNarrowCollectionBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.Pad(40_000, x => x % 1_000);
+		Assert.Equal(40_000, result.Count());
+	}
+
+	[Fact]
+	public void PadNarrowListBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.Pad(40_000, x => x % 1_000);
+		Assert.Equal(40_000, result.Count());
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(200, result.ElementAt(11_200));
+		Assert.Equal(800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(40_001));
+	}
+
+	public static IEnumerable<object[]> GetCharSequences() =>
+		"hello".AsEnumerable()
+			.GetAllSequences()
+			.Select(x => new object[] { x, });
+
+	[Theory]
+	[MemberData(nameof(GetCharSequences))]
+	public void PadNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<char> seq)
+	{
+		using (seq)
 		{
-			using (seq)
-			{
-				var result = seq.Pad(3);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz");
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadNarrowSourceSequenceWithDefaultPadding(IDisposableEnumerable<string> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(5);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz", null, null);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadNarrowSourceSequenceWithNonDefaultPadding(IDisposableEnumerable<string> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(5, string.Empty);
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz", string.Empty, string.Empty);
-			}
-		}
-
-		[Theory]
-		[MemberData(nameof(GetStringSequences))]
-		public void PadNarrowSourceSequenceWithDynamicPadding(IDisposableEnumerable<string> seq, bool select)
-		{
-			using (seq)
-			{
-				var result = seq.Pad(5, x => $"Extra{x}");
-				if (select) result = result.Select(SuperEnumerable.Identity);
-				result.AssertSequenceEqual("foo", "bar", "baz", "Extra3", "Extra4");
-			}
-		}
-
-		[Fact]
-		public void PadNarrowListBehavior()
-		{
-			using var seq = Seq("foo", "bar", "baz").AsBreakingList();
-
-			var result = seq.Pad(5, x => $"Extra{x}");
-			Assert.Equal(5, result.Count());
-			Assert.Equal("bar", result.ElementAt(1));
-			Assert.Equal("Extra4", result.ElementAt(^1));
-
-			_ = Assert.Throws<ArgumentOutOfRangeException>(
-				"index",
-				() => result.ElementAt(5));
+			var result = seq.Pad(15, i => i % 2 == 0 ? '+' : '-');
+			result.AssertSequenceEqual(
+				"hello-+-+-+-+-+",
+				testCollectionEnumerable: true);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds an `ICollection<>` implementation of the `Pad` operator. 

Fixes #450
