### PR TITLE
Improve `ICollection<>` error checking

### DIFF
--- a/Generators/SuperLinq.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipLongest.sbntxt
@@ -125,7 +125,7 @@ public static partial class SuperEnumerable
 			{{~ end ~}}) =>
 		ZipLongest({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
 
-	private class ZipLongestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
+	private sealed class ZipLongestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
 	{
 		{{~ for $j in 1..$i ~}}
 		private readonly global::System.Collections.Generic.IList<T{{ $j }}> _list{{ $j }};
@@ -160,7 +160,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+			global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipShortest.sbntxt
@@ -110,7 +110,7 @@ public static partial class SuperEnumerable
 			{{~ end ~}}) =>
 		ZipShortest({{~ for $j in 1..$i ~}}{{ $ordinals[$j] }}, {{ end }}global::System.ValueTuple.Create);
 
-	private class ZipShortestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
+	private sealed class ZipShortestIterator<{{ for $j in 1..$i }}T{{ $j }}, {{ end }}TResult> : ListIterator<TResult>
 	{
 		{{~ for $j in 1..$i ~}}
 		private readonly global::System.Collections.Generic.IList<T{{ $j }}> _list{{ $j }};
@@ -145,7 +145,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+			global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -45,7 +45,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class AssertCountCollectionIterator<T> : CollectionIterator<T>
+	private sealed class AssertCountCollectionIterator<T> : CollectionIterator<T>
 	{
 		private readonly IEnumerable<T> _source;
 		private readonly int _count;
@@ -76,13 +76,13 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			Guard.IsNotNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, Count - 1);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_ = _source.CopyTo(array, arrayIndex);
 		}
 	}
 
-	private class AssertCountListIterator<T> : ListIterator<T>
+	private sealed class AssertCountListIterator<T> : ListIterator<T>
 	{
 		private readonly IList<T> _source;
 		private readonly int _count;
@@ -114,7 +114,7 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			Guard.IsNotNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, Count - 1);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 		}

--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -31,7 +31,7 @@ public partial class SuperEnumerable
 		public virtual void CopyTo(T[] array, int arrayIndex)
 		{
 			Guard.IsNotNull(array);
-			Guard.IsGreaterThanOrEqualTo(arrayIndex, 0);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			if (Count + arrayIndex > array.Length)
 				ThrowHelper.ThrowArgumentException(nameof(array), "Destination is not long enough.");

--- a/Source/SuperLinq/CountDown.cs
+++ b/Source/SuperLinq/CountDown.cs
@@ -161,6 +161,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 			return _resultSelector(
 				_source[index],
 				_source.Count - index < _count ? _source.Count - index - 1 : null);

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -144,7 +144,7 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			Guard.IsNotNull(array);
-			Guard.IsGreaterThanOrEqualTo(arrayIndex, 0);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 

--- a/Source/SuperLinq/FillForward.cs
+++ b/Source/SuperLinq/FillForward.cs
@@ -132,7 +132,7 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			Guard.IsNotNull(array);
-			Guard.IsGreaterThanOrEqualTo(arrayIndex, 0);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
@@ -77,7 +77,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T2">The type of the elements of <paramref name = "second"/>.</typeparam>
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? )> ZipLongest<T1, T2>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second) => ZipLongest(first, second, global::System.ValueTuple.Create);
-    private class ZipLongestIterator<T1, T2, TResult> : ListIterator<TResult>
+    private sealed class ZipLongestIterator<T1, T2, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -102,7 +102,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default);
         }
     }
@@ -177,7 +177,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T3">The type of the elements of <paramref name = "third"/>.</typeparam>
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? , T3? )> ZipLongest<T1, T2, T3>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third) => ZipLongest(first, second, third, global::System.ValueTuple.Create);
-    private class ZipLongestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
+    private sealed class ZipLongestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -204,7 +204,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default);
         }
     }
@@ -286,7 +286,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "T4">The type of the elements of <paramref name = "fourth"/>.</typeparam>
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(T1? , T2? , T3? , T4? )> ZipLongest<T1, T2, T3, T4>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth) => ZipLongest(first, second, third, fourth, global::System.ValueTuple.Create);
-    private class ZipLongestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
+    private sealed class ZipLongestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -315,7 +315,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default, index < _list4.Count ? _list4[index] : default);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
@@ -61,7 +61,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TSecond">The type of the elements of <paramref name = "second"/>.</typeparam>
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond)> ZipShortest<TFirst, TSecond>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second) => ZipShortest(first, second, global::System.ValueTuple.Create);
-    private class ZipShortestIterator<T1, T2, TResult> : ListIterator<TResult>
+    private sealed class ZipShortestIterator<T1, T2, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -86,7 +86,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index]);
         }
     }
