### PR TITLE
Undo `Defer` changes

### DIFF
--- a/Source/SuperLinq.Async/Defer.cs
+++ b/Source/SuperLinq.Async/Defer.cs
@@ -14,19 +14,14 @@ public static partial class AsyncSuperEnumerable
 	{
 		Guard.IsNotNull(enumerableFactory);
 
-		return new DeferEnumerable<TResult>(enumerableFactory);
-	}
+		return Core(enumerableFactory);
 
-	private sealed class DeferEnumerable<T> : IAsyncEnumerable<T>
-	{
-		private readonly Func<IAsyncEnumerable<T>> _factory;
-
-		public DeferEnumerable(Func<IAsyncEnumerable<T>> factory)
+		static async IAsyncEnumerable<TResult> Core(
+			Func<IAsyncEnumerable<TResult>> enumerableFactory,
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
-			_factory = factory;
+			await foreach (var el in enumerableFactory().WithCancellation(cancellationToken).ConfigureAwait(false))
+				yield return el;
 		}
-
-		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken) =>
-			_factory().GetAsyncEnumerator(cancellationToken);
 	}
 }

--- a/Source/SuperLinq/Defer.cs
+++ b/Source/SuperLinq/Defer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace SuperLinq;
 
@@ -16,21 +17,12 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(enumerableFactory);
 
-		return new DeferEnumerable<TResult>(enumerableFactory);
-	}
+		return Core(enumerableFactory);
 
-	private sealed class DeferEnumerable<T> : IEnumerable<T>
-	{
-		private readonly Func<IEnumerable<T>> _factory;
-
-		public DeferEnumerable(Func<IEnumerable<T>> factory)
+		static IEnumerable<TResult> Core(Func<IEnumerable<TResult>> enumerableFactory)
 		{
-			_factory = factory;
+			foreach (var el in enumerableFactory())
+				yield return el;
 		}
-
-		public IEnumerator<T> GetEnumerator() =>
-			_factory().GetEnumerator();
-
-		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 }


### PR DESCRIPTION
This PR reverts the changes in #471 and #479. Using the `GetEnumerator` function as changed moves the execution of `factory` to when `GetEnumerator()` is called, rather than when the first `MoveNext()` is called.