### PR TITLE
Remove some `CollectionIterators`

### DIFF
--- a/Source/SuperLinq/Do.cs
+++ b/Source/SuperLinq/Do.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace SuperLinq;
+﻿namespace SuperLinq;
 
 public partial class SuperEnumerable
 {
@@ -39,9 +37,6 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(onNext);
 		Guard.IsNotNull(onCompleted);
-
-		if (source is ICollection<TSource> coll)
-			return new DoIterator<TSource>(coll, onNext, onError: null, onCompleted);
 
 		return DoCore(source, onNext, onCompleted);
 	}
@@ -96,9 +91,6 @@ public partial class SuperEnumerable
 		Guard.IsNotNull(onError);
 		Guard.IsNotNull(onCompleted);
 
-		if (source.TryGetCollectionCount() != null)
-			return new DoIterator<TSource>(source, onNext, onError, onCompleted);
-
 		return DoCore(source, onNext, onError, onCompleted);
 	}
 
@@ -125,28 +117,4 @@ public partial class SuperEnumerable
 		onCompleted();
 	}
 
-
-	private sealed class DoIterator<T> : CollectionIterator<T>
-	{
-		private readonly IEnumerable<T> _source;
-		private readonly Action<T> _onNext;
-		private readonly Action<Exception>? _onError;
-		private readonly Action _onCompleted;
-
-		public DoIterator(IEnumerable<T> source, Action<T> onNext, Action<Exception>? onError, Action onCompleted)
-		{
-			_source = source;
-			_onNext = onNext;
-			_onError = onError;
-			_onCompleted = onCompleted;
-		}
-
-		public override int Count => _source.GetCollectionCount();
-
-		[ExcludeFromCodeCoverage]
-		protected override IEnumerable<T> GetEnumerable() =>
-			_onError != null
-			? DoCore(_source, _onNext, _onError, _onCompleted)
-			: DoCore(_source, _onNext, _onCompleted);
-	}
 }

--- a/Source/SuperLinq/Rank.cs
+++ b/Source/SuperLinq/Rank.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace SuperLinq;
+﻿namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -54,9 +52,6 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		if (source is ICollection<TSource> coll)
-			return new RankIterator<TSource, TKey>(coll, keySelector, comparer: null, isDense: true);
-
 		return RankByCore(source, keySelector, comparer: null, isDense: true);
 	}
 
@@ -81,9 +76,6 @@ public static partial class SuperEnumerable
 	{
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
-
-		if (source is ICollection<TSource> coll)
-			return new RankIterator<TSource, TKey>(coll, keySelector, comparer, isDense: true);
 
 		return RankByCore(source, keySelector, comparer, isDense: true);
 	}
@@ -138,9 +130,6 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		if (source is ICollection<TSource> coll)
-			return new RankIterator<TSource, TKey>(coll, keySelector, comparer: null, isDense: false);
-
 		return RankByCore(source, keySelector, comparer: null, isDense: false);
 	}
 
@@ -166,9 +155,6 @@ public static partial class SuperEnumerable
 		Guard.IsNotNull(source);
 		Guard.IsNotNull(keySelector);
 
-		if (source.TryGetCollectionCount() != null)
-			return new RankIterator<TSource, TKey>(source, keySelector, comparer, isDense: false);
-
 		return RankByCore(source, keySelector, comparer, isDense: false);
 	}
 
@@ -186,7 +172,6 @@ public static partial class SuperEnumerable
 			.OrderBy(keySelector, comparer)
 			.Lag(1))
 		{
-#pragma warning disable CA1508 // Avoid dead conditional code
 			if (rank == 0
 				|| comparer.Compare(
 					keySelector(cur),
@@ -195,33 +180,10 @@ public static partial class SuperEnumerable
 				rank += isDense ? 1 : count;
 				count = 0;
 			}
-#pragma warning restore CA1508 // Avoid dead conditional code
 
 			count++;
 
 			yield return (cur, rank);
 		}
-	}
-
-	private sealed class RankIterator<TSource, TKey> : CollectionIterator<(TSource, int)>
-	{
-		private readonly IEnumerable<TSource> _source;
-		private readonly Func<TSource, TKey> _keySelector;
-		private readonly IComparer<TKey>? _comparer;
-		private readonly bool _isDense;
-
-		public RankIterator(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer, bool isDense)
-		{
-			_source = source;
-			_keySelector = keySelector;
-			_comparer = comparer;
-			_isDense = isDense;
-		}
-
-		public override int Count => _source.GetCollectionCount();
-
-		[ExcludeFromCodeCoverage]
-		protected override IEnumerable<(TSource, int)> GetEnumerable() =>
-			RankByCore(_source, _keySelector, _comparer, _isDense);
 	}
 }