@@ -156,7 +156,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TThird">The type of the elements of <paramref name = "third"/>.</typeparam>
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird)> ZipShortest<TFirst, TSecond, TThird>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third) => ZipShortest(first, second, third, global::System.ValueTuple.Create);
-    private class ZipShortestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
+    private sealed class ZipShortestIterator<T1, T2, T3, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -183,7 +183,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index], _list3[index]);
         }
     }
@@ -259,7 +259,7 @@ public static partial class SuperEnumerable
     /// <typeparam name = "TFourth">The type of the elements of <paramref name = "fourth"/>.</typeparam>
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<(TFirst, TSecond, TThird, TFourth)> ZipShortest<TFirst, TSecond, TThird, TFourth>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth) => ZipShortest(first, second, third, fourth, global::System.ValueTuple.Create);
-    private class ZipShortestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
+    private sealed class ZipShortestIterator<T1, T2, T3, T4, TResult> : ListIterator<TResult>
     {
         private readonly global::System.Collections.Generic.IList<T1> _list1;
         private readonly global::System.Collections.Generic.IList<T2> _list2;
@@ -288,7 +288,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
         }
     }

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -130,7 +130,7 @@ public static partial class SuperEnumerable
 			yield return iter.Current;
 	}
 
-	private class InsertCollectionIterator<T> : CollectionIterator<T>
+	private sealed class InsertCollectionIterator<T> : CollectionIterator<T>
 	{
 		private readonly IEnumerable<T> _first;
 		private readonly IEnumerable<T> _second;
@@ -179,7 +179,7 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class InsertListIterator<T> : ListIterator<T>
+	private sealed class InsertListIterator<T> : ListIterator<T>
 	{
 		private readonly IList<T> _first;
 		private readonly IList<T> _second;

--- a/Source/SuperLinq/Lag.cs
+++ b/Source/SuperLinq/Lag.cs
@@ -107,9 +107,12 @@ public static partial class SuperEnumerable
 					i < _offset ? _defaultLagValue : _source[i - _offset]);
 		}
 
-		protected override TResult ElementAt(int index) =>
-			_resultSelector(
+		protected override TResult ElementAt(int index)
+		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			return _resultSelector(
 				_source[index],
 				index < _offset ? _defaultLagValue : _source[index - _offset]);
+		}
 	}
 }

--- a/Source/SuperLinq/Lead.cs
+++ b/Source/SuperLinq/Lead.cs
@@ -116,11 +116,14 @@ public static partial class SuperEnumerable
 					i < maxOffset ? _source[i + _offset] : _defaultLeadValue);
 		}
 
-		protected override TResult ElementAt(int index) =>
-			_resultSelector(
+		protected override TResult ElementAt(int index)
+		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			return _resultSelector(
 				_source[index],
 				index < Math.Max(_source.Count - _offset, 0)
 					? _source[index + _offset]
 					: _defaultLeadValue);
+		}
 	}
 }

--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -191,7 +191,7 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsLessThan(index, Count);
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 			return index < _source.Count
 				? _source[index]
 				: _paddingSelector(index);

--- a/Source/SuperLinq/PadStart.cs
+++ b/Source/SuperLinq/PadStart.cs
@@ -213,7 +213,7 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsLessThan(index, Count);
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 
 			var offset = Math.Max(_width - _source.Count, 0);
 			return index < offset

--- a/Source/SuperLinq/PreScan.cs
+++ b/Source/SuperLinq/PreScan.cs
@@ -93,6 +93,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			var (sList, b, cnt) = _source is IList<T> s
 				? (s, 0, s.Count)
 				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -135,6 +135,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(TSource[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			_source.CopyTo(array, arrayIndex);
 
 			var idx = _index.GetOffset(_source.Count);

--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -67,6 +67,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			var (sList, b, cnt) = _source is IList<T> s
 				? (s, 0, s.Count)
 				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));
@@ -173,6 +176,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(TState[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			var list = _source is IList<TSource> l ? l : _source.ToList();
 
 			var state = _state;

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -79,6 +79,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			var (sList, b, cnt) = _source is IList<T> s
 				? (s, 0, s.Count)
 				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));
