### PR TITLE
Update `DensePartialSortBy` to use `NullKeyDictionary`

### DIFF
--- a/Source/SuperLinq.Async/DensePartialSort.cs
+++ b/Source/SuperLinq.Async/DensePartialSort.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq.Async;
+﻿using SuperLinq.Collections;
+
+namespace SuperLinq.Async;
 
 public static partial class AsyncSuperEnumerable
 {
@@ -249,21 +251,21 @@ public static partial class AsyncSuperEnumerable
 		static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			var top = new SortedSet<TKey>(comparer);
-			var dic = new Dictionary<(TKey Key, int Index), List<TSource>>(count);
+			var dic = new NullKeyDictionary<TKey, List<TSource>>(count);
 
 			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{
 				var key = keySelector(item);
 				if (top.TryGetValue(key, out var oKey))
 				{
-					dic[(oKey, 1)].Add(item);
+					dic[oKey].Add(item);
 					continue;
 				}
 
 				if (top.Count < count)
 				{
 					_ = top.Add(key);
-					dic[(key, 1)] = new() { item, };
+					dic[key] = new() { item, };
 					continue;
 				}
 
@@ -271,15 +273,15 @@ public static partial class AsyncSuperEnumerable
 				if (comparer.Compare(key, max) > 0)
 					continue;
 
-				_ = dic.Remove((max, 1));
+				_ = dic.Remove(max);
 				_ = top.Remove(max);
 				_ = top.Add(key);
-				dic[(key, 1)] = new() { item, };
+				dic[key] = new() { item, };
 			}
 
 			foreach (var entry in top)
 			{
-				foreach (var i in dic[(entry, 1)])
+				foreach (var i in dic[entry])
 					yield return i;
 			}
 		}

--- a/Source/SuperLinq/Collections/NullKeyDictionary.cs
+++ b/Source/SuperLinq/Collections/NullKeyDictionary.cs
@@ -13,6 +13,10 @@ internal sealed class NullKeyDictionary<TKey, TValue> : Dictionary<ValueTuple<TK
 		: base(comparer: ValueTupleEqualityComparer.Create(comparer))
 	{ }
 
+	public NullKeyDictionary(int count)
+		: base(count, comparer: ValueTupleEqualityComparer.Create<TKey>(default))
+	{ }
+
 	public TValue this[TKey key]
 	{
 		get => this[ValueTuple.Create(key)];

--- a/Source/SuperLinq/DensePartialSort.cs
+++ b/Source/SuperLinq/DensePartialSort.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using SuperLinq.Collections;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -249,21 +251,21 @@ public static partial class SuperEnumerable
 		static IEnumerable<TSource> Core(IEnumerable<TSource> source, int count, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
 		{
 			var top = new SortedSet<TKey>(comparer);
-			var dic = new Dictionary<(TKey Key, int Index), List<TSource>>(count);
+			var dic = new NullKeyDictionary<TKey, List<TSource>>(count);
 
 			foreach (var item in source)
 			{
 				var key = keySelector(item);
 				if (top.TryGetValue(key, out var oKey))
 				{
-					dic[(oKey, 1)].Add(item);
+					dic[oKey].Add(item);
 					continue;
 				}
 
 				if (top.Count < count)
 				{
 					_ = top.Add(key);
-					dic[(key, 1)] = new() { item, };
+					dic[key] = new() { item, };
 					continue;
 				}
 
@@ -271,15 +273,15 @@ public static partial class SuperEnumerable
 				if (comparer.Compare(key, max) > 0)
 					continue;
 
-				_ = dic.Remove((max, 1));
+				_ = dic.Remove(max);
 				_ = top.Remove(max);
 				_ = top.Add(key);
-				dic[(key, 1)] = new() { item, };
+				dic[key] = new() { item, };
 			}
 
 			foreach (var entry in top)
 			{
-				foreach (var i in dic[(entry, 1)])
+				foreach (var i in dic[entry])
 					yield return i;
 			}
 		}

--- a/Tests/SuperLinq.Async.Test/DensePartialSortByTest.cs
+++ b/Tests/SuperLinq.Async.Test/DensePartialSortByTest.cs
@@ -64,4 +64,43 @@ public class DensePartialSortByTests
 		await sorted.Select(e => e.Key[0])
 			.AssertSequenceEqual('A', 'A', 'C', 'C', 'E', 'E');
 	}
+
+	[Fact]
+	public async Task DensePartialSortByIsStable()
+	{
+		await using var list = new[]
+		{
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+		}.AsTestingSequence(maxEnumerations: 5);
+
+		var stableSort = new[]
+		{
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+		};
+
+		for (var i = 1; i <= 5; i++)
+		{
+			var sorted = list.DensePartialSortBy(i, x => x.key);
+			await sorted.AssertSequenceEqual(
+				stableSort.Take(i * 2));
+		}
+	}
 }