--- a/Tests/SuperLinq.Test/DenseRankTest.cs
+++ b/Tests/SuperLinq.Test/DenseRankTest.cs
@@ -16,7 +16,7 @@ public class DenseRankTests
 
 	public static IEnumerable<object[]> GetSimpleSequences() =>
 		Enumerable.Repeat(1, 10)
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -48,7 +48,7 @@ public class DenseRankTests
 	public static IEnumerable<object[]> GetDescendingIntSequences() =>
 		Enumerable.Range(456, 100)
 			.Reverse()
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -67,7 +67,7 @@ public class DenseRankTests
 
 	public static IEnumerable<object[]> GetAscendingIntSequences() =>
 		Enumerable.Range(456, 100)
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -88,7 +88,7 @@ public class DenseRankTests
 		Enumerable.Range(0, 10)
 			.Concat(Enumerable.Range(0, 10))
 			.Concat(Enumerable.Range(0, 10))
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -124,7 +124,7 @@ public class DenseRankTests
 				new Person(Name: "Jim", Age: 74, ExpectedRank: 8),
 				new Person(Name: "Jes", Age: 11, ExpectedRank: 1),
 		}
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -145,7 +145,7 @@ public class DenseRankTests
 	public static IEnumerable<object[]> GetDateTimeSequences() =>
 		Enumerable.Range(1, 10)
 			.Select(x => new DateTime(2010, x, 20 - x))
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -182,18 +182,5 @@ public class DenseRankTests
 						.OrderByDescending(x => x.Day)
 						.Select((x, i) => (x, i + 1)));
 		}
-	}
-
-	[Fact]
-	public void TestRankCollectionCount()
-	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
-
-		var result = sequence.DenseRank();
-		result.AssertCollectionErrorChecking(10_000);
-
-		result = sequence.DenseRank(comparer: Comparer<int>.Default);
-		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/DoTest.cs
+++ b/Tests/SuperLinq.Test/DoTest.cs
@@ -12,7 +12,7 @@ public class DoTest
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 10)
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x });
 
 	[Theory]
@@ -104,18 +104,5 @@ public class DoTest
 				.Consume());
 
 		Assert.Equal(155, count);
-	}
-
-	[Fact]
-	public void DoCollectionCount()
-	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
-
-		var result = sequence.Do(delegate { });
-		result.AssertCollectionErrorChecking(10_000);
-
-		result = sequence.Do(delegate { }, onError: delegate { });
-		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/PreScanTest.cs
+++ b/Tests/SuperLinq.Test/PreScanTest.cs
@@ -56,40 +56,4 @@ public class PreScanTest
 				0);
 		sequence.AssertSequenceEqual(0, 1, 3);
 	}
-
-	[Fact]
-	public void PreScanCollection()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
-
-		var result = seq.PreScan((a, b) => a + b, 5);
-		result.AssertCollectionErrorChecking(10);
-
-		result.ToArray()
-			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50);
-		Assert.Equal(1, seq.CopyCount);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 0, 0, 0, 0, 0);
-		Assert.Equal(2, seq.CopyCount);
-	}
-
-	[Fact]
-	public void PreScanList()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingList();
-
-		var result = seq.PreScan((a, b) => a + b, 5);
-		result.AssertCollectionErrorChecking(10);
-
-		result.ToArray()
-			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 0, 0, 0, 0, 0);
-	}
 }