@@ -168,6 +171,9 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(TAccumulate[] array, int arrayIndex)
 		{
+			Guard.IsNotNull(array);
+			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+
 			var list = _source is IList<TSource> l ? l : _source.ToList();
 
 			var seed = _seed;

--- a/Source/SuperLinq/Sequence.cs
+++ b/Source/SuperLinq/Sequence.cs
@@ -78,7 +78,7 @@ public static partial class SuperEnumerable
 		return new SequenceIterator(start, step, (((long)stop - start) / step) + 1);
 	}
 
-	private class SequenceIterator : ListIterator<int>
+	private sealed class SequenceIterator : ListIterator<int>
 	{
 		private readonly int _start;
 		private readonly int _step;

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -60,6 +60,8 @@ public static partial class SuperEnumerable
 
 		protected override (TSource, TResult) ElementAt(int index)
 		{
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+
 			var el = _source[index];
 			return (el, _selector(el));
 		}

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -63,7 +63,7 @@ public class AssertCountTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.AssertCount(10_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 		result.AssertSequenceEqual(Enumerable.Range(0, 10_000));
 	}
 
@@ -73,14 +73,12 @@ public class AssertCountTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.AssertCount(10_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(200, result.ElementAt(200));
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(40_001));
 	}
 
 	[Fact]

--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -186,7 +186,10 @@ public class BatchTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Batch(20);
-		Assert.Equal(10_000 / 20, result.Count());
+		var length = 10_000 / 20;
+		result.AssertCollectionErrorChecking(length);
+		result.AssertListElementChecking(length);
+
 		Assert.Equal(Enumerable.Range(1_000, 20), result.ElementAt(50));
 		Assert.Equal(Enumerable.Range(9_980, 20), result.ElementAt(^1));
 	}
@@ -197,7 +200,10 @@ public class BatchTest
 		using var seq = Enumerable.Range(0, 10_002).AsBreakingList();
 
 		var result = seq.Batch(20);
-		Assert.Equal((10_002 / 20) + 1, result.Count());
+		var length = (10_002 / 20) + 1;
+		result.AssertCollectionErrorChecking(length);
+		result.AssertListElementChecking(length);
+
 		Assert.Equal(Enumerable.Range(1_000, 20), result.ElementAt(50));
 		Assert.Equal(Enumerable.Range(9_980, 20), result.ElementAt(^2));
 		Assert.Equal(Enumerable.Range(10_000, 2), result.ElementAt(^1));

--- a/Tests/SuperLinq.Test/BreakingList.cs
+++ b/Tests/SuperLinq.Test/BreakingList.cs
@@ -17,7 +17,13 @@ internal class BreakingList<T> : BreakingSequence<T>, IList<T>, IDisposableEnume
 
 	public T this[int index]
 	{
-		get => List[index];
+		get
+		{
+			if (index < 0 || index >= List.Count)
+				Assert.Fail("LINQ Operators should prevent this from happening.");
+			return List[index];
+		}
+
 		set => Assert.Fail("LINQ Operators should not be calling this method.");
 	}
 

--- a/Tests/SuperLinq.Test/CountDownTest.cs
+++ b/Tests/SuperLinq.Test/CountDownTest.cs
@@ -60,7 +60,7 @@ public class CountDownTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.CountDown(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 	}
 
 	[Fact]
@@ -69,7 +69,9 @@ public class CountDownTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.CountDown(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((10, default(int?)), result.ElementAt(10));
 		Assert.Equal((50, default(int?)), result.ElementAt(50));
 		Assert.Equal((9_995, 4), result.ElementAt(^5));

--- a/Tests/SuperLinq.Test/DoTest.cs
+++ b/Tests/SuperLinq.Test/DoTest.cs
@@ -113,9 +113,9 @@ public class DoTest
 			.AsBreakingCollection();
 
 		var result = sequence.Do(delegate { });
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 
 		result = sequence.Do(delegate { }, onError: delegate { });
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/ExcludeTest.cs
+++ b/Tests/SuperLinq.Test/ExcludeTest.cs
@@ -114,7 +114,9 @@ public class ExcludeTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Exclude(1_001, 1_000);
-		Assert.Equal(9_000, result.Count());
+		result.AssertCollectionErrorChecking(9_000);
+		result.AssertListElementChecking(9_000);
+
 		Assert.Equal(10, result.ElementAt(10));
 		Assert.Equal(1_000, result.ElementAt(1_000));
 		Assert.Equal(2_001, result.ElementAt(1_001));
@@ -128,7 +130,9 @@ public class ExcludeTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Exclude(9_500, 1_000);
-		Assert.Equal(9_500, result.Count());
+		result.AssertCollectionErrorChecking(9_500);
+		result.AssertListElementChecking(9_500);
+
 		Assert.Equal(10, result.ElementAt(10));
 		Assert.Equal(9_450, result.ElementAt(^50));
 	}
