### PR TITLE
`Insert`: `IList<>` implementation

### DIFF
--- a/Tests/SuperLinq.Test/InsertTest.cs
+++ b/Tests/SuperLinq.Test/InsertTest.cs
@@ -3,66 +3,135 @@
 public class InsertTest
 {
 	[Fact]
+	public void InsertIsLazy()
+	{
+		_ = new BreakingSequence<int>().Insert(new BreakingSequence<int>(), 0);
+	}
+
+	[Fact]
 	public void InsertWithNegativeIndex()
 	{
 		_ = Assert.Throws<ArgumentOutOfRangeException>(() =>
 			 new BreakingSequence<int>().Insert(new[] { 97, 98, 99 }, -1));
 	}
 
-	[Fact]
-	public void InsertWithIndexGreaterThanSourceLengthMaterialized()
+	public static IEnumerable<object[]> GetSequences()
 	{
-		var seq1 = Enumerable.Range(0, 10).ToList();
-		var seq2 = new[] { 97, 98, 99 };
+		var baseSeq = Enumerable.Range(0, 10);
+		var insSeq = Seq(97, 98, 99);
 
-		using var test1 = seq1.AsTestingSequence();
-		using var test2 = seq2.AsTestingSequence();
-
-		var result = test1.Insert(test2, 11);
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(delegate
+		return new List<object[]>
 		{
-			foreach (var (index, e) in result.Index())
-				Assert.Equal(seq1[index], e);
-		});
-	}
-
-	[Fact]
-	public void InsertWithIndexGreaterThanSourceLengthLazy()
-	{
-		var seq1 = Enumerable.Range(0, 10);
-		var seq2 = new[] { 97, 98, 99 };
-
-		using var test1 = seq1.AsTestingSequence();
-		using var test2 = seq2.AsTestingSequence();
-
-		var result = test1.Insert(test2, 11).Take(10);
-
-		Assert.Equal(result, seq1);
+			new object[] { baseSeq.AsTestingSequence(maxEnumerations: 2), insSeq.AsTestingSequence(maxEnumerations: 2), },
+			new object[] { baseSeq.AsTestingCollection(maxEnumerations: 2), insSeq.AsTestingCollection(maxEnumerations: 2), },
+			new object[] { baseSeq.AsBreakingList(), insSeq.AsBreakingList(), },
+		};
 	}
 
 	[Theory]
-	[InlineData(3, 0)]
-	[InlineData(3, 1)]
-	[InlineData(3, 2)]
-	[InlineData(3, 3)]
-	public void Insert(int count, int index)
+	[MemberData(nameof(GetSequences))]
+	public void InsertWithIndexGreaterThanSourceLength(
+		IDisposableEnumerable<int> seq1,
+		IDisposableEnumerable<int> seq2)
 	{
-		var seq1 = Enumerable.Range(1, count);
-		var seq2 = new[] { 97, 98, 99 };
+		using (seq1)
+		using (seq2)
+		{
+			var result = seq1.Insert(seq2, 11);
 
-		using var test1 = seq1.AsTestingSequence();
-		using var test2 = seq2.AsTestingSequence();
+			_ = Assert.Throws<ArgumentOutOfRangeException>(delegate
+			{
+				result.AssertSequenceEqual(Enumerable.Range(0, 10));
+			});
+		}
+	}
 
-		var result = test1.Insert(test2, index);
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void InsertWithEndIndexGreaterThanSourceLength(
+		IDisposableEnumerable<int> seq1,
+		IDisposableEnumerable<int> seq2)
+	{
+		using (seq1)
+		using (seq2)
+		{
+			var result = seq1.Insert(seq2, ^11);
 
-		var expectations = seq1.Take(index).Concat(seq2).Concat(seq1.Skip(index));
-		Assert.Equal(expectations, result);
+			_ = Assert.Throws<ArgumentOutOfRangeException>(delegate
+			{
+				result.AssertSequenceEqual(Enumerable.Range(0, 10));
+			});
+		}
+	}
+
+	public static IEnumerable<object[]> GetInsertData() =>
+		Seq(0, 5, 10, ^0, ^5, ^10)
+			.SelectMany(
+				_ => GetSequences(),
+				(i, x) => new object[] { x[0], x[1], i });
+
+	[Theory]
+	[MemberData(nameof(GetInsertData))]
+	public void Insert(
+		IDisposableEnumerable<int> seq1,
+		IDisposableEnumerable<int> seq2,
+		Index index)
+	{
+		using (seq1)
+		using (seq2)
+		{
+			var result = seq1.Insert(seq2, index);
+			var idx = index.GetOffset(10);
+
+			result.AssertSequenceEqual(
+				Enumerable.Range(0, idx)
+					.Concat(Seq(97, 98, 99))
+					.Concat(Enumerable.Range(idx, 10 - idx)),
+				testCollectionEnumerable: true);
+		}
 	}
 
 	[Fact]
-	public void InsertIsLazy()
+	public void InsertCollectionBehavior()
 	{
-		_ = new BreakingSequence<int>().Insert(new BreakingSequence<int>(), 0);
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingCollection();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq1.Insert(seq2, 5_000);
+		Assert.Equal(20_000, result.Count());
+	}
+
+	[Fact]
+	public void InsertListFromStartBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.Insert(seq2, 5_000);
+		Assert.Equal(20_000, result.Count());
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(6_200, result.ElementAt(11_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(20_000));
+	}
+
+	[Fact]
+	public void InsertListFromEndBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.Insert(seq2, ^5_000);
+		Assert.Equal(20_000, result.Count());
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(6_200, result.ElementAt(11_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
+
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(20_000));
 	}
 }


### PR DESCRIPTION
This PR adds an `IList<>` implementation of `Insert`, which improves memory usage and performance. 

Fixes #455 
