### PR TITLE
Improve `NullArgumentTest` to cover `GetShortestPath` methods

### DIFF
--- a/Source/SuperLinq/GetShortestPath.cs
+++ b/Source/SuperLinq/GetShortestPath.cs
@@ -279,6 +279,8 @@ public partial class SuperEnumerable
 				break;
 
 			var newStates = getNeighbors(current, cost);
+			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+
 			foreach (var (s, p) in newStates)
 			{
 				if (!totalCost.TryGetValue(s, out _))
@@ -584,6 +586,8 @@ public partial class SuperEnumerable
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
+			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+
 			foreach (var (s, p) in newStates)
 			{
 				if (!totalCost.TryGetValue(s, out _))
@@ -767,6 +771,8 @@ public partial class SuperEnumerable
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
+			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+
 			foreach (var (s, p) in newStates)
 			{
 				if (!totalCost.TryGetValue(s, out _))
@@ -1083,6 +1089,8 @@ public partial class SuperEnumerable
 					break;
 
 				var newStates = getNeighbors(current, costs.traversed);
+				Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+
 				foreach (var (s, p, h) in newStates)
 					queue.EnqueueMinimum(s, (h, p));
 			}
@@ -1410,6 +1418,8 @@ public partial class SuperEnumerable
 
 				var cost = from.traversed;
 				var newStates = getNeighbors(current, cost);
+				Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+
 				foreach (var (s, p, h) in newStates)
 					queue.EnqueueMinimum(s, (current, h, p));
 			}


### PR DESCRIPTION
This PR addresses the gap in the `NullArgumentTest`, where it does not test `GetShortestPath` methods. It does so by changing the `Func<>` passed in to return an empty enumerable rather than `null`. 

This PR also adds a null-reference check for the returned value from the `getNeighbors()` call.

Fixes #195 