### PR TITLE
Optimise FallbackIfEmpty

### DIFF
--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -76,13 +76,13 @@ public static partial class SuperEnumerable
 		}
 
 		public override int Count =>
-			_source.TryGetCollectionCount() is { } and 0
+			_source.GetCollectionCount() == 0
 				? _fallback.Count()
 				: _source.GetCollectionCount();
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			return _source.TryGetCollectionCount() is { } and 0
+			return _source.GetCollectionCount() == 0
 				? _fallback
 				: _source;
 		}

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -40,7 +40,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(fallback);
 
-		return source is ICollection<T>
+		return source.TryGetCollectionCount() is not null
 			? new FallbackIfEmptyCollectionIterator<T>(source, fallback)
 			: Core(source, fallback);
 

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -40,8 +40,8 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(fallback);
 
-		return source is ICollection<T> 
-			? new FallbackIfEmptyCollectionIterator<T>(source, fallback) 
+		return source is ICollection<T>
+			? new FallbackIfEmptyCollectionIterator<T>(source, fallback)
 			: Core(source, fallback);
 
 		static IEnumerable<T> Core(IEnumerable<T> source, IEnumerable<T> fallback)

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -40,7 +40,9 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(fallback);
 
-		return Core(source, fallback);
+		return source.TryGetCollectionCount() is { } and 0
+			? fallback
+			: Core(source, fallback);
 
 		static IEnumerable<T> Core(IEnumerable<T> source, IEnumerable<T> fallback)
 		{
@@ -48,8 +50,11 @@ public static partial class SuperEnumerable
 			{
 				if (e.MoveNext())
 				{
-					do { yield return e.Current; }
-					while (e.MoveNext());
+					do
+					{
+						yield return e.Current;
+					} while (e.MoveNext());
+
 					yield break;
 				}
 			}

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -41,6 +41,7 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(fallback);
 
 		return source.TryGetCollectionCount() is not null
+			   && fallback.TryGetCollectionCount() is not null
 			? new FallbackIfEmptyCollectionIterator<T>(source, fallback)
 			: Core(source, fallback);
 

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -52,14 +52,13 @@ public class FallbackIfEmptyTest
 	[Fact]
 	public void FallbackIfEmptyUsesCollectionCountAtIterationTime()
 	{
-		using var source = new BreakingCountCollection<int>();
+		var stack = new Stack<int>(Enumerable.Range(1, 3));
+		var result = stack.FallbackIfEmpty(4);
 
-		var result = source.FallbackIfEmpty(new BreakingSequence<int>());
-		_ = Assert.Throws<TestException>(() => result.Consume());
-	}
+		result.Consume();
 
-	internal class BreakingCountCollection<T> : BreakingCollection<T>
-	{
-		public new int Count => throw new TestException();
+		stack.Push(4);
+
+		result.Consume();
 	}
 }

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -47,4 +47,18 @@ public class FallbackIfEmptyTest
 		var result = source.FallbackIfEmpty(new BreakingSequence<int>());
 		result.AssertCollectionErrorChecking(1);
 	}
+
+	[Fact]
+	public void FallbackIfEmptyUsesCollectionCountAtIterationTime()
+	{
+		using var source = new BreakingCountCollection<int>();
+
+		var result = source.FallbackIfEmpty(new BreakingSequence<int>());
+		_ = Assert.Throws<TestException>(() => result.Consume());
+	}
+
+	internal class BreakingCountCollection<T> : BreakingCollection<T>
+	{
+		public new int Count => throw new TestException();
+	}
 }

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -13,7 +13,7 @@ public class FallbackIfEmptyTest
 	[Fact]
 	public void FallbackIfEmptyWithEmptyListSequence()
 	{
-		using var source = Enumerable.Empty<int>().ToList().AsTestingSequence(maxEnumerations: 2);
+		var source = Enumerable.Empty<int>().ToList();
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
 		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
 	}

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -11,15 +11,7 @@ public class FallbackIfEmptyTest
 	}
 
 	[Fact]
