### PR TITLE
`AssertCount`: `IList<>` implementation

### DIFF
--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -24,28 +24,105 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
+		if (source is IList<TSource> list)
+			return new AssertCountListIterator<TSource>(list, count);
+
+		if (source.TryGetCollectionCount() is int)
+			return new AssertCountCollectionIterator<TSource>(source, count);
+
 		return Core(source, count);
 
 		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count)
 		{
-			if (source.TryGetCollectionCount() is int c)
+			var c = 0;
+			foreach (var item in source)
 			{
-				Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+				if (++c > count)
+					break;
+				yield return item;
+			}
+			Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+		}
+	}
 
-				foreach (var item in source)
-					yield return item;
-			}
-			else
+	private class AssertCountCollectionIterator<T> : CollectionIterator<T>
+	{
+		private readonly IEnumerable<T> _source;
+		private readonly int _count;
+
+		public AssertCountCollectionIterator(IEnumerable<T> source, int count)
+		{
+			_source = source;
+			_count = count;
+		}
+
+		public override int Count
+		{
+			get
 			{
-				c = 0;
-				foreach (var item in source)
-				{
-					if (++c > count)
-						break;
-					yield return item;
-				}
-				Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+				Guard.IsEqualTo(_source.GetCollectionCount(), _count, "source.Count()");
+				return _count;
 			}
+		}
+
+		protected override IEnumerable<T> GetEnumerable()
+		{
+			Guard.IsEqualTo(_source.GetCollectionCount(), _count, "source.Count()");
+
+			foreach (var item in _source)
+				yield return item;
+		}
+
+		public override void CopyTo(T[] array, int arrayIndex)
+		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, Count - 1);
+
+			_ = _source.CopyTo(array, arrayIndex);
+		}
+	}
+
+	private class AssertCountListIterator<T> : ListIterator<T>
+	{
+		private readonly IList<T> _source;
+		private readonly int _count;
+
+		public AssertCountListIterator(IList<T> source, int count)
+		{
+			_source = source;
+			_count = count;
+		}
+
+		public override int Count
+		{
+			get
+			{
+				Guard.IsEqualTo(_source.Count, _count, "source.Count()");
+				return _count;
+			}
+		}
+
+		protected override IEnumerable<T> GetEnumerable()
+		{
+			var cnt = (uint)Count;
+			for (var i = 0; i < cnt; i++)
+			{
+				yield return _source[i];
+			}
+		}
+
+		public override void CopyTo(T[] array, int arrayIndex)
+		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, Count - 1);
+
+			_source.CopyTo(array, arrayIndex);
+		}
+
+		protected override T ElementAt(int index)
+		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			return _source[index];
 		}
 	}
 }

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -58,16 +58,17 @@ public class AssertCountTest
 	}
 
 	[Fact]
-	public void AssertCountNarrowCollectionBehavior()
+	public void AssertCountCollectionBehavior()
 	{
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.AssertCount(10_000);
 		Assert.Equal(10_000, result.Count());
+		result.AssertSequenceEqual(Enumerable.Range(0, 10_000));
 	}
 
 	[Fact]
-	public void AssertCountNarrowListBehavior()
+	public void AssertCountListBehavior()
 	{
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -15,20 +15,9 @@ public class AssertCountTest
 			() => new BreakingSequence<int>().AssertCount(-1));
 	}
 
-	[Fact]
-	public void AssertCountSequenceWithMatchingLength()
-	{
-		var data = new[] { "foo", "bar", "baz" };
-		data.AssertCount(3).Consume();
-		using (var xs = data.AsTestingSequence())
-			xs.AssertCount(3).Consume();
-		using (var xs = data.AsTestingCollection())
-			xs.AssertCount(3).Consume();
-	}
-
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.GetBreakingCollectionSequences()
+			.GetAllSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -37,8 +26,22 @@ public class AssertCountTest
 	{
 		using (seq)
 		{
+			var result = seq.AssertCount(11);
 			_ = Assert.Throws<ArgumentException>("source.Count()",
-				() => seq.AssertCount(11).Consume());
+				() => result.Consume());
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void AssertCountEqualSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.AssertCount(10);
+			result.AssertSequenceEqual(
+				Enumerable.Range(1, 10),
+				testCollectionEnumerable: true);
 		}
 	}
 