@@ -139,7 +143,9 @@ public class ExcludeTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Exclude(15_000, 1_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(10, result.ElementAt(10));
 		Assert.Equal(9_950, result.ElementAt(^50));
 	}
@@ -150,11 +156,10 @@ public class ExcludeTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Exclude(0, 10_000);
+		result.AssertCollectionErrorChecking(0);
 
-#pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
-		Assert.Equal(0, result.Count());
-#pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>("index", () => result.ElementAt(0));
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"index",
+			() => result.ElementAt(0));
 	}
 }

--- a/Tests/SuperLinq.Test/FillBackwardTest.cs
+++ b/Tests/SuperLinq.Test/FillBackwardTest.cs
@@ -55,4 +55,14 @@ public class FillBackwardTest
 				.AssertSequenceEqual(5, 10, 15, 20, 5, 60, 70, 80, 90, 10, 11, 12, 13);
 		}
 	}
+
+	[Fact]
+	public void FillBackwardCollectionCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.FillBackward();
+		result.AssertCollectionErrorChecking(10_000);
+	}
 }

--- a/Tests/SuperLinq.Test/FillForwardTest.cs
+++ b/Tests/SuperLinq.Test/FillForwardTest.cs
@@ -100,4 +100,14 @@ public class FillForwardTest
 				new { Continent = "Africa", Country = "Egypt", City = "Alexandria", Value = 890 },
 				new { Continent = "Africa", Country = "Kenya", City = "Nairobi", Value = 901 });
 	}
+
+	[Fact]
+	public void FillForwardCollectionCount()
+	{
+		using var sequence = Enumerable.Range(1, 10_000)
+			.AsBreakingCollection();
+
+		var result = sequence.FillForward();
+		result.AssertCollectionErrorChecking(10_000);
+	}
 }

--- a/Tests/SuperLinq.Test/InsertTest.cs
+++ b/Tests/SuperLinq.Test/InsertTest.cs
@@ -98,7 +98,7 @@ public class InsertTest
 		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq1.Insert(seq2, 5_000);
-		Assert.Equal(20_000, result.Count());
+		result.AssertCollectionErrorChecking(20_000);
 	}
 
 	[Fact]
@@ -108,14 +108,12 @@ public class InsertTest
 		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq1.Insert(seq2, 5_000);
-		Assert.Equal(20_000, result.Count());
+		result.AssertCollectionErrorChecking(20_000);
+		result.AssertListElementChecking(20_000);
+
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(6_200, result.ElementAt(11_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(20_000));
 	}
 
 	[Fact]
@@ -125,13 +123,26 @@ public class InsertTest
 		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq1.Insert(seq2, ^5_000);
-		Assert.Equal(20_000, result.Count());
+		result.AssertCollectionErrorChecking(20_000);
+		result.AssertListElementChecking(20_000);
+
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(6_200, result.ElementAt(11_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
+	}
 
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(20_000));
+	[Fact]
+	public void InsertListAtEndBehavior()
+	{
+		using var seq1 = Enumerable.Range(0, 10_000).AsBreakingList();
+		using var seq2 = Enumerable.Range(0, 10_000).AsBreakingList();
+
+		var result = seq1.Insert(seq2, ^0);
+		result.AssertCollectionErrorChecking(20_000);
+		result.AssertListElementChecking(20_000);
+
+		Assert.Equal(1_200, result.ElementAt(1_200));
+		Assert.Equal(1_200, result.ElementAt(11_200));
+		Assert.Equal(8_800, result.ElementAt(^1_200));
 	}
 }

--- a/Tests/SuperLinq.Test/InterleaveTest.cs
+++ b/Tests/SuperLinq.Test/InterleaveTest.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Verify the behavior of the Interleave operator
 /// </summary>
-public class InterleaveTests
+public class InterleaveTest
 {
 	/// <summary>
 	/// Verify that Interleave behaves in a lazy manner
@@ -132,13 +132,13 @@ public class InterleaveTests
 	[Fact]
 	public void TestInterleaveCollectionCount()
 	{
-		using var sequenceA = Enumerable.Range(1, 100).AsBreakingCollection();
-		using var sequenceB = Enumerable.Range(1, 100).AsBreakingCollection();
+		using var sequenceA = Enumerable.Range(1, 10_000).AsBreakingCollection();
+		using var sequenceB = Enumerable.Range(1, 10_000).AsBreakingCollection();
 
-		var coll = sequenceA.Interleave(sequenceB);
-		Assert.Equal(200, coll.Count());
+		var result = sequenceA.Interleave(sequenceB);
+		result.AssertCollectionErrorChecking(20_000);
 
-		coll = Seq(sequenceA, sequenceB).Interleave<int>();
-		Assert.Equal(200, coll.Count());
+		result = Seq(sequenceA, sequenceB).Interleave<int>();
+		result.AssertCollectionErrorChecking(20_000);
 	}
 }

