### PR TITLE
Address net8-preview changes

### DIFF
--- a/Source/SuperLinq/Permutations.cs
+++ b/Source/SuperLinq/Permutations.cs
@@ -169,7 +169,7 @@ public static partial class SuperEnumerable
 		/// same.
 		/// </remarks>
 		/// <returns>List of permuted source sequence values</returns>
-		private IList<T> PermuteValueSet()
+		private T[] PermuteValueSet()
 		{
 			var permutedSet = new T[_permutation.Length];
 			for (var i = 0; i < _permutation.Length; i++)

--- a/Tests/SuperLinq.Test/CopyToTest.cs
+++ b/Tests/SuperLinq.Test/CopyToTest.cs
@@ -54,13 +54,13 @@ public class CopyToTest
 	[Fact]
 	public void ThrowsOnTooMuchDataForIListArray()
 	{
-		_ = Assert.Throws<ArgumentException>(
+		_ = Assert.ThrowsAny<ArgumentException>(
 			() => Seq(1).CopyTo((IList<int>)Array.Empty<int>()));
-		_ = Assert.Throws<ArgumentException>(
+		_ = Assert.ThrowsAny<ArgumentException>(
 			() => Enumerable.Range(1, 1).CopyTo((IList<int>)Array.Empty<int>()));
-		_ = Assert.Throws<ArgumentException>(
+		_ = Assert.ThrowsAny<ArgumentException>(
 			() => new List<int> { 1 }.AsEnumerable().CopyTo((IList<int>)Array.Empty<int>()));
-		_ = Assert.Throws<ArgumentException>(
+		_ = Assert.ThrowsAny<ArgumentException>(
 			() => new List<int> { 1 }.AsReadOnly().AsEnumerable().CopyTo((IList<int>)Array.Empty<int>()));
 	}
 


### PR DESCRIPTION
This PR fixes changes from the latest net8 preview compiler:
* a newly generated CA1859 warning;
* the expected exception thrown by `CopyTo`