-	public void FallbackIfEmptyWithEmptyListSequence()
-	{
-		var source = Enumerable.Empty<int>().ToList();
-		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
-		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
-	}
-
-	[Fact]
-	public void FallbackIfEmptyWithCollectionListSequence()
+	public void FallbackIfEmptyWithCollectionSequence()
 	{
 		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
@@ -30,7 +22,13 @@ public class FallbackIfEmptyTest
 	public void FallbackIfEmptyWithNotEmptySequence()
 	{
 		using var source = Seq(1).AsTestingSequence(maxEnumerations: 2);
-		source.FallbackIfEmpty(12).AssertSequenceEqual(1);
-		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(1);
+		source.FallbackIfEmpty(new BreakingSequence<int>()).AssertSequenceEqual(1);
+	}
+
+	[Fact]
+	public void FallbackIfEmptyWithNotEmptyCollectionSequence()
+	{
+		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
+		source.FallbackIfEmpty(new BreakingSequence<int>()).AssertSequenceEqual(1);
 	}
 }

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -5,60 +5,60 @@ public class FallbackIfEmptyTest
 	[Fact]
 	public void FallbackIfEmptyWithEmptySequence()
 	{
-		using var source = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 2);
+		using var source = Seq<int>().AsTestingSequence();
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
 	}
 
 	[Fact]
 	public void FallbackIfEmptyWithCollectionSequence()
 	{
-		using var source = Enumerable.Empty<int>().AsTestingCollection();
+		using var source = Seq<int>().AsTestingCollection();
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
 	}
 
 	[Fact]
 	public void FallbackIfEmptyWithNotEmptySequence()
 	{
-		using var source = Seq(1).AsTestingSequence(maxEnumerations: 2);
+		using var source = Seq(1).AsTestingSequence();
 		source.FallbackIfEmpty(new BreakingSequence<int>()).AssertSequenceEqual(1);
 	}
 
 	[Fact]
 	public void FallbackIfEmptyWithNotEmptyCollectionSequence()
 	{
-		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
+		using var source = Seq(1).AsTestingCollection();
 		source.FallbackIfEmpty(new BreakingSequence<int>()).AssertSequenceEqual(1);
 	}
 
 	[Fact]
 	public void AssertFallbackIfEmptyCollectionBehaviorOnEmptyCollection()
 	{
-		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
+		using var source = Seq<int>().AsBreakingCollection();
+		using var fallback = Enumerable.Range(0, 10_000).AsBreakingCollection();
 
-		var result = source.FallbackIfEmpty(12);
-		result.AssertCollectionErrorChecking(1);
+		var result = source.FallbackIfEmpty(fallback);
+		result.AssertCollectionErrorChecking(10_000);
 	}
 
 	[Fact]
 	public void AssertFallbackIfEmptyCollectionBehaviorOnNonEmptyCollection()
 	{
-		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
-
+		using var source = Enumerable.Range(0, 10_000).AsBreakingCollection();
 		using var fallback = new BreakingCollection<int>();
+
 		var result = source.FallbackIfEmpty(fallback);
-		result.AssertCollectionErrorChecking(1);
+		result.AssertCollectionErrorChecking(10_000);
 	}
 
 	[Fact]
 	public void FallbackIfEmptyUsesCollectionCountAtIterationTime()
 	{
-		var stack = new Stack<int>(Enumerable.Range(1, 3));
+		var stack = new Stack<int>();
+
 		var result = stack.FallbackIfEmpty(4);
+		result.AssertSequenceEqual(4);
 
-		result.Consume();
-
-		stack.Push(4);
-
-		result.Consume();
+		stack.Push(1);
+		result.AssertSequenceEqual(1);
 	}
 }

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -11,6 +11,14 @@ public class FallbackIfEmptyTest
 	}
 
 	[Fact]
+	public void FallbackIfEmptyWithEmptyListSequence()
+	{
+		using var source = Enumerable.Empty<int>().ToList().AsTestingSequence(maxEnumerations: 2);
+		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
+		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
+	}
+
+	[Fact]
 	public void FallbackIfEmptyWithNotEmptySequence()
 	{
 		using var source = Seq(1).AsTestingSequence(maxEnumerations: 2);

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -44,7 +44,8 @@ public class FallbackIfEmptyTest
 	{
 		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
 
-		var result = source.FallbackIfEmpty(new BreakingSequence<int>());
+		using var fallback = new BreakingCollection<int>();
+		var result = source.FallbackIfEmpty(fallback);
 		result.AssertCollectionErrorChecking(1);
 	}
 

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -12,7 +12,7 @@ public class FallbackIfEmptyTest
 	[Fact]
 	public void FallbackIfEmptyWithCollectionSequence()
 	{
-		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
+		using var source = Enumerable.Empty<int>().AsTestingCollection();
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
 	}
 

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -19,6 +19,14 @@ public class FallbackIfEmptyTest
 	}
 
 	[Fact]
+	public void FallbackIfEmptyWithCollectionListSequence()
+	{
+		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
+		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
+		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
+	}
+
+	[Fact]
 	public void FallbackIfEmptyWithNotEmptySequence()
 	{
 		using var source = Seq(1).AsTestingSequence(maxEnumerations: 2);

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -29,4 +29,22 @@ public class FallbackIfEmptyTest
 		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
 		source.FallbackIfEmpty(new BreakingSequence<int>()).AssertSequenceEqual(1);
 	}
+
+	[Fact]
+	public void AssertFallbackIfEmptyCollectionBehaviorOnEmptyCollection()
+	{
+		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
+
+		var result = source.FallbackIfEmpty(12);
+		result.AssertCollectionErrorChecking(1);
+	}
+
+	[Fact]
+	public void AssertFallbackIfEmptyCollectionBehaviorOnNonEmptyCollection()
+	{
+		using var source = Seq(1).AsTestingCollection(maxEnumerations: 2);
+
+		var result = source.FallbackIfEmpty(new BreakingSequence<int>());
+		result.AssertCollectionErrorChecking(1);
+	}
 }

--- a/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
+++ b/Tests/SuperLinq.Test/FallbackIfEmptyTest.cs
@@ -7,7 +7,6 @@ public class FallbackIfEmptyTest
 	{
 		using var source = Enumerable.Empty<int>().AsTestingSequence(maxEnumerations: 2);
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
-		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
 	}
 
 	[Fact]
@@ -15,7 +14,6 @@ public class FallbackIfEmptyTest
 	{
 		using var source = Enumerable.Empty<int>().AsTestingCollection(maxEnumerations: 2);
 		source.FallbackIfEmpty(12).AssertSequenceEqual(12);
-		source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR improves the `FallbackIfEmpty` performance in the case of collections.

Fixes #367 