--- a/Tests/SuperLinq.Test/LagTest.cs
+++ b/Tests/SuperLinq.Test/LagTest.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Verify the behavior of the Lag operator
 /// </summary>
-public class LagTests
+public class LagTest
 {
 	/// <summary>
 	/// Verify that lag behaves in a lazy manner.
@@ -156,7 +156,9 @@ public class LagTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Lag(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((10, 0), result.ElementAt(10));
 		Assert.Equal((50, 30), result.ElementAt(50));
 		Assert.Equal((9_950, 9_930), result.ElementAt(^50));

--- a/Tests/SuperLinq.Test/LeadTest.cs
+++ b/Tests/SuperLinq.Test/LeadTest.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Verify the behavior of the Lead operator.
 /// </summary>
-public class LeadTests
+public class LeadTest
 {
 	/// <summary>
 	/// Verify that Lead() behaves in a lazy manner.
@@ -159,7 +159,9 @@ public class LeadTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Lead(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((50, 70), result.ElementAt(50));
 		Assert.Equal((9_950, 9_970), result.ElementAt(^50));
 		Assert.Equal((9_990, 0), result.ElementAt(^10));

--- a/Tests/SuperLinq.Test/PadStartTest.cs
+++ b/Tests/SuperLinq.Test/PadStartTest.cs
@@ -41,7 +41,7 @@ public class PadStartTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.PadStart(5_000, x => x % 1_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 	}
 
 	[Fact]
@@ -50,13 +50,11 @@ public class PadStartTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.PadStart(5_000, x => x % 1_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(10_001));
 	}
 
 	[Theory]
@@ -104,7 +102,7 @@ public class PadStartTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.PadStart(40_000, x => x % 1_000);
-		Assert.Equal(40_000, result.Count());
+		result.AssertCollectionErrorChecking(40_000);
 	}
 
 	[Fact]
@@ -113,14 +111,12 @@ public class PadStartTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.PadStart(40_000, x => x % 1_000);
-		Assert.Equal(40_000, result.Count());
+		result.AssertCollectionErrorChecking(40_000);
+		result.AssertListElementChecking(40_000);
+
 		Assert.Equal(200, result.ElementAt(1_200));
 		Assert.Equal(1_200, result.ElementAt(31_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(40_001));
 	}
 
 	public static IEnumerable<object[]> GetCharSequences() =>

--- a/Tests/SuperLinq.Test/PadTest.cs
+++ b/Tests/SuperLinq.Test/PadTest.cs
@@ -36,18 +36,25 @@ public class PadTest
 	}
 
 	[Fact]
+	public void PadWideCollectionBehavior()
+	{
+		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
+
+		var result = seq.Pad(5_000, x => x % 1_000);
+		result.AssertCollectionErrorChecking(10_000);
+	}
+
+	[Fact]
 	public void PadWideListBehavior()
 	{
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Pad(5_000, x => x % 1_000);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(8_800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(10_001));
 	}
 
 	[Theory]
@@ -95,7 +102,7 @@ public class PadTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
 		var result = seq.Pad(40_000, x => x % 1_000);
-		Assert.Equal(40_000, result.Count());
+		result.AssertCollectionErrorChecking(40_000);
 	}
 
 	[Fact]
@@ -104,14 +111,12 @@ public class PadTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Pad(40_000, x => x % 1_000);
-		Assert.Equal(40_000, result.Count());
+		result.AssertCollectionErrorChecking(40_000);
+		result.AssertListElementChecking(40_000);
+
 		Assert.Equal(1_200, result.ElementAt(1_200));
 		Assert.Equal(200, result.ElementAt(11_200));
 		Assert.Equal(800, result.ElementAt(^1_200));
-
-		_ = Assert.Throws<ArgumentOutOfRangeException>(
-			"index",
-			() => result.ElementAt(40_001));
 	}
 
 	public static IEnumerable<object[]> GetCharSequences() =>

--- a/Tests/SuperLinq.Test/PreScanTest.cs
+++ b/Tests/SuperLinq.Test/PreScanTest.cs
@@ -63,7 +63,7 @@ public class PreScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
 		var result = seq.PreScan((a, b) => a + b, 5);
