### PR TITLE
Improve `Defer` implementation

### DIFF
--- a/Source/SuperLinq/Defer.cs
+++ b/Source/SuperLinq/Defer.cs
@@ -1,5 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿using System.Collections;
 
 namespace SuperLinq;
 
@@ -17,12 +16,21 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(enumerableFactory);
 
-		return Core(enumerableFactory);
+		return new DeferEnumerable<TResult>(enumerableFactory);
+	}
 
-		static IEnumerable<TResult> Core(Func<IEnumerable<TResult>> enumerableFactory)
+	private sealed class DeferEnumerable<T> : IEnumerable<T>
+	{
+		private readonly Func<IEnumerable<T>> _factory;
+
+		public DeferEnumerable(Func<IEnumerable<T>> factory)
 		{
-			foreach (var el in enumerableFactory())
-				yield return el;
+			_factory = factory;
 		}
+
+		public IEnumerator<T> GetEnumerator() =>
+			_factory().GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 }


### PR DESCRIPTION
This PR changes the `Defer` implementation to use a `DeferEnumerable`. This reduces SuperLinq overhead by eliminating the state-machine required to enumerate the returned enumerable. Instead, the correct `IEnumerator<>` is returned directly to be used by the consumer.