### PR TITLE
Address off-by-1 error in `FindLastIndex`

### DIFF
--- a/Source/SuperLinq/FindLastIndex.cs
+++ b/Source/SuperLinq/FindLastIndex.cs
@@ -126,7 +126,7 @@ public static partial class SuperEnumerable
 			var i = 0;
 			foreach (var element in source)
 			{
-				if (i >= index.Value)
+				if (i > index.Value)
 					break;
 
 				if (predicate(element))

--- a/Tests/SuperLinq.Test/FindLastIndexTest.cs
+++ b/Tests/SuperLinq.Test/FindLastIndexTest.cs
@@ -68,7 +68,7 @@ public class FindLastIndexTest
 		array[^6] = 3;
 		Assert.Equal(
 			(^6).GetOffset(20),
-			array.FindLastIndex(i => i == 3, ^5));
+			array.FindLastIndex(i => i == 3, ^6));
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR fixes a bug in `FindLastIndex`; the previous version escaped too early if the predicate to match was valid at `index`.