-		Assert.Equal(10, result.Count());
+		result.AssertCollectionErrorChecking(10);
 
 		result.ToArray()
 			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50);
@@ -82,7 +82,7 @@ public class PreScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingList();
 
 		var result = seq.PreScan((a, b) => a + b, 5);
-		Assert.Equal(10, result.Count());
+		result.AssertCollectionErrorChecking(10);
 
 		result.ToArray()
 			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50);

--- a/Tests/SuperLinq.Test/RankTest.cs
+++ b/Tests/SuperLinq.Test/RankTest.cs
@@ -152,9 +152,9 @@ public class RankTests
 			.AsBreakingCollection();
 
 		var result = sequence.Rank();
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 
 		result = sequence.Rank(comparer: Comparer<int>.Default);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/ReplaceTest.cs
+++ b/Tests/SuperLinq.Test/ReplaceTest.cs
@@ -121,7 +121,9 @@ public class ReplaceTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Replace(20, -1);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(10, result.ElementAt(10));
 		Assert.Equal(-1, result.ElementAt(20));
 		Assert.Equal(9_950, result.ElementAt(^50));

--- a/Tests/SuperLinq.Test/ScanByTest.cs
+++ b/Tests/SuperLinq.Test/ScanByTest.cs
@@ -121,6 +121,6 @@ public class ScanByTest
 			.AsBreakingCollection();
 
 		var result = sequence.ScanBy(x => x, x => x, (a, b, c) => a);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/ScanRightTest.cs
+++ b/Tests/SuperLinq.Test/ScanRightTest.cs
@@ -62,7 +62,7 @@ public class ScanRightTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
 		var result = seq.ScanRight((a, b) => a + b);
-		Assert.Equal(10, result.Count());
+		result.AssertCollectionErrorChecking(10);
 
 		result.ToArray()
 			.AssertSequenceEqual(55, 54, 52, 49, 45, 40, 34, 27, 19, 10);
@@ -151,7 +151,7 @@ public class ScanRightTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
 		var result = seq.ScanRight(5, (a, b) => a + b);
-		Assert.Equal(11, result.Count());
+		result.AssertCollectionErrorChecking(11);
 
 		result.ToArray()
 			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);
@@ -170,7 +170,7 @@ public class ScanRightTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingList();
 
 		var result = seq.ScanRight(5, (a, b) => a + b);
-		Assert.Equal(11, result.Count());
+		result.AssertCollectionErrorChecking(11);
 
 		result.ToArray()
 			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);

--- a/Tests/SuperLinq.Test/ScanTest.cs
+++ b/Tests/SuperLinq.Test/ScanTest.cs
@@ -43,7 +43,7 @@ public class ScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
 		var result = seq.Scan((a, b) => a + b);
-		Assert.Equal(10, result.Count());
+		result.AssertCollectionErrorChecking(10);
 
 		result.ToArray()
 			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
@@ -62,7 +62,7 @@ public class ScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingList();
 
 		var result = seq.Scan((a, b) => a + b);
-		Assert.Equal(10, result.Count());
+		result.AssertCollectionErrorChecking(10);
 
 		result.ToArray()
 			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
@@ -115,7 +115,7 @@ public class ScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
 
 		var result = seq.Scan(5, (a, b) => a + b);
-		Assert.Equal(11, result.Count());
+		result.AssertCollectionErrorChecking(11);
 
 		result.ToArray()
 			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);
@@ -134,7 +134,7 @@ public class ScanTest
 		using var seq = Enumerable.Range(1, 10).AsBreakingList();
 
 		var result = seq.Scan(5, (a, b) => a + b);
-		Assert.Equal(11, result.Count());
+		result.AssertCollectionErrorChecking(11);
 
 		result.ToArray()
 			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);

--- a/Tests/SuperLinq.Test/SequenceTest.cs
+++ b/Tests/SuperLinq.Test/SequenceTest.cs
@@ -165,4 +165,16 @@ public class SequenceTest
 
 		Assert.True(result.Take(100).All(x => x == start));
 	}
+
+	[Fact]
+	public void SequenceListBehavior()
+	{
+		var result = SuperEnumerable.Sequence(0, 9_999);
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
+		Assert.Equal(10, result.ElementAt(10));
+		Assert.Equal(20, result.ElementAt(20));
+		Assert.Equal(9_950, result.ElementAt(^50));
+	}
 }

