### PR TITLE
added test coverage for cases where the task is not via ThrowIfCancel…

### DIFF
--- a/Tests/SuperLinq.Async.Test/TimeoutTest.cs
+++ b/Tests/SuperLinq.Async.Test/TimeoutTest.cs
@@ -59,7 +59,7 @@ public class TimeoutTest
 	}
 
 	[Fact]
-	public async Task TimeoutExceptionWithOperationCanceledExceptionInnerException()
+	public async Task TimeoutExceptionWithoutOperationCanceledExceptionInnerException()
 	{
 		var sequence = new SequenceWithoutThrowIfCancellationRequested();
 
@@ -72,7 +72,7 @@ public class TimeoutTest
 	}
 
 	[Fact]
-	public async Task TimeoutExceptionWithoutOperationCanceledExceptionInnerException()
+	public async Task TimeoutExceptionWithOperationCanceledExceptionInnerException()
 	{
 		var sequence = new SequenceWithThrowIfCancellationRequested();
 

--- a/Tests/SuperLinq.Async.Test/TimeoutTest.cs
+++ b/Tests/SuperLinq.Async.Test/TimeoutTest.cs
@@ -61,9 +61,10 @@ public class TimeoutTest
 	[Fact]
 	public async Task TimeoutExceptionWithoutOperationCanceledExceptionInnerException()
 	{
-		var sequence = new SequenceWithoutThrowIfCancellationRequested();
+		await using var ts = new SequenceWithoutThrowIfCancellationRequested()
+			.AsTestingSequence();
 
-		var result = sequence.Timeout(TimeSpan.FromMilliseconds(0));
+		var result = ts.Timeout(TimeSpan.FromMilliseconds(0));
 
 		var timeoutException = await Assert.ThrowsAsync<TimeoutException>(
 			async () => await result.Consume());
@@ -74,9 +75,10 @@ public class TimeoutTest
 	[Fact]
 	public async Task TimeoutExceptionWithOperationCanceledExceptionInnerException()
 	{
-		var sequence = new SequenceWithThrowIfCancellationRequested();
+		await using var ts = new SequenceWithThrowIfCancellationRequested()
+			.AsTestingSequence();
 
-		var result = sequence.Timeout(TimeSpan.FromMilliseconds(0));
+		var result = ts.Timeout(TimeSpan.FromMilliseconds(0));
 
 		var timeoutException = await Assert.ThrowsAsync<TimeoutException>(
 			async () => await result.Consume());


### PR DESCRIPTION
If the task is not  cancelled via ThrowIfCancellationRequested(), we still handle it correctly in the implementation but no test were made for those.