--- a/Tests/SuperLinq.Test/RankTest.cs
+++ b/Tests/SuperLinq.Test/RankTest.cs
@@ -16,7 +16,7 @@ public class RankTests
 
 	public static IEnumerable<object[]> GetSimpleSequences() =>
 		Enumerable.Repeat(1, 10)
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -48,7 +48,7 @@ public class RankTests
 	public static IEnumerable<object[]> GetDescendingIntSequences() =>
 		Enumerable.Range(456, 100)
 			.Reverse()
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -67,7 +67,7 @@ public class RankTests
 
 	public static IEnumerable<object[]> GetAscendingIntSequences() =>
 		Enumerable.Range(456, 100)
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	[Theory]
@@ -88,7 +88,7 @@ public class RankTests
 		Enumerable.Range(0, 10)
 			.Concat(Enumerable.Range(0, 10))
 			.Concat(Enumerable.Range(0, 10))
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -124,7 +124,7 @@ public class RankTests
 				new Person(Name: "Jim", Age: 74, ExpectedRank: 8),
 				new Person(Name: "Jes", Age: 11, ExpectedRank: 1),
 		}
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -145,7 +145,7 @@ public class RankTests
 	public static IEnumerable<object[]> GetDateTimeSequences() =>
 		Enumerable.Range(1, 10)
 			.Select(x => new DateTime(2010, x, 20 - x))
-			.GetCollectionSequences()
+			.GetTestingSequence()
 			.Select(x => new object[] { x, });
 
 	/// <summary>
@@ -182,18 +182,5 @@ public class RankTests
 						.OrderByDescending(x => x.Day)
 						.Select((x, i) => (x, i + 1)));
 		}
-	}
-
-	[Fact]
-	public void TestRankCollectionCount()
-	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
-
-		var result = sequence.Rank();
-		result.AssertCollectionErrorChecking(10_000);
-
-		result = sequence.Rank(comparer: Comparer<int>.Default);
-		result.AssertCollectionErrorChecking(10_000);
 	}
 }

--- a/Tests/SuperLinq.Test/ScanByTest.cs
+++ b/Tests/SuperLinq.Test/ScanByTest.cs
@@ -113,14 +113,4 @@ public class ScanByTest
 		_ = Assert.Throws<TestException>(() =>
 			result.ElementAt(5));
 	}
-
-	[Fact]
-	public void ScanByCollectionCount()
-	{
-		using var sequence = Enumerable.Range(1, 10_000)
-			.AsBreakingCollection();
-
-		var result = sequence.ScanBy(x => x, x => x, (a, b, c) => a);
-		result.AssertCollectionErrorChecking(10_000);
-	}
 }

--- a/Tests/SuperLinq.Test/ScanRightTest.cs
+++ b/Tests/SuperLinq.Test/ScanRightTest.cs
@@ -56,42 +56,6 @@ public class ScanRightTest
 		_ = new BreakingSequence<int>().ScanRight(BreakingFunc.Of<int, int, int>());
 	}
 
-	[Fact]
-	public void ScanRightCollection()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
-
-		var result = seq.ScanRight((a, b) => a + b);
-		result.AssertCollectionErrorChecking(10);
-
-		result.ToArray()
-			.AssertSequenceEqual(55, 54, 52, 49, 45, 40, 34, 27, 19, 10);
-		Assert.Equal(1, seq.CopyCount);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 55, 54, 52, 49, 45, 40, 34, 27, 19, 10, 0, 0, 0, 0, 0);
-		Assert.Equal(2, seq.CopyCount);
-	}
-
-	[Fact]
-	public void ScanRightList()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingList();
-
-		var result = seq.ScanRight((a, b) => a + b);
-		Assert.Equal(10, result.Count());
-
-		result.ToArray()
-			.AssertSequenceEqual(55, 54, 52, 49, 45, 40, 34, 27, 19, 10);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 55, 54, 52, 49, 45, 40, 34, 27, 19, 10, 0, 0, 0, 0, 0);
-	}
-
 	// ScanRight(source, seed, func)
 
 	[Theory]