--- a/Tests/SuperLinq.Test/TagFirstLastTest.cs
+++ b/Tests/SuperLinq.Test/TagFirstLastTest.cs
@@ -35,7 +35,9 @@ public class TagFirstLastTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.TagFirstLast();
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((0, true, false), result.ElementAt(0));
 		Assert.Equal((30, false, false), result.ElementAt(30));
 		Assert.Equal((9_999, false, true), result.ElementAt(^1));

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Test;
+﻿using CommunityToolkit.Diagnostics;
+
+namespace Test;
 
 public enum SourceKind
 {
@@ -8,6 +10,7 @@ public enum SourceKind
 
 internal static partial class TestExtensions
 {
+	#region Sequences
 	internal static IEnumerable<T> Seq<T>(params T[] values) => values;
 
 	public static IEnumerable<int> SeqExceptionAt(int index) =>
@@ -16,17 +19,12 @@ internal static partial class TestExtensions
 				.Select(i => Func(() => i))
 				.Append(BreakingFunc.Of<int>())
 				.ToArray());
+	#endregion
 
-	/// <summary>
-	/// Just to make our testing easier so we can chain the assertion call.
-	/// </summary>
+	#region Sequence Content Validation
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool testCollectionEnumerable = false) =>
 		actual.AssertSequenceEqual(expected as IList<T> ?? expected.ToList(), testCollectionEnumerable);
 
-	/// <summary>
-	/// Make testing even easier - a params array makes for readable tests :)
-	/// The sequence should be evaluated exactly once.
-	/// </summary>
 	internal static void AssertSequenceEqual<T>(this IEnumerable<T> actual, params T[] expected) =>
 		actual.AssertSequenceEqual((IList<T>)expected);
 
@@ -59,7 +57,60 @@ internal static partial class TestExtensions
 
 	internal static void AssertCollectionEqual<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T>? comparer) =>
 		Assert.True(actual.CollectionEqual(expected, comparer));
+	#endregion
 
+	#region Collection Error Checking
+	internal static void AssertCollectionErrorChecking<T>(this IEnumerable<T> result, int length)
+	{
+		var coll = result as ICollection<T>;
+		Guard.IsNotNull(coll);
+
+		Assert.Equal(length, result.Count());
+		Assert.Equal(length, coll.Count);
+
+		_ = Assert.Throws<ArgumentNullException>(
+			"array",
+			() => coll.CopyTo(null!, 0));
+
+		var array = new T[length * 2];
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"arrayIndex",
+			() => coll.CopyTo(array, -1));
+		_ = Assert.Throws<ArgumentOutOfRangeException>(
+			"arrayIndex",
+			() => coll.CopyTo(array, length + 1));
+
+		Assert.True(array.All(x => EqualityComparer<T>.Default.Equals(x, default)));
+	}
+
+	internal static void AssertListElementChecking<T>(this IEnumerable<T> result, int length)
+	{
+		var list = result as IList<T>;
+		Guard.IsNotNull(list);
+
+		if (length > 0)
+		{
+			_ = result.ElementAt(0);
+			_ = result.ElementAt(length - 1);
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(-1));
+
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(length));
+		}
+		else
+		{
+			_ = Assert.Throws<ArgumentOutOfRangeException>(
+				"index",
+				() => result.ElementAt(0));
+		}
+	}
+	#endregion
+
+	#region Testing Sequence Generation
 	internal static IEnumerable<IDisposableEnumerable<T>> GetCollectionSequences<T>(this IEnumerable<T> input)
 	{
 		// UI will consume one enumeration
@@ -88,4 +139,5 @@ internal static partial class TestExtensions
 		yield return input.AsTestingCollection(maxEnumerations: 2);
 		yield return input.AsBreakingList();
 	}
+	#endregion
 }

--- a/Tests/SuperLinq.Test/WindowLeftTest.cs
+++ b/Tests/SuperLinq.Test/WindowLeftTest.cs
@@ -142,7 +142,9 @@ public partial class WindowLeftTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.WindowLeft(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(Enumerable.Range(50, 20), result.ElementAt(50));
 		Assert.Equal(Enumerable.Range(9_999, 1), result.ElementAt(^1));
 	}

--- a/Tests/SuperLinq.Test/WindowRightTest.cs
+++ b/Tests/SuperLinq.Test/WindowRightTest.cs
@@ -144,7 +144,9 @@ public partial class WindowRightTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.WindowRight(20);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal(Enumerable.Range(0, 10), result.ElementAt(10));
 		Assert.Equal(Enumerable.Range(9_980, 20), result.ElementAt(^1));
 	}