--- a/Tests/SuperLinq.Async.Test/DensePartialSortTest.cs
+++ b/Tests/SuperLinq.Async.Test/DensePartialSortTest.cs
@@ -56,4 +56,45 @@ public class DensePartialSortTests
 			.Select(s => s[0])
 			.AssertSequenceEqual('A', 'A', 'C', 'C', 'E', 'E');
 	}
+
+	[Fact]
+	public async Task DensePartialSortIsStable()
+	{
+		await using var list = new[]
+		{
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+		}.AsTestingSequence(maxEnumerations: 5);
+
+		var stableSort = new[]
+		{
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+		};
+
+		var comparer = Comparer<(int key, string text)>.Create((a, b) => a.key.CompareTo(b.key));
+
+		for (var i = 1; i <= 5; i++)
+		{
+			var sorted = list.DensePartialSort(i, comparer);
+			await sorted.AssertSequenceEqual(
+				stableSort.Take(i * 2));
+		}
+	}
 }

--- a/Tests/SuperLinq.Test/DensePartialSortByTest.cs
+++ b/Tests/SuperLinq.Test/DensePartialSortByTest.cs
@@ -64,4 +64,43 @@ public class DensePartialSortByTests
 			.Select(e => e.Key[0])
 			.AssertSequenceEqual('A', 'A', 'C', 'C', 'E', 'E');
 	}
+
+	[Fact]
+	public void DensePartialSortByIsStable()
+	{
+		using var list = new[]
+		{
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+		}.AsTestingSequence(maxEnumerations: 5);
+
+		var stableSort = new[]
+		{
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+		};
+
+		for (var i = 1; i <= 5; i++)
+		{
+			var sorted = list.DensePartialSortBy(i, x => x.key);
+			sorted.AssertSequenceEqual(
+				stableSort.Take(i * 2));
+		}
+	}
 }

--- a/Tests/SuperLinq.Test/DensePartialSortTest.cs
+++ b/Tests/SuperLinq.Test/DensePartialSortTest.cs
@@ -56,4 +56,45 @@ public class DensePartialSortTests
 			.Select(s => s[0])
 			.AssertSequenceEqual('A', 'A', 'C', 'C', 'E', 'E');
 	}
+
+	[Fact]
+	public void DensePartialSortIsStable()
+	{
+		using var list = new[]
+		{
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+		}.AsTestingSequence(maxEnumerations: 5);
+
+		var stableSort = new[]
+		{
+			(key: 1, text: "9"),
+			(key: 1, text: "10"),
+			(key: 2, text: "7"),
+			(key: 2, text: "8"),
+			(key: 3, text: "5"),
+			(key: 3, text: "6"),
+			(key: 4, text: "3"),
+			(key: 4, text: "4"),
+			(key: 5, text: "1"),
+			(key: 5, text: "2"),
+		};
+
+		var comparer = Comparer<(int key, string text)>.Create((a, b) => a.key.CompareTo(b.key));
+
+		for (var i = 1; i <= 5; i++)
+		{
+			var sorted = list.DensePartialSort(i, comparer);
+			sorted.AssertSequenceEqual(
+				stableSort.Take(i * 2));
+		}
+	}
 }


### PR DESCRIPTION
This PR updates the `DensePartialSort(By)` operators to properly use `NullKeyDictionary<>`; the previous version was copied from `PartialSort(By)`, and the modification did not remove the unnecessary `int Index` tuple key. 

Fixes #499 
