### PR TITLE
Fix bug in async `Publish`

### DIFF
--- a/Source/SuperLinq.Async/Publish.cs
+++ b/Source/SuperLinq.Async/Publish.cs
@@ -228,7 +228,15 @@ public static partial class AsyncSuperEnumerable
 			}
 			finally
 			{
-				_ = _buffers?.Remove(buffer);
+				await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+				try
+				{
+					_ = _buffers?.Remove(buffer);
+				}
+				finally
+				{
+					_ = _lock.Release();
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a potential bug in the dispose of an async `Publish` enumerable.