@@ -143,41 +107,5 @@ public class ScanRightTest
 	public void ScanRightSeedIsLazy()
 	{
 		_ = new BreakingSequence<int>().ScanRight(string.Empty, BreakingFunc.Of<int, string, string>());
-	}
-
-	[Fact]
-	public void ScanRightSeedCollection()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
-
-		var result = seq.ScanRight(5, (a, b) => a + b);
-		result.AssertCollectionErrorChecking(11);
-
-		result.ToArray()
-			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);
-		Assert.Equal(1, seq.CopyCount);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5, 0, 0, 0, 0);
-		Assert.Equal(2, seq.CopyCount);
-	}
-
-	[Fact]
-	public void ScanRightSeedList()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingList();
-
-		var result = seq.ScanRight(5, (a, b) => a + b);
-		result.AssertCollectionErrorChecking(11);
-
-		result.ToArray()
-			.AssertSequenceEqual(60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 60, 59, 57, 54, 50, 45, 39, 32, 24, 15, 5, 0, 0, 0, 0);
 	}
 }

--- a/Tests/SuperLinq.Test/ScanTest.cs
+++ b/Tests/SuperLinq.Test/ScanTest.cs
@@ -38,42 +38,6 @@ public class ScanTest
 	}
 
 	[Fact]
-	public void ScanCollection()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
-
-		var result = seq.Scan((a, b) => a + b);
-		result.AssertCollectionErrorChecking(10);
-
-		result.ToArray()
-			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
-		Assert.Equal(1, seq.CopyCount);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 0, 0, 0, 0, 0);
-		Assert.Equal(2, seq.CopyCount);
-	}
-
-	[Fact]
-	public void ScanList()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingList();
-
-		var result = seq.Scan((a, b) => a + b);
-		result.AssertCollectionErrorChecking(10);
-
-		result.ToArray()
-			.AssertSequenceEqual(1, 3, 6, 10, 15, 21, 28, 36, 45, 55);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 0, 0, 0, 0, 0);
-	}
-
-	[Fact]
 	public void SeededScanEmpty()
 	{
 		using var seq = TestingSequence.Of<int>();
@@ -107,41 +71,5 @@ public class ScanTest
 
 		_ = Assert.Throws<TestException>(result.Consume);
 		result.Take(4).AssertSequenceEqual(0, 1, 3, 6);
-	}
-
-	[Fact]
-	public void SeededScanCollection()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingCollection();
-
-		var result = seq.Scan(5, (a, b) => a + b);
-		result.AssertCollectionErrorChecking(11);
-
-		result.ToArray()
-			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);
-		Assert.Equal(1, seq.CopyCount);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60, 0, 0, 0, 0);
-		Assert.Equal(2, seq.CopyCount);
-	}
-
-	[Fact]
-	public void SeededScanList()
-	{
-		using var seq = Enumerable.Range(1, 10).AsBreakingList();
-
-		var result = seq.Scan(5, (a, b) => a + b);
-		result.AssertCollectionErrorChecking(11);
-
-		result.ToArray()
-			.AssertSequenceEqual(5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60);
-
-		var arr = new int[20];
-		_ = result.CopyTo(arr, 5);
-		arr
-			.AssertSequenceEqual(0, 0, 0, 0, 0, 5, 6, 8, 11, 15, 20, 26, 33, 41, 50, 60, 0, 0, 0, 0);
 	}
 }

--- a/Tests/SuperLinq.Test/TestExtensions.cs
+++ b/Tests/SuperLinq.Test/TestExtensions.cs
@@ -111,6 +111,12 @@ internal static partial class TestExtensions
 	#endregion
 
 	#region Testing Sequence Generation
+	internal static IEnumerable<IDisposableEnumerable<T>> GetTestingSequence<T>(this IEnumerable<T> input)
+	{
+		// UI will consume one enumeration
+		yield return input.AsTestingSequence(maxEnumerations: 2);
+	}
+
 	internal static IEnumerable<IDisposableEnumerable<T>> GetCollectionSequences<T>(this IEnumerable<T> input)
 	{
 		// UI will consume one enumeration


### PR DESCRIPTION
This PR removes some `CollectionIterators`, which do not meet the correct mechanics of `ICollection<>`.

Fixes #548