--- a/Tests/SuperLinq.Test/WindowTest.cs
+++ b/Tests/SuperLinq.Test/WindowTest.cs
@@ -147,7 +147,10 @@ public partial class WindowTests
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.Window(20);
-		Assert.Equal(10_000 - 20 + 1, result.Count());
+		var length = 10_000 - 20 + 1;
+		result.AssertCollectionErrorChecking(length);
+		result.AssertListElementChecking(length);
+
 		Assert.Equal(Enumerable.Range(50, 20), result.ElementAt(50));
 		Assert.Equal(Enumerable.Range(9_980, 20), result.ElementAt(^1));
 	}

--- a/Tests/SuperLinq.Test/ZipLongestTest.cs
+++ b/Tests/SuperLinq.Test/ZipLongestTest.cs
@@ -65,13 +65,17 @@ public class ZipLongestTest
 		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipLongest(seq2);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50), result.ElementAt(50));
 		Assert.Equal((9_950, 0), result.ElementAt(^50));
 
 		result = seq2.ZipLongest(seq1);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((0, 9_950), result.ElementAt(^50));
 	}
 
@@ -172,13 +176,17 @@ public class ZipLongestTest
 		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipLongest(seq2, seq3);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((10, 10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50, 50), result.ElementAt(50));
 		Assert.Equal((9_950, 0, 0), result.ElementAt(^50));
 
 		result = seq2.ZipLongest(seq1, seq3);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((0, 9_950, 0), result.ElementAt(^50));
 	}
 
@@ -298,13 +306,17 @@ public class ZipLongestTest
 		using var seq4 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipLongest(seq2, seq3, seq4);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((10, 10, 10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50, 50, 50), result.ElementAt(50));
 		Assert.Equal((9_950, 0, 0, 0), result.ElementAt(^50));
 
 		result = seq2.ZipLongest(seq1, seq3, seq4);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((0, 9_950, 0, 0), result.ElementAt(^50));
 	}
 }

--- a/Tests/SuperLinq.Test/ZipMapTest.cs
+++ b/Tests/SuperLinq.Test/ZipMapTest.cs
@@ -66,7 +66,9 @@ public class ZipMapTest
 		using var seq = Enumerable.Range(0, 10_000).AsBreakingList();
 
 		var result = seq.ZipMap(a => a + 10);
-		Assert.Equal(10_000, result.Count());
+		result.AssertCollectionErrorChecking(10_000);
+		result.AssertListElementChecking(10_000);
+
 		Assert.Equal((20, 30), result.ElementAt(20));
 		Assert.Equal((9_980, 9_990), result.ElementAt(^20));
 	}

--- a/Tests/SuperLinq.Test/ZipShortestTest.cs
+++ b/Tests/SuperLinq.Test/ZipShortestTest.cs
@@ -90,13 +90,17 @@ public class ZipShortestTest
 		using var seq2 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipShortest(seq2);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50), result.ElementAt(50));
 		Assert.Equal((4_950, 4_950), result.ElementAt(^50));
 
 		result = seq2.ZipShortest(seq1);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((4_950, 4_950), result.ElementAt(^50));
 	}
 
@@ -193,13 +197,17 @@ public class ZipShortestTest
 		using var seq3 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipShortest(seq2, seq3);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((10, 10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50, 50), result.ElementAt(50));
 		Assert.Equal((4_950, 4_950, 4_950), result.ElementAt(^50));
 
 		result = seq2.ZipShortest(seq1, seq3);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((4_950, 4_950, 4_950), result.ElementAt(^50));
 	}
 
@@ -314,13 +322,17 @@ public class ZipShortestTest
 		using var seq4 = Enumerable.Range(0, 5_000).AsBreakingList();
 
 		var result = seq1.ZipShortest(seq2, seq3, seq4);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((10, 10, 10, 10), result.ElementAt(10));
 		Assert.Equal((50, 50, 50, 50), result.ElementAt(50));
 		Assert.Equal((4_950, 4_950, 4_950, 4_950), result.ElementAt(^50));
 
 		result = seq2.ZipShortest(seq1, seq3, seq4);
-		Assert.Equal(5_000, result.Count());
+		result.AssertCollectionErrorChecking(5_000);
+		result.AssertListElementChecking(5_000);
+
 		Assert.Equal((4_950, 4_950, 4_950, 4_950), result.ElementAt(^50));
 	}
 }


### PR DESCRIPTION
This PR adds additional `ICollection<>` and `IList<>` error checking for implementation methods. These methods should validate incoming arguments are valid. Many operators updated to address missing validation checks.

Fixes #460 