@@ -48,9 +51,35 @@ public class AssertCountTest
 	{
 		using (seq)
 		{
+			var result = seq.AssertCount(9);
 			_ = Assert.Throws<ArgumentException>("source.Count()",
-				() => seq.AssertCount(9).Consume());
+				() => result.Consume());
 		}
+	}
+
+	[Fact]
+	public void AssertCountNarrowCollectionBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.AssertCount(10_000);
+		Assert.Equal(10_000, result.Count());
+	}
+
+	[Fact]
+	public void AssertCountNarrowListBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq.AssertCount(10_000);
+		Assert.Equal(10_000, result.Count());
+		Assert.Equal(200, result.ElementAt(200));
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(40_001));
 	}
 
 	[Fact]
@@ -58,6 +87,8 @@ public class AssertCountTest
 	{
 		var stack = new Stack<int>(Enumerable.Range(1, 3));
 		var result = stack.AssertCount(4);
+		_ = Assert.Throws<ArgumentException>("source.Count()",
+			() => result.Consume());
 		stack.Push(4);
 		result.Consume();
 	}


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `AssertCount`, which improves memory usage and performance. 

Fixes #368 

```
// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```

|               Method |              source1 |     N |           Mean |       Error |      StdDev |   Gen0 |   Gen1 | Allocated |
|--------------------- |--------------------- |------ |---------------:|------------:|------------:|-------:|-------:|----------:|
|     AssertCountCount | Syste(...)nt32] [47] | 10000 |       9.315 ns |   0.1111 ns |   0.0928 ns | 0.0025 | 0.0000 |      32 B |
|     AssertCountCount | Syste(...)nt32] [62] | 10000 |  93,450.214 ns | 240.7976 ns | 201.0769 ns |      - |      - |     160 B |
|    AssertCountCopyTo | Syste(...)nt32] [47] | 10000 |   1,982.281 ns |  20.8584 ns |  19.5109 ns | 3.1815 | 0.0038 |   40056 B |
|    AssertCountCopyTo | Syste(...)nt32] [62] | 10000 | 111,738.183 ns | 354.8046 ns | 314.5251 ns | 8.4229 | 0.8545 |  106344 B |
| AssertCountElementAt | Syste(...)nt32] [47] | 10000 |      14.817 ns |   0.1419 ns |   0.1327 ns | 0.0025 | 0.0000 |      32 B |
| AssertCountElementAt | Syste(...)nt32] [62] | 10000 |  70,984.471 ns | 196.4768 ns | 174.1716 ns |      - |      - |     160 B |


<details>
<summary>Code</summary>

```csharp
#load "BenchmarkDotNet"

void Main()
{
	RunBenchmark();
}

public IEnumerable<object[]> EnumerableArguments()
{
	foreach (var i in new[] { 10_000, })
	{
		yield return new object[]
		{
			Enumerable.Range(1, i).Where(_ => true),
			i,
		};
		yield return new object[]
		{
			Enumerable.Range(1, i).ToList(),
			i,
		};
	}
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void AssertCountCount(IEnumerable<int> source1, int N)
{
	_ = source1.AssertCount(10_000).Count();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void AssertCountCopyTo(IEnumerable<int> source1, int N)
{
	_ = source1.AssertCount(10_000).ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(EnumerableArguments))]
public void AssertCountElementAt(IEnumerable<int> source1, int N)
{
	_ = source1.AssertCount(10_000).ElementAt(8_000);
}
```
</details>