### PR TITLE
Improve `CollectionIterator.CopyTo`

### DIFF
--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -33,12 +33,7 @@ public partial class SuperEnumerable
 			Guard.IsNotNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
-			if (Count + arrayIndex > array.Length)
-				ThrowHelper.ThrowArgumentException(nameof(array), "Destination is not long enough.");
-
-			var i = arrayIndex;
-			foreach (var el in GetEnumerable())
-				array[i++] = el;
+			_ = SuperEnumerable.CopyTo(GetEnumerable(), array, arrayIndex);
 		}
 	}
 }


### PR DESCRIPTION
This PR updates `CollectionIterator.CopyTo` to use the `SuperEnumerable.CopyTo` method to copy data into the destination array. The code is essentially unchanged in most cases, but will provide some performance improvement if the sequence is a collection.

Fixes #503 