### PR TITLE
Remove CommunityToolkit.Diagnostics

### DIFF
--- a/Generators/SuperLinq.Async.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/EquiZip.sbntxt
@@ -42,10 +42,10 @@ public static partial class AsyncSuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(
 			{{~ for $j in 1..$i ~}}
@@ -77,7 +77,7 @@ public static partial class AsyncSuperEnumerable
 							end ~}}
 						)
 					{
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
  					}
 
 					yield break;
@@ -85,7 +85,7 @@ public static partial class AsyncSuperEnumerable
 
 				{{~ for $j in 2..$i ~}}
 				if (!await e{{$j}}.MoveNextAsync())
-					global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
+					ThrowHelper.ThrowInvalidOperationException(
 						"{{ $cardinals[$j] }} sequence too short.");
 				{{~ end ~}}
 

--- a/Generators/SuperLinq.Async.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/Fold.sbntxt
@@ -26,8 +26,8 @@ public static partial class AsyncSuperEnumerable
 		{{~ end ~}}
 		TResult> folder)
     {
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(folder);
 
 		return Core(source, folder);
 

--- a/Generators/SuperLinq.Async.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/ZipLongest.sbntxt
@@ -38,10 +38,10 @@ public static partial class AsyncSuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $j }}?, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(
 			{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Async.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Async.Generator/ZipShortest.sbntxt
@@ -36,10 +36,10 @@ public static partial class AsyncSuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(
 			{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/Aggregate.sbntxt
+++ b/Generators/SuperLinq.Generator/Aggregate.sbntxt
@@ -39,13 +39,13 @@ public static partial class SuperEnumerable
 		{{~ end ~}}
         global::System.Func<{{ for $j in 1..$i }}TAccumulate{{$j}}, {{ end }}TResult> resultSelector)
 	{
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator{{$j}});
+        ArgumentNullException.ThrowIfNull(accumulator{{$j}});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		foreach (var item in source)
 		{

--- a/Generators/SuperLinq.Generator/Cartesian.sbntxt
+++ b/Generators/SuperLinq.Generator/Cartesian.sbntxt
@@ -41,10 +41,10 @@ public static partial class SuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{$j}}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(
 			{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Generator/EquiZip.sbntxt
@@ -185,7 +185,8 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsLessThan(index, Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/EquiZip.sbntxt
+++ b/Generators/SuperLinq.Generator/EquiZip.sbntxt
@@ -42,10 +42,10 @@ public static partial class SuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		if (
 			{{~ for $j in 1..$i ~}}
@@ -88,7 +88,7 @@ public static partial class SuperEnumerable
 							end ~}}
 						)
 					{
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
  					}
 
 					yield break;
@@ -96,7 +96,7 @@ public static partial class SuperEnumerable
 
 				{{~ for $j in 2..$i ~}}
 				if (!e{{$j}}.MoveNext())
-					global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
+					ThrowHelper.ThrowInvalidOperationException(
 						"{{ $cardinals[$j] }} sequence too short.");
 				{{~ end ~}}
 
@@ -162,7 +162,7 @@ public static partial class SuperEnumerable
 				{{~ for $j in 2..$i ~}}
 				if (_list{{ $j }}.Count != count)
 				{
-					global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException(
+					ThrowHelper.ThrowInvalidOperationException(
 						(count < _list{{ $j }}.Count ? "First" : "{{ $cardinals[$j] }}") + " sequence too short.");
 				}
 				{{~ end ~}}
@@ -185,7 +185,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+			Guard.IsLessThan(index, Count);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/Fold.sbntxt
+++ b/Generators/SuperLinq.Generator/Fold.sbntxt
@@ -26,8 +26,8 @@ public static partial class SuperEnumerable
 		{{~ end ~}}
 		TResult> folder)
     {
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(folder);
 
 		var elements = source.AssertCount({{$i}}).ToList();
 

--- a/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
+++ b/Generators/SuperLinq.Generator/ToDelimitedString.sbntxt
@@ -25,8 +25,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<{{t}}> source, global::System.String delimiter)
 	{
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-		global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(delimiter);
 		return ToDelimitedStringImpl(source, delimiter, Builder);
 
 		static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, {{t}} e) => sb.Append(e);

--- a/Generators/SuperLinq.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipLongest.sbntxt
@@ -50,10 +50,10 @@ public static partial class SuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $j }}?, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		if (
 			{{~ for $j in 1..$i ~}}
@@ -160,7 +160,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/ZipLongest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipLongest.sbntxt
@@ -160,7 +160,8 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipShortest.sbntxt
@@ -36,10 +36,10 @@ public static partial class SuperEnumerable
         global::System.Func<{{ for $j in 1..$i }}T{{ $cardinals[$j] }}, {{ end }}TResult> resultSelector)
 	{
 		{{~ for $j in 1..$i ~}}
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull({{ $ordinals[$j] }});
+        ArgumentNullException.ThrowIfNull({{ $ordinals[$j] }});
 		{{~ end ~}}
 
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(resultSelector);
 
 		if (
 			{{~ for $j in 1..$i ~}}
@@ -145,7 +145,7 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Generators/SuperLinq.Generator/ZipShortest.sbntxt
+++ b/Generators/SuperLinq.Generator/ZipShortest.sbntxt
@@ -145,7 +145,8 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			return _resultSelector(
 				{{~ for $j in 1..$i ~}}

--- a/Source/SuperLinq.Async/AggregateBy.cs
+++ b/Source/SuperLinq.Async/AggregateBy.cs
@@ -105,10 +105,10 @@ public static partial class AsyncSuperEnumerable
 		Func<TAccumulate, TSource, TAccumulate> func,
 		IEqualityComparer<TKey>? comparer = null) where TKey : notnull
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, keySelector, seedSelector, func, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq.Async/AggregateRight.cs
+++ b/Source/SuperLinq.Async/AggregateRight.cs
@@ -25,8 +25,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<TSource> AggregateRight<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> func, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.AggregateRight((a, b, ct) => new ValueTask<TSource>(func(a, b)), cancellationToken);
 	}
@@ -54,8 +54,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<TSource> AggregateRight<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.AggregateRight((a, b, ct) => func(a, b), cancellationToken);
 	}
@@ -86,8 +86,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TSource, CancellationToken, ValueTask<TSource>> func,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, func, cancellationToken);
 
@@ -138,8 +138,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TAccumulate> AggregateRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.AggregateRight(seed, (a, b, ct) => new ValueTask<TAccumulate>(func(a, b)), cancellationToken);
 	}
@@ -172,8 +172,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TAccumulate> AggregateRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, ValueTask<TAccumulate>> func, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.AggregateRight(seed, (a, b, ct) => func(a, b), cancellationToken);
 	}
@@ -206,8 +206,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TAccumulate> AggregateRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, CancellationToken, ValueTask<TAccumulate>> func, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, seed, func, cancellationToken);
 
@@ -256,8 +256,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TResult> AggregateRight<TSource, TAccumulate, TResult>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(func);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(func);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.AggregateRight(seed, (a, b, ct) => new ValueTask<TAccumulate>(func(a, b)), (a, ct) => new ValueTask<TResult>(resultSelector(a)), cancellationToken);
 	}
@@ -294,8 +294,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TResult> AggregateRight<TSource, TAccumulate, TResult>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, ValueTask<TAccumulate>> func, Func<TAccumulate, ValueTask<TResult>> resultSelector, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(func);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(func);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.AggregateRight(seed, (a, b, ct) => func(a, b), (a, ct) => resultSelector(a), cancellationToken);
 	}
@@ -332,9 +332,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<TResult> AggregateRight<TSource, TAccumulate, TResult>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, CancellationToken, ValueTask<TAccumulate>> func, Func<TAccumulate, CancellationToken, ValueTask<TResult>> resultSelector, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, seed, func, resultSelector, cancellationToken);
 

--- a/Source/SuperLinq.Async/Amb.cs
+++ b/Source/SuperLinq.Async/Amb.cs
@@ -27,11 +27,11 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<TSource> source,
 		params IAsyncEnumerable<TSource>[] otherSources)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(otherSources);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(otherSources);
 
 		foreach (var s in otherSources)
-			Guard.IsNotNull(s, nameof(otherSources));
+			ArgumentNullException.ThrowIfNull(s, nameof(otherSources));
 
 		return Amb(otherSources.Prepend(source));
 	}
@@ -58,7 +58,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> Amb<TSource>(
 		this IEnumerable<IAsyncEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 

--- a/Source/SuperLinq.Async/AssertCount.cs
+++ b/Source/SuperLinq.Async/AssertCount.cs
@@ -21,7 +21,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> AssertCount<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return Core(source, count);

--- a/Source/SuperLinq.Async/AssertCount.cs
+++ b/Source/SuperLinq.Async/AssertCount.cs
@@ -22,7 +22,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> AssertCount<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return Core(source, count);
 
@@ -38,7 +38,8 @@ public static partial class AsyncSuperEnumerable
 					break;
 				yield return item;
 			}
-			Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+
+			ArgumentOutOfRangeException.ThrowIfNotEqual(c, count, $"{nameof(source)}.Count()");
 		}
 	}
 }

--- a/Source/SuperLinq.Async/Batch.cs
+++ b/Source/SuperLinq.Async/Batch.cs
@@ -24,7 +24,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<IList<TSource>> Batch<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
 		// yes this operator duplicates on net6+; but no name overlap, so leave alone
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return Core(source, size);

--- a/Source/SuperLinq.Async/Batch.cs
+++ b/Source/SuperLinq.Async/Batch.cs
@@ -25,7 +25,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		// yes this operator duplicates on net6+; but no name overlap, so leave alone
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return Core(source, size);
 

--- a/Source/SuperLinq.Async/BindByIndex.cs
+++ b/Source/SuperLinq.Async/BindByIndex.cs
@@ -18,9 +18,7 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<TSource> source,
 		IAsyncEnumerable<int> indices)
 	{
-#pragma warning disable MA0015
-		return BindByIndex(source, indices, static (e, i) => e, static i => throw new ArgumentOutOfRangeException(nameof(indices), "Index is greater than the length of the first sequence."));
-#pragma warning restore MA0015
+		return BindByIndex(source, indices, static (e, i) => e, static i => ThrowHelper.ThrowArgumentOutOfRangeException<TSource>(nameof(indices), "Index is greater than the length of the first sequence."));
 	}
 
 	/// <summary>
@@ -63,7 +61,7 @@ public static partial class AsyncSuperEnumerable
 			[EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			// keeps track of the order of indices to know what order items should be output in
-			var lookup = await indices.Index().ToDictionaryAsync(x => { Guard.IsGreaterThanOrEqualTo(x.item, 0, nameof(indices)); return x.item; }, x => x.index, cancellationToken).ConfigureAwait(false);
+			var lookup = await indices.Index().ToDictionaryAsync(x => { ArgumentOutOfRangeException.ThrowIfNegative(x.item, nameof(indices)); return x.item; }, x => x.index, cancellationToken).ConfigureAwait(false);
 			// keep track of items out of output order
 			var lookback = new Dictionary<int, TSource>();
 

--- a/Source/SuperLinq.Async/BindByIndex.cs
+++ b/Source/SuperLinq.Async/BindByIndex.cs
@@ -51,10 +51,10 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, int, TResult> resultSelector,
 		Func<int, TResult> missingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(indices);
-		Guard.IsNotNull(resultSelector);
-		Guard.IsNotNull(missingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(indices);
+		ArgumentNullException.ThrowIfNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(missingSelector);
 
 		return Core(source, indices, resultSelector, missingSelector);
 

--- a/Source/SuperLinq.Async/Buffer.cs
+++ b/Source/SuperLinq.Async/Buffer.cs
@@ -52,8 +52,8 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IAsyncEnumerable<TSource> source, int count, int skip)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
-		Guard.IsGreaterThan(skip, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(skip);
 
 		return Core(source, count, skip);
 

--- a/Source/SuperLinq.Async/Buffer.cs
+++ b/Source/SuperLinq.Async/Buffer.cs
@@ -51,7 +51,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IAsyncEnumerable<TSource> source, int count, int skip)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 		Guard.IsGreaterThan(skip, 0);
 

--- a/Source/SuperLinq.Async/Case.cs
+++ b/Source/SuperLinq.Async/Case.cs
@@ -28,8 +28,8 @@ public static partial class AsyncSuperEnumerable
 		IDictionary<TValue, IAsyncEnumerable<TResult>> sources)
 		where TValue : notnull
 	{
-		Guard.IsNotNull(selector);
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(selector);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Case(selector.ToAsync(), sources, AsyncEnumerable.Empty<TResult>());
 	}
@@ -60,8 +60,8 @@ public static partial class AsyncSuperEnumerable
 		IDictionary<TValue, IAsyncEnumerable<TResult>> sources)
 		where TValue : notnull
 	{
-		Guard.IsNotNull(selector);
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(selector);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Case(selector, sources, AsyncEnumerable.Empty<TResult>());
 	}
@@ -89,8 +89,8 @@ public static partial class AsyncSuperEnumerable
 		IAsyncEnumerable<TResult> defaultSource)
 		where TValue : notnull
 	{
-		Guard.IsNotNull(selector);
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(selector);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Case(selector.ToAsync(), sources, defaultSource);
 	}
@@ -118,9 +118,9 @@ public static partial class AsyncSuperEnumerable
 		IAsyncEnumerable<TResult> defaultSource)
 		where TValue : notnull
 	{
-		Guard.IsNotNull(selector);
-		Guard.IsNotNull(sources);
-		Guard.IsNotNull(defaultSource);
+		ArgumentNullException.ThrowIfNull(selector);
+		ArgumentNullException.ThrowIfNull(sources);
+		ArgumentNullException.ThrowIfNull(defaultSource);
 
 		return Core(selector, sources, defaultSource);
 

--- a/Source/SuperLinq.Async/Catch.cs
+++ b/Source/SuperLinq.Async/Catch.cs
@@ -21,8 +21,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TException, IAsyncEnumerable<TSource>> handler)
 		where TException : Exception
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(handler);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(handler);
 
 		return Core(source, handler);
 
@@ -71,8 +71,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Catch<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return Catch(new[] { first, second, });
 	}
@@ -89,7 +89,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Catch<TSource>(params IAsyncEnumerable<TSource>[] sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.ToAsyncEnumerable().Catch();
 	}
@@ -106,7 +106,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Catch<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.ToAsyncEnumerable().Catch();
 	}
@@ -123,7 +123,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Catch<TSource>(this IAsyncEnumerable<IAsyncEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 
@@ -146,7 +146,7 @@ public static partial class AsyncSuperEnumerable
 			// make it outside of the inner `while (true)`
 			while (true)
 			{
-				Guard.IsNotNull(source);
+				ArgumentNullException.ThrowIfNull(source);
 				await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
 
 				while (true)

--- a/Source/SuperLinq.Async/Choose.cs
+++ b/Source/SuperLinq.Async/Choose.cs
@@ -33,8 +33,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<T> source,
 		Func<T, (bool, TResult)> chooser)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(chooser);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(chooser);
 
 		return Choose(source, (x, ct) => new ValueTask<(bool, TResult)>(chooser(x)));
 	}
@@ -70,8 +70,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<T> source,
 		Func<T, ValueTask<(bool, TResult)>> chooser)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(chooser);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(chooser);
 
 		return Choose(source, (x, ct) => chooser(x));
 	}
@@ -107,8 +107,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<T> source,
 		Func<T, CancellationToken, ValueTask<(bool, TResult)>> chooser)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(chooser);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(chooser);
 
 		return Core(source, chooser);
 

--- a/Source/SuperLinq.Async/CollectionEqual.cs
+++ b/Source/SuperLinq.Async/CollectionEqual.cs
@@ -81,8 +81,8 @@ public static partial class AsyncSuperEnumerable
 		IEqualityComparer<TSource>? comparer,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return Core(first, second, comparer, cancellationToken);
 

--- a/Source/SuperLinq.Async/ConcurrentMerge.cs
+++ b/Source/SuperLinq.Async/ConcurrentMerge.cs
@@ -74,7 +74,7 @@ public static partial class AsyncSuperEnumerable
 		int maxConcurrency)
 	{
 		ArgumentNullException.ThrowIfNull(sources);
-		Guard.IsGreaterThanOrEqualTo(maxConcurrency, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConcurrency);
 
 		foreach (var s in sources)
 			ArgumentNullException.ThrowIfNull(s, nameof(sources));

--- a/Source/SuperLinq.Async/ConcurrentMerge.cs
+++ b/Source/SuperLinq.Async/ConcurrentMerge.cs
@@ -24,8 +24,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<TSource> source,
 		params IAsyncEnumerable<TSource>[] otherSources)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(otherSources);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(otherSources);
 
 		return ConcurrentMerge(otherSources.Prepend(source), int.MaxValue);
 	}
@@ -73,11 +73,11 @@ public static partial class AsyncSuperEnumerable
 		this IEnumerable<IAsyncEnumerable<TSource>> sources,
 		int maxConcurrency)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 		Guard.IsGreaterThanOrEqualTo(maxConcurrency, 1);
 
 		foreach (var s in sources)
-			Guard.IsNotNull(s, nameof(sources));
+			ArgumentNullException.ThrowIfNull(s, nameof(sources));
 
 		return Core(sources, maxConcurrency);
 

--- a/Source/SuperLinq.Async/Consume.cs
+++ b/Source/SuperLinq.Async/Consume.cs
@@ -11,7 +11,7 @@ public static partial class AsyncSuperEnumerable
 	/// <param name="cancellationToken">The optional cancellation token to be used for cancelling the sequence at any time.</param>
 	public static ValueTask Consume<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return Core(source, cancellationToken);
 
 		static async ValueTask Core(IAsyncEnumerable<T> source, CancellationToken cancellationToken)

--- a/Source/SuperLinq.Async/CopyTo.cs
+++ b/Source/SuperLinq.Async/CopyTo.cs
@@ -53,7 +53,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(list);
-		Guard.IsGreaterThanOrEqualTo(index, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(index);
 
 		if (list is TSource[] array)
 		{

--- a/Source/SuperLinq.Async/CopyTo.cs
+++ b/Source/SuperLinq.Async/CopyTo.cs
@@ -51,8 +51,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static async ValueTask<int> CopyTo<TSource>(this IAsyncEnumerable<TSource> source, IList<TSource> list, int index, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(list);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(list);
 		Guard.IsGreaterThanOrEqualTo(index, 0);
 
 		if (list is TSource[] array)

--- a/Source/SuperLinq.Async/CountBy.cs
+++ b/Source/SuperLinq.Async/CountBy.cs
@@ -32,8 +32,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<(TKey key, int count)> CountBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq.Async/CountDown.cs
+++ b/Source/SuperLinq.Async/CountDown.cs
@@ -73,8 +73,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<TSource> source,
 		int count, Func<TSource, int?, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
 		return Core(source, count, resultSelector);

--- a/Source/SuperLinq.Async/CountDown.cs
+++ b/Source/SuperLinq.Async/CountDown.cs
@@ -75,7 +75,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		return Core(source, count, resultSelector);
 

--- a/Source/SuperLinq.Async/CountMethods.cs
+++ b/Source/SuperLinq.Async/CountMethods.cs
@@ -25,7 +25,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> AtLeast<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return QuantityIterator(source, limit: count, min: count, max: int.MaxValue, cancellationToken);
@@ -54,7 +54,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> AtMost<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return QuantityIterator(source, limit: count + 1, min: 0, max: count, cancellationToken);
@@ -82,7 +82,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> Exactly<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return QuantityIterator(source, limit: count + 1, min: count, max: count, cancellationToken);
@@ -113,7 +113,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> CountBetween<T>(this IAsyncEnumerable<T> source, int min, int max, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(min, 0);
 		Guard.IsGreaterThanOrEqualTo(max, min);
 
@@ -156,8 +156,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<int> CompareCount<TFirst, TSecond>(this IAsyncEnumerable<TFirst> first, IAsyncEnumerable<TSecond> second, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return Core(first, second, cancellationToken);
 

--- a/Source/SuperLinq.Async/CountMethods.cs
+++ b/Source/SuperLinq.Async/CountMethods.cs
@@ -26,7 +26,7 @@ public static partial class AsyncSuperEnumerable
 	public static ValueTask<bool> AtLeast<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, limit: count, min: count, max: int.MaxValue, cancellationToken);
 	}
@@ -55,7 +55,7 @@ public static partial class AsyncSuperEnumerable
 	public static ValueTask<bool> AtMost<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, limit: count + 1, min: 0, max: count, cancellationToken);
 	}
@@ -83,7 +83,7 @@ public static partial class AsyncSuperEnumerable
 	public static ValueTask<bool> Exactly<T>(this IAsyncEnumerable<T> source, int count, CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, limit: count + 1, min: count, max: count, cancellationToken);
 	}
@@ -114,8 +114,8 @@ public static partial class AsyncSuperEnumerable
 	public static ValueTask<bool> CountBetween<T>(this IAsyncEnumerable<T> source, int min, int max, CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(min, 0);
-		Guard.IsGreaterThanOrEqualTo(max, min);
+		ArgumentOutOfRangeException.ThrowIfNegative(min);
+		ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
 		return QuantityIterator(source, limit: max + 1, min: min, max: max, cancellationToken);
 	}

--- a/Source/SuperLinq.Async/Defer.cs
+++ b/Source/SuperLinq.Async/Defer.cs
@@ -12,7 +12,7 @@ public static partial class AsyncSuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IAsyncEnumerable<TResult> Defer<TResult>(Func<IAsyncEnumerable<TResult>> enumerableFactory)
 	{
-		Guard.IsNotNull(enumerableFactory);
+		ArgumentNullException.ThrowIfNull(enumerableFactory);
 
 		return Core(enumerableFactory);
 

--- a/Source/SuperLinq.Async/DensePartialSort.cs
+++ b/Source/SuperLinq.Async/DensePartialSort.cs
@@ -238,9 +238,9 @@ public static partial class AsyncSuperEnumerable
 		IComparer<TKey>? comparer,
 		OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;
 		if (direction == OrderByDirection.Descending)

--- a/Source/SuperLinq.Async/DensePartialSort.cs
+++ b/Source/SuperLinq.Async/DensePartialSort.cs
@@ -239,7 +239,7 @@ public static partial class AsyncSuperEnumerable
 		OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;

--- a/Source/SuperLinq.Async/DistinctBy.cs
+++ b/Source/SuperLinq.Async/DistinctBy.cs
@@ -50,8 +50,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq.Async/DistinctUntilChanged.cs
+++ b/Source/SuperLinq.Async/DistinctUntilChanged.cs
@@ -24,7 +24,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource>(this IAsyncEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return DistinctUntilChanged(source, Identity, comparer);
 	}
 
@@ -41,7 +41,7 @@ public static partial class AsyncSuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return DistinctUntilChanged<TSource, TKey>(source, keySelector.ToAsync(), comparer: null);
 	}
 
@@ -74,7 +74,7 @@ public static partial class AsyncSuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return DistinctUntilChanged(source, keySelector.ToAsync(), comparer);
 	}
 
@@ -91,8 +91,8 @@ public static partial class AsyncSuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq.Async/Do.cs
+++ b/Source/SuperLinq.Async/Do.cs
@@ -16,8 +16,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
 
 		return Do(source, onNext.ToAsync(), onCompleted: () => default);
 	}
@@ -36,8 +36,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask> onNext)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
 
 		return Do(source, onNext, onCompleted: () => default);
 	}
@@ -57,9 +57,9 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext, Action onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return Do(source, onNext.ToAsync(), onCompleted.ToAsync());
 	}
@@ -79,9 +79,9 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask> onNext, Func<ValueTask> onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return Core(source, onNext, onCompleted);
 
@@ -117,9 +117,9 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onError);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onError);
 
 		return Do(source, onNext.ToAsync(), onError.ToAsync(), onCompleted: () => default);
 	}
@@ -139,9 +139,9 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask> onNext, Func<Exception, ValueTask> onError)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onError);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onError);
 
 		return Do(source, onNext, onError, onCompleted: () => default);
 	}
@@ -163,10 +163,10 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onError);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onError);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return Do(source, onNext.ToAsync(), onError.ToAsync(), onCompleted.ToAsync());
 	}
@@ -188,10 +188,10 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Do<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask> onNext, Func<Exception, ValueTask> onError, Func<ValueTask> onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onError);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onError);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return Core(source, onNext, onError, onCompleted);
 

--- a/Source/SuperLinq.Async/DoWhile.cs
+++ b/Source/SuperLinq.Async/DoWhile.cs
@@ -23,7 +23,7 @@ public partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> DoWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<bool> condition)
 	{
-		Guard.IsNotNull(condition);
+		ArgumentNullException.ThrowIfNull(condition);
 
 		return DoWhile(source, condition.ToAsync());
 	}
@@ -50,8 +50,8 @@ public partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> DoWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<ValueTask<bool>> condition)
 	{
 
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(condition);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(condition);
 
 		return Core(source, condition);
 

--- a/Source/SuperLinq.Async/ElementAt.cs
+++ b/Source/SuperLinq.Async/ElementAt.cs
@@ -21,7 +21,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<TSource> ElementAtAsync<TSource>(this IAsyncEnumerable<TSource> source, Index index, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (!index.IsFromEnd)
 		{
@@ -54,7 +54,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Index index, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (!index.IsFromEnd)
 		{

--- a/Source/SuperLinq.Async/EndsWith.cs
+++ b/Source/SuperLinq.Async/EndsWith.cs
@@ -23,8 +23,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<bool> EndsWith<T>(this IAsyncEnumerable<T> first, IEnumerable<T> second, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return EndsWith(first, second.ToAsyncEnumerable(), comparer: null, cancellationToken);
 	}
@@ -74,8 +74,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<bool> EndsWith<T>(this IAsyncEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return EndsWith(first, second.ToAsyncEnumerable(), comparer, cancellationToken);
 	}
@@ -101,8 +101,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<bool> EndsWith<T>(this IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, IEqualityComparer<T>? comparer, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		comparer ??= EqualityComparer<T>.Default;
 

--- a/Source/SuperLinq.Async/ExceptBy.cs
+++ b/Source/SuperLinq.Async/ExceptBy.cs
@@ -59,9 +59,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? keyComparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(first, second, keySelector, keyComparer);
 

--- a/Source/SuperLinq.Async/FallbackIfEmpty.cs
+++ b/Source/SuperLinq.Async/FallbackIfEmpty.cs
@@ -37,8 +37,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="fallback"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<T> FallbackIfEmpty<T>(this IAsyncEnumerable<T> source, IEnumerable<T> fallback)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(fallback);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(fallback);
 
 		return source.FallbackIfEmpty(fallback.ToAsyncEnumerable());
 	}
@@ -59,8 +59,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="fallback"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<T> FallbackIfEmpty<T>(this IAsyncEnumerable<T> source, IAsyncEnumerable<T> fallback)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(fallback);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(fallback);
 
 		return Core(source, fallback);
 

--- a/Source/SuperLinq.Async/FillBackward.cs
+++ b/Source/SuperLinq.Async/FillBackward.cs
@@ -45,8 +45,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return FillBackwardImpl(source, i => new ValueTask<bool>(predicate(i)), fillSelector: null);
 	}
@@ -72,8 +72,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return FillBackwardImpl(source, predicate, fillSelector: null);
 	}
@@ -104,9 +104,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillBackwardImpl(source, i => new ValueTask<bool>(predicate(i)), (a, b) => new ValueTask<T>(fillSelector(a, b)));
 	}
@@ -137,9 +137,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillBackwardImpl(source, predicate, (a, b) => new ValueTask<T>(fillSelector(a, b)));
 	}
@@ -170,9 +170,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate, Func<T, T, ValueTask<T>> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillBackwardImpl(source, i => new ValueTask<bool>(predicate(i)), fillSelector);
 	}
@@ -203,9 +203,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillBackward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate, Func<T, T, ValueTask<T>> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillBackwardImpl(source, predicate, fillSelector);
 	}

--- a/Source/SuperLinq.Async/FillForward.cs
+++ b/Source/SuperLinq.Async/FillForward.cs
@@ -45,8 +45,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return FillForwardImpl(source, i => new ValueTask<bool>(predicate(i)), fillSelector: null);
 	}
@@ -72,8 +72,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return FillForwardImpl(source, predicate, fillSelector: null);
 	}
@@ -104,9 +104,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillForwardImpl(source, i => new ValueTask<bool>(predicate(i)), (a, b) => new ValueTask<T>(fillSelector(a, b)));
 	}
@@ -137,9 +137,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillForwardImpl(source, predicate, (a, b) => new ValueTask<T>(fillSelector(a, b)));
 	}
@@ -170,9 +170,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, bool> predicate, Func<T, T, ValueTask<T>> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillForwardImpl(source, i => new ValueTask<bool>(predicate(i)), fillSelector);
 	}
@@ -203,9 +203,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> FillForward<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> predicate, Func<T, T, ValueTask<T>> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return FillForwardImpl(source, predicate, fillSelector);
 	}

--- a/Source/SuperLinq.Async/Finally.cs
+++ b/Source/SuperLinq.Async/Finally.cs
@@ -19,8 +19,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Finally<TSource>(this IAsyncEnumerable<TSource> source, Action finallyAction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(finallyAction);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(finallyAction);
 
 		return Core(source, finallyAction);
 

--- a/Source/SuperLinq.Async/FindIndex.cs
+++ b/Source/SuperLinq.Async/FindIndex.cs
@@ -113,8 +113,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<int> FindIndex<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, Index index, int count, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return Core(source, predicate, index, count, cancellationToken);

--- a/Source/SuperLinq.Async/FindIndex.cs
+++ b/Source/SuperLinq.Async/FindIndex.cs
@@ -115,7 +115,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return Core(source, predicate, index, count, cancellationToken);
 

--- a/Source/SuperLinq.Async/FindLastIndex.cs
+++ b/Source/SuperLinq.Async/FindLastIndex.cs
@@ -119,7 +119,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return Core(source, predicate, index, count, cancellationToken);
 

--- a/Source/SuperLinq.Async/FindLastIndex.cs
+++ b/Source/SuperLinq.Async/FindLastIndex.cs
@@ -117,8 +117,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static ValueTask<int> FindLastIndex<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, Index index, int count, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		return Core(source, predicate, index, count, cancellationToken);

--- a/Source/SuperLinq.Async/ForEach.cs
+++ b/Source/SuperLinq.Async/ForEach.cs
@@ -19,8 +19,8 @@ public partial class AsyncSuperEnumerable
 		Action<TSource> action,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		return Core(source, action, cancellationToken);
 
@@ -51,8 +51,8 @@ public partial class AsyncSuperEnumerable
 		Func<TSource, ValueTask> action,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		return Core(source, action, cancellationToken);
 
@@ -85,8 +85,8 @@ public partial class AsyncSuperEnumerable
 		Action<TSource, int> action,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		return Core(source, action, cancellationToken);
 
@@ -120,8 +120,8 @@ public partial class AsyncSuperEnumerable
 		Func<TSource, int, ValueTask> action,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		return Core(source, action, cancellationToken);
 

--- a/Source/SuperLinq.Async/From.cs
+++ b/Source/SuperLinq.Async/From.cs
@@ -16,7 +16,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> From<T>(Func<Task<T>> function)
 	{
-		Guard.IsNotNull(function);
+		ArgumentNullException.ThrowIfNull(function);
 		return Core(function);
 
 		static async IAsyncEnumerable<T> Core(Func<Task<T>> function, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -41,8 +41,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> From<T>(Func<Task<T>> function1, Func<Task<T>> function2)
 	{
-		Guard.IsNotNull(function1);
-		Guard.IsNotNull(function2);
+		ArgumentNullException.ThrowIfNull(function1);
+		ArgumentNullException.ThrowIfNull(function2);
 		return Core(function1, function2);
 
 		static async IAsyncEnumerable<T> Core(Func<Task<T>> function1, Func<Task<T>> function2, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -70,9 +70,9 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> From<T>(Func<Task<T>> function1, Func<Task<T>> function2, Func<Task<T>> function3)
 	{
-		Guard.IsNotNull(function1);
-		Guard.IsNotNull(function2);
-		Guard.IsNotNull(function3);
+		ArgumentNullException.ThrowIfNull(function1);
+		ArgumentNullException.ThrowIfNull(function2);
+		ArgumentNullException.ThrowIfNull(function3);
 		return Core(function1, function2, function3);
 
 		static async IAsyncEnumerable<T> Core(Func<Task<T>> function1, Func<Task<T>> function2, Func<Task<T>> function3, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -117,7 +117,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> Evaluate<T>(this IEnumerable<Func<Task<T>>> functions)
 	{
-		Guard.IsNotNull(functions);
+		ArgumentNullException.ThrowIfNull(functions);
 		return Core(functions);
 
 		static async IAsyncEnumerable<T> Core(IEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -145,7 +145,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<T> Evaluate<T>(this IAsyncEnumerable<Func<Task<T>>> functions)
 	{
-		Guard.IsNotNull(functions);
+		ArgumentNullException.ThrowIfNull(functions);
 		return Core(functions);
 
 		static async IAsyncEnumerable<T> Core(IAsyncEnumerable<Func<Task<T>>> functions, [EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Source/SuperLinq.Async/Generate.cs
+++ b/Source/SuperLinq.Async/Generate.cs
@@ -23,7 +23,7 @@ public static partial class AsyncSuperEnumerable
 	/// </example>
 	public static IAsyncEnumerable<TResult> Generate<TResult>(TResult initial, Func<TResult, ValueTask<TResult>> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 		return Generate(initial, (r, ct) => generator(r));
 	}
 
@@ -48,7 +48,7 @@ public static partial class AsyncSuperEnumerable
 	/// </example>
 	public static IAsyncEnumerable<TResult> Generate<TResult>(TResult initial, Func<TResult, CancellationToken, ValueTask<TResult>> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Core(initial, generator);
 

--- a/Source/SuperLinq.Async/GenerateByIndex.cs
+++ b/Source/SuperLinq.Async/GenerateByIndex.cs
@@ -21,7 +21,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TResult> GenerateByIndex<TResult>(Func<int, TResult> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Sequence(0, int.MaxValue)
 			.Select(generator);
@@ -46,7 +46,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TResult> GenerateByIndex<TResult>(Func<int, ValueTask<TResult>> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Sequence(0, int.MaxValue)
 			.SelectAwait(generator);
@@ -71,7 +71,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TResult> GenerateByIndex<TResult>(Func<int, CancellationToken, ValueTask<TResult>> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Sequence(0, int.MaxValue)
 			.SelectAwaitWithCancellation(generator);

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/EquiZip.g.cs
@@ -28,9 +28,9 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> EquiZip<TFirst, TSecond, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -42,14 +42,14 @@ public static partial class AsyncSuperEnumerable
                 {
                     if (await e2.MoveNextAsync())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!await e2.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current);
             }
         }
@@ -102,10 +102,10 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> EquiZip<TFirst, TSecond, TThird, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -118,16 +118,16 @@ public static partial class AsyncSuperEnumerable
                 {
                     if (await e2.MoveNextAsync() || await e3.MoveNextAsync())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!await e2.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 if (!await e3.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current, e3.Current);
             }
         }
@@ -184,11 +184,11 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> EquiZip<TFirst, TSecond, TThird, TFourth, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -202,18 +202,18 @@ public static partial class AsyncSuperEnumerable
                 {
                     if (await e2.MoveNextAsync() || await e3.MoveNextAsync() || await e4.MoveNextAsync())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!await e2.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 if (!await e3.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
                 if (!await e4.MoveNextAsync())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Fourth sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Fourth sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current, e3.Current, e4.Current);
             }
         }

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/Fold.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/Fold.g.cs
@@ -19,8 +19,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, TResult> folder)
         {
@@ -46,8 +46,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, TResult> folder)
         {
@@ -73,8 +73,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, TResult> folder)
         {
@@ -100,8 +100,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, TResult> folder)
         {
@@ -127,8 +127,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, TResult> folder)
         {
@@ -154,8 +154,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, TResult> folder)
         {
@@ -181,8 +181,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, TResult> folder)
         {
@@ -208,8 +208,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -235,8 +235,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -262,8 +262,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -289,8 +289,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -316,8 +316,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -343,8 +343,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -370,8 +370,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -397,8 +397,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -424,8 +424,8 @@ public static partial class AsyncSuperEnumerable
     /// </exception>
     public static global::System.Threading.Tasks.ValueTask<TResult> Fold<T, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         return Core(source, folder);
         static async global::System.Threading.Tasks.ValueTask<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/ZipLongest.g.cs
@@ -24,9 +24,9 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipLongest<T1, T2, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -88,10 +88,10 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipLongest<T1, T2, T3, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -160,11 +160,11 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipLongest<T1, T2, T3, T4, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Collections.Generic.IAsyncEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<T1> first, global::System.Collections.Generic.IAsyncEnumerable<T2> second, global::System.Collections.Generic.IAsyncEnumerable<T3> third, global::System.Collections.Generic.IAsyncEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq.Async/Generated/SuperLinq.Async.Generator/SuperLinq.Async.Generator.Generator/ZipShortest.g.cs
@@ -22,9 +22,9 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipShortest<TFirst, TSecond, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -78,10 +78,10 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipShortest<TFirst, TSecond, TThird, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -140,11 +140,11 @@ public static partial class AsyncSuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IAsyncEnumerable<TResult> ZipShortest<TFirst, TSecond, TThird, TFourth, TResult>(this global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, resultSelector);
         static async global::System.Collections.Generic.IAsyncEnumerable<TResult> Core(global::System.Collections.Generic.IAsyncEnumerable<TFirst> first, global::System.Collections.Generic.IAsyncEnumerable<TSecond> second, global::System.Collections.Generic.IAsyncEnumerable<TThird> third, global::System.Collections.Generic.IAsyncEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/Source/SuperLinq.Async/GetShortestPath.cs
+++ b/Source/SuperLinq.Async/GetShortestPath.cs
@@ -141,9 +141,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -266,9 +266,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -452,9 +452,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -581,9 +581,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -790,8 +790,8 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -985,9 +985,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -1116,9 +1116,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -1319,9 +1319,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -1462,9 +1462,9 @@ public partial class AsyncSuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;

--- a/Source/SuperLinq.Async/GlobalUsings.cs
+++ b/Source/SuperLinq.Async/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿#if !NET6_0_OR_GREATER
+global using ArgumentNullException = SuperLinq.Exceptions.ArgumentNullException;
+#endif
+
+#if !NET8_0_OR_GREATER
+global using ArgumentOutOfRangeException = SuperLinq.Exceptions.ArgumentOutOfRangeException;
+#endif

--- a/Source/SuperLinq.Async/GroupAdjacent.cs
+++ b/Source/SuperLinq.Async/GroupAdjacent.cs
@@ -65,8 +65,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return GroupAdjacent(source, keySelector, Identity, comparer);
 	}
@@ -105,9 +105,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		Func<TSource, TElement> elementSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(elementSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(elementSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, elementSelector,
@@ -153,9 +153,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TElement> elementSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(elementSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(elementSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, elementSelector,
@@ -197,9 +197,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, Identity,
@@ -244,9 +244,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TKey, IEnumerable<TSource>, TResult> resultSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, Identity,

--- a/Source/SuperLinq.Async/HasDuplicates.cs
+++ b/Source/SuperLinq.Async/HasDuplicates.cs
@@ -59,8 +59,8 @@ public static partial class AsyncSuperEnumerable
 	/// </returns>
 	public static ValueTask<bool> HasDuplicates<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer);
 

--- a/Source/SuperLinq.Async/If.cs
+++ b/Source/SuperLinq.Async/If.cs
@@ -20,8 +20,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TResult> If<TResult>(Func<bool> condition, IAsyncEnumerable<TResult> thenSource)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(thenSource);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(thenSource);
 
 		return If(condition.ToAsync(), thenSource, AsyncEnumerable.Empty<TResult>());
 	}
@@ -44,8 +44,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TResult> If<TResult>(Func<ValueTask<bool>> condition, IAsyncEnumerable<TResult> thenSource)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(thenSource);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(thenSource);
 
 		return If(condition, thenSource, AsyncEnumerable.Empty<TResult>());
 	}
@@ -71,9 +71,9 @@ public static partial class AsyncSuperEnumerable
 		IAsyncEnumerable<TResult> thenSource,
 		IAsyncEnumerable<TResult> elseSource)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(thenSource);
-		Guard.IsNotNull(elseSource);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(thenSource);
+		ArgumentNullException.ThrowIfNull(elseSource);
 
 		return If(condition.ToAsync(), thenSource, elseSource);
 	}
@@ -99,9 +99,9 @@ public static partial class AsyncSuperEnumerable
 		IAsyncEnumerable<TResult> thenSource,
 		IAsyncEnumerable<TResult> elseSource)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(thenSource);
-		Guard.IsNotNull(elseSource);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(thenSource);
+		ArgumentNullException.ThrowIfNull(elseSource);
 
 		return Case(
 			condition,

--- a/Source/SuperLinq.Async/Index.cs
+++ b/Source/SuperLinq.Async/Index.cs
@@ -31,7 +31,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<(int index, TSource item)> Index<TSource>(this IAsyncEnumerable<TSource> source, int startIndex)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return source.Select((item, index) => (startIndex + index, item));
 	}
 }

--- a/Source/SuperLinq.Async/Insert.cs
+++ b/Source/SuperLinq.Async/Insert.cs
@@ -32,7 +32,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(first);
 		ArgumentNullException.ThrowIfNull(second);
-		Guard.IsGreaterThanOrEqualTo(index, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(index);
 
 		return Core(first, second, index);
 

--- a/Source/SuperLinq.Async/Insert.cs
+++ b/Source/SuperLinq.Async/Insert.cs
@@ -30,8 +30,8 @@ public static partial class AsyncSuperEnumerable
 	/// </exception>
 	public static IAsyncEnumerable<T> Insert<T>(this IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, int index)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 		Guard.IsGreaterThanOrEqualTo(index, 0);
 
 		return Core(first, second, index);
@@ -88,8 +88,8 @@ public static partial class AsyncSuperEnumerable
 	/// </exception>
 	public static IAsyncEnumerable<T> Insert<T>(this IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, Index index)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return !index.IsFromEnd ? Insert(first, second, index) :
 			index.Value == 0 ? first.Concat(second) :

--- a/Source/SuperLinq.Async/Interleave.cs
+++ b/Source/SuperLinq.Async/Interleave.cs
@@ -26,8 +26,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException">Any of the items in <paramref name="otherSources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<T> Interleave<T>(this IAsyncEnumerable<T> source, params IAsyncEnumerable<T>[] otherSources)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(otherSources);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(otherSources);
 		return Interleave(otherSources.Prepend(source));
 	}
 
@@ -53,7 +53,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<T> Interleave<T>(this IEnumerable<IAsyncEnumerable<T>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 

--- a/Source/SuperLinq.Async/Join.MergeJoin.cs
+++ b/Source/SuperLinq.Async/Join.MergeJoin.cs
@@ -14,7 +14,7 @@ public static partial class AsyncSuperEnumerable
 		}
 
 		public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => _comparer.Compare(x, y) == 0;
-		public int GetHashCode([DisallowNull] TKey obj) => throw new NotSupportedException();
+		public int GetHashCode([DisallowNull] TKey obj) => ThrowHelper.ThrowNotSupportedException<int>();
 	}
 
 	private static async IAsyncEnumerable<TResult> MergeJoin<TLeft, TRight, TKey, TResult>(

--- a/Source/SuperLinq.Async/Join.cs
+++ b/Source/SuperLinq.Async/Join.cs
@@ -22,17 +22,17 @@ public static partial class AsyncSuperEnumerable
 		Func<TRight, TResult>? rightResultSelector,
 		Func<TLeft, TRight, TResult> bothResultSelector)
 	{
-		Guard.IsNotNull(left);
-		Guard.IsNotNull(right);
-		Guard.IsNotNull(leftKeySelector);
-		Guard.IsNotNull(rightKeySelector);
+		ArgumentNullException.ThrowIfNull(left);
+		ArgumentNullException.ThrowIfNull(right);
+		ArgumentNullException.ThrowIfNull(leftKeySelector);
+		ArgumentNullException.ThrowIfNull(rightKeySelector);
 
 		if (joinOperation.HasFlag(JoinOperation.LeftOuter))
-			Guard.IsNotNull(leftResultSelector);
+			ArgumentNullException.ThrowIfNull(leftResultSelector);
 		if (joinOperation.HasFlag(JoinOperation.RightOuter))
-			Guard.IsNotNull(rightResultSelector);
+			ArgumentNullException.ThrowIfNull(rightResultSelector);
 
-		Guard.IsNotNull(bothResultSelector);
+		ArgumentNullException.ThrowIfNull(bothResultSelector);
 
 		return joinType switch
 		{
@@ -85,18 +85,18 @@ public static partial class AsyncSuperEnumerable
 		TComparer comparer)
 		where TComparer : notnull, IComparer<TKey>, IEqualityComparer<TKey>
 	{
-		Guard.IsNotNull(left);
-		Guard.IsNotNull(right);
-		Guard.IsNotNull(leftKeySelector);
-		Guard.IsNotNull(rightKeySelector);
+		ArgumentNullException.ThrowIfNull(left);
+		ArgumentNullException.ThrowIfNull(right);
+		ArgumentNullException.ThrowIfNull(leftKeySelector);
+		ArgumentNullException.ThrowIfNull(rightKeySelector);
 
 		if (joinOperation.HasFlag(JoinOperation.LeftOuter))
-			Guard.IsNotNull(leftResultSelector);
+			ArgumentNullException.ThrowIfNull(leftResultSelector);
 		if (joinOperation.HasFlag(JoinOperation.RightOuter))
-			Guard.IsNotNull(rightResultSelector);
+			ArgumentNullException.ThrowIfNull(rightResultSelector);
 
-		Guard.IsNotNull(bothResultSelector);
-		Guard.IsNotNull(comparer);
+		ArgumentNullException.ThrowIfNull(bothResultSelector);
+		ArgumentNullException.ThrowIfNull(comparer);
 
 		return joinType switch
 		{

--- a/Source/SuperLinq.Async/Lag.cs
+++ b/Source/SuperLinq.Async/Lag.cs
@@ -85,7 +85,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLagValue, resultSelector);
 

--- a/Source/SuperLinq.Async/Lag.cs
+++ b/Source/SuperLinq.Async/Lag.cs
@@ -16,7 +16,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<(TSource current, TSource? lag)> Lag<TSource>(this IAsyncEnumerable<TSource> source, int offset)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return source.Select(Some)
 					 .Lag(offset, default, (curr, lag) => (curr.Value, lag is (true, var some) ? some : default));
@@ -38,8 +38,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lag<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Select(Some)
 					 .Lag(offset, default, (curr, lag) => resultSelector(curr.Value, lag is (true, var some) ? some : default));
@@ -61,8 +61,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lag<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Lag(offset, defaultLagValue, (curr, lag) => new ValueTask<TResult>(resultSelector(curr, lag)));
 	}
@@ -83,8 +83,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lag<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLagValue, resultSelector);

--- a/Source/SuperLinq.Async/Lead.cs
+++ b/Source/SuperLinq.Async/Lead.cs
@@ -16,7 +16,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<(TSource current, TSource? lead)> Lead<TSource>(this IAsyncEnumerable<TSource> source, int offset)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return source.Select(Some)
 					 .Lead(offset, default, (curr, lead) => (curr.Value, lead is (true, var some) ? some : default));
@@ -39,8 +39,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lead<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Select(Some)
 					 .Lead(offset, default, (curr, lead) => resultSelector(curr.Value, lead is (true, var some) ? some : default));
@@ -62,8 +62,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lead<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Lead(offset, defaultLeadValue, (curr, lead) => new ValueTask<TResult>(resultSelector(curr, lead)));
 	}
@@ -84,8 +84,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TResult> Lead<TSource, TResult>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, ValueTask<TResult>> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLeadValue, resultSelector);

--- a/Source/SuperLinq.Async/Lead.cs
+++ b/Source/SuperLinq.Async/Lead.cs
@@ -86,7 +86,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLeadValue, resultSelector);
 

--- a/Source/SuperLinq.Async/Memoize.cs
+++ b/Source/SuperLinq.Async/Memoize.cs
@@ -27,7 +27,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncBuffer<TSource> Memoize<TSource>(this IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return new EnumerableMemoizedBuffer<TSource>(source);
 	}
@@ -100,7 +100,7 @@ public static partial class AsyncSuperEnumerable
 
 				if (_exceptionIndex == -1)
 				{
-					Guard.IsNotNull(_exception);
+					ArgumentNullException.ThrowIfNull(_exception);
 					_exception.Throw();
 				}
 

--- a/Source/SuperLinq.Async/Memoize.cs
+++ b/Source/SuperLinq.Async/Memoize.cs
@@ -57,13 +57,13 @@ public static partial class AsyncSuperEnumerable
 		public async ValueTask Reset(CancellationToken cancellationToken = default)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			await _lock.WaitAsync(cancellationToken);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				_buffer = new();
 				_initialized = false;
@@ -88,13 +88,13 @@ public static partial class AsyncSuperEnumerable
 		private void InitializeEnumerator(CancellationToken cancellationToken)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			_lock.Wait(cancellationToken);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -134,13 +134,13 @@ public static partial class AsyncSuperEnumerable
 				T? element;
 
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
 				try
 				{
 					if (_disposed)
-						ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 					if (!_initialized
 						|| buffer != _buffer)
 					{

--- a/Source/SuperLinq.Async/OnErrorResumeNext.cs
+++ b/Source/SuperLinq.Async/OnErrorResumeNext.cs
@@ -13,8 +13,8 @@ public static partial class AsyncSuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return OnErrorResumeNext(new[] { first, second, });
 	}
@@ -29,7 +29,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(params IAsyncEnumerable<TSource>[] sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.ToAsyncEnumerable().OnErrorResumeNext();
 	}
@@ -44,7 +44,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.ToAsyncEnumerable().OnErrorResumeNext();
 	}
@@ -59,7 +59,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> OnErrorResumeNext<TSource>(this IAsyncEnumerable<IAsyncEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 
@@ -69,7 +69,7 @@ public static partial class AsyncSuperEnumerable
 		{
 			await foreach (var source in sources.WithCancellation(cancellationToken).ConfigureAwait(false))
 			{
-				Guard.IsNotNull(source);
+				ArgumentNullException.ThrowIfNull(source);
 				await using var e = source.GetConfiguredAsyncEnumerator(cancellationToken);
 
 				while (true)

--- a/Source/SuperLinq.Async/OrderBy.cs
+++ b/Source/SuperLinq.Async/OrderBy.cs
@@ -14,8 +14,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IOrderedAsyncEnumerable<T> OrderBy<T, TKey>(this IAsyncEnumerable<T> source, Func<T, TKey> keySelector, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 			? source.OrderBy(keySelector)
 			: source.OrderByDescending(keySelector);
@@ -34,8 +34,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IOrderedAsyncEnumerable<T> OrderBy<T, TKey>(this IAsyncEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey> comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 			? source.OrderBy(keySelector, comparer)
 			: source.OrderByDescending(keySelector, comparer);
@@ -53,8 +53,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IOrderedAsyncEnumerable<T> ThenBy<T, TKey>(this IOrderedAsyncEnumerable<T> source, Func<T, TKey> keySelector, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 			? source.ThenBy(keySelector)
 			: source.ThenByDescending(keySelector);
@@ -73,8 +73,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IOrderedAsyncEnumerable<T> ThenBy<T, TKey>(this IOrderedAsyncEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey> comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 			? source.ThenBy(keySelector, comparer)
 			: source.ThenByDescending(keySelector, comparer);

--- a/Source/SuperLinq.Async/Pad.cs
+++ b/Source/SuperLinq.Async/Pad.cs
@@ -89,8 +89,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="width"/> is less than 0.</exception>
 	public static IAsyncEnumerable<TSource> Pad<TSource>(this IAsyncEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(paddingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
 		return Core(source, width, paddingSelector);

--- a/Source/SuperLinq.Async/Pad.cs
+++ b/Source/SuperLinq.Async/Pad.cs
@@ -91,7 +91,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(paddingSelector);
-		Guard.IsGreaterThanOrEqualTo(width, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(width);
 
 		return Core(source, width, paddingSelector);
 

--- a/Source/SuperLinq.Async/PadStart.cs
+++ b/Source/SuperLinq.Async/PadStart.cs
@@ -92,7 +92,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(paddingSelector);
-		Guard.IsGreaterThanOrEqualTo(width, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(width);
 
 		return PadStartImpl(source, width, paddingSelector);
 

--- a/Source/SuperLinq.Async/PadStart.cs
+++ b/Source/SuperLinq.Async/PadStart.cs
@@ -90,8 +90,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="width"/> is less than 0.</exception>
 	public static IAsyncEnumerable<TSource> PadStart<TSource>(this IAsyncEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(paddingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
 		return PadStartImpl(source, width, paddingSelector);

--- a/Source/SuperLinq.Async/PartialSort.cs
+++ b/Source/SuperLinq.Async/PartialSort.cs
@@ -109,7 +109,7 @@ public static partial class AsyncSuperEnumerable
 		IComparer<T>? comparer, OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		comparer ??= Comparer<T>.Default;
 		if (direction == OrderByDirection.Descending)
@@ -271,7 +271,7 @@ public static partial class AsyncSuperEnumerable
 		OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;

--- a/Source/SuperLinq.Async/PartialSort.cs
+++ b/Source/SuperLinq.Async/PartialSort.cs
@@ -108,7 +108,7 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<T> source, int count,
 		IComparer<T>? comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
 		comparer ??= Comparer<T>.Default;
@@ -270,9 +270,9 @@ public static partial class AsyncSuperEnumerable
 		IComparer<TKey>? comparer,
 		OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;
 		if (direction == OrderByDirection.Descending)

--- a/Source/SuperLinq.Async/Partition.cs
+++ b/Source/SuperLinq.Async/Partition.cs
@@ -67,9 +67,9 @@ public static partial class AsyncSuperEnumerable
 		Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, predicate, resultSelector, cancellationToken);
 
@@ -107,8 +107,8 @@ public static partial class AsyncSuperEnumerable
 		Func<IAsyncEnumerable<T>, IAsyncEnumerable<T>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Partition(
 			key1: true, key2: false,
@@ -140,8 +140,8 @@ public static partial class AsyncSuperEnumerable
 		Func<IAsyncEnumerable<T>, IAsyncEnumerable<T>, IAsyncEnumerable<T>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Partition(
 			key1: true, key2: false, key3: null,
@@ -210,8 +210,8 @@ public static partial class AsyncSuperEnumerable
 		Func<IAsyncEnumerable<TElement>, IAsyncEnumerable<IAsyncGrouping<TKey, TElement>>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(
 			source, 1, key, key2: default, key3: default, comparer,
@@ -284,8 +284,8 @@ public static partial class AsyncSuperEnumerable
 		Func<IAsyncEnumerable<TElement>, IAsyncEnumerable<TElement>, IAsyncEnumerable<IAsyncGrouping<TKey, TElement>>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(
 			source, 2, key1, key2, key3: default, comparer,
@@ -360,8 +360,8 @@ public static partial class AsyncSuperEnumerable
 		Func<IAsyncEnumerable<TElement>, IAsyncEnumerable<TElement>, IAsyncEnumerable<TElement>, IAsyncEnumerable<IAsyncGrouping<TKey, TElement>>, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(source, 3, key1, key2, key3, comparer, resultSelector, cancellationToken);
 	}

--- a/Source/SuperLinq.Async/PreScan.cs
+++ b/Source/SuperLinq.Async/PreScan.cs
@@ -42,8 +42,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TSource, TSource> transformation,
 		TSource identity)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, transformation, identity);
 

--- a/Source/SuperLinq.Async/Publish.cs
+++ b/Source/SuperLinq.Async/Publish.cs
@@ -48,13 +48,13 @@ public static partial class AsyncSuperEnumerable
 		public async ValueTask Reset(CancellationToken cancellationToken = default)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				_initialized = false;
 				_version++;
@@ -82,13 +82,13 @@ public static partial class AsyncSuperEnumerable
 		private (Queue<T> buffer, int version) InitializeEnumerator(CancellationToken cancellationToken)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			_lock.Wait(cancellationToken);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -135,13 +135,13 @@ public static partial class AsyncSuperEnumerable
 					T? element;
 
 					if (_disposed)
-						ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 					await _lock.WaitAsync(cancellationToken);
 					try
 					{
 						if (_disposed)
-							ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+							ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 						if (!_initialized
 							|| version != _version)
 						{

--- a/Source/SuperLinq.Async/Publish.cs
+++ b/Source/SuperLinq.Async/Publish.cs
@@ -17,7 +17,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IAsyncBuffer<TSource> Publish<TSource>(this IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return new PublishBuffer<TSource>(source);
 	}

--- a/Source/SuperLinq.Async/Random.cs
+++ b/Source/SuperLinq.Async/Random.cs
@@ -67,7 +67,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<int> Random(int maxValue)
 	{
-		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(maxValue);
 
 		return Random(s_randomInstance, maxValue);
 	}
@@ -84,7 +84,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<int> Random(Random rand, int maxValue)
 	{
 		ArgumentNullException.ThrowIfNull(rand);
-		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(maxValue);
 
 		return RandomImpl(rand, r => r.Next(maxValue));
 	}
@@ -130,7 +130,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<int> Random(Random rand, int minValue, int maxValue)
 	{
 		ArgumentNullException.ThrowIfNull(rand);
-		Guard.IsLessThanOrEqualTo(minValue, maxValue);
+		ArgumentOutOfRangeException.ThrowIfLessThan(maxValue, minValue);
 
 		return RandomImpl(rand, r => r.Next(minValue, maxValue));
 	}

--- a/Source/SuperLinq.Async/Random.cs
+++ b/Source/SuperLinq.Async/Random.cs
@@ -234,7 +234,7 @@ public static partial class AsyncSuperEnumerable
 			// randomizing operator from the outer class then they will
 			// need to be overriden.
 
-			throw new NotSupportedException("Should never reach this code.");
+			return ThrowHelper.ThrowNotSupportedException<double>();
 		}
 	}
 #endif

--- a/Source/SuperLinq.Async/Random.cs
+++ b/Source/SuperLinq.Async/Random.cs
@@ -38,7 +38,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<int> Random(Random rand)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 
 		return RandomImpl(rand, r => r.Next());
 	}
@@ -83,7 +83,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<int> Random(Random rand, int maxValue)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
 
 		return RandomImpl(rand, r => r.Next(maxValue));
@@ -129,7 +129,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="minValue"/> is greater than <paramref name="maxValue"/>.</exception>
 	public static IAsyncEnumerable<int> Random(Random rand, int minValue, int maxValue)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 		Guard.IsLessThanOrEqualTo(minValue, maxValue);
 
 		return RandomImpl(rand, r => r.Next(minValue, maxValue));
@@ -170,7 +170,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<double> RandomDouble(Random rand)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 
 		return RandomImpl(rand, r => r.NextDouble());
 	}

--- a/Source/SuperLinq.Async/Rank.cs
+++ b/Source/SuperLinq.Async/Rank.cs
@@ -49,8 +49,8 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<(TSource item, int rank)> DenseRankBy<TSource, TKey>(
 		this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByImpl(source, keySelector, comparer: null, isDense: true);
 	}
@@ -74,8 +74,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IComparer<TKey> comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByImpl(source, keySelector, comparer, isDense: true);
 	}
@@ -127,8 +127,8 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<(TSource item, int rank)> RankBy<TSource, TKey>(
 		this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByImpl(source, keySelector, comparer: null, isDense: false);
 	}
@@ -152,8 +152,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IComparer<TKey> comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByImpl(source, keySelector, comparer, isDense: false);
 	}

--- a/Source/SuperLinq.Async/Repeat.cs
+++ b/Source/SuperLinq.Async/Repeat.cs
@@ -24,7 +24,7 @@ public partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> Repeat<TSource>(this IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(source);
 
@@ -58,7 +58,7 @@ public partial class AsyncSuperEnumerable
 	/// <c>0</c>.</exception>
 	public static IAsyncEnumerable<TSource> Repeat<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 
 		return Core(source, count);

--- a/Source/SuperLinq.Async/Repeat.cs
+++ b/Source/SuperLinq.Async/Repeat.cs
@@ -59,7 +59,7 @@ public partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> Repeat<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		return Core(source, count);
 

--- a/Source/SuperLinq.Async/Replace.cs
+++ b/Source/SuperLinq.Async/Replace.cs
@@ -22,7 +22,7 @@ public static partial class AsyncSuperEnumerable
 		int index,
 		TSource value)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(source, value, index);
 
@@ -56,7 +56,7 @@ public static partial class AsyncSuperEnumerable
 		Index index,
 		TSource value)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(source, value, index);
 

--- a/Source/SuperLinq.Async/Retry.cs
+++ b/Source/SuperLinq.Async/Retry.cs
@@ -52,7 +52,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> Retry<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		return Enumerable.Repeat(source, count).Catch();
 	}

--- a/Source/SuperLinq.Async/Retry.cs
+++ b/Source/SuperLinq.Async/Retry.cs
@@ -21,7 +21,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Retry<TSource>(this IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Repeat<IAsyncEnumerable<TSource>>(source).Catch();
 	}
@@ -51,7 +51,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Retry<TSource>(this IAsyncEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 
 		return Enumerable.Repeat(source, count).Catch();

--- a/Source/SuperLinq.Async/RunLengthEncode.cs
+++ b/Source/SuperLinq.Async/RunLengthEncode.cs
@@ -27,7 +27,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<(T value, int count)> RunLengthEncode<T>(this IAsyncEnumerable<T> sequence, IEqualityComparer<T>? comparer)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 
 		return Core(sequence, comparer ?? EqualityComparer<T>.Default);
 

--- a/Source/SuperLinq.Async/Scan.cs
+++ b/Source/SuperLinq.Async/Scan.cs
@@ -20,8 +20,8 @@ public static partial class AsyncSuperEnumerable
 		this IAsyncEnumerable<TSource> source,
 		Func<TSource, TSource, TSource> transformation)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, transformation);
 
@@ -89,8 +89,8 @@ public static partial class AsyncSuperEnumerable
 		TState seed,
 		Func<TState, TSource, TState> transformation)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, seed, transformation);
 

--- a/Source/SuperLinq.Async/ScanBy.cs
+++ b/Source/SuperLinq.Async/ScanBy.cs
@@ -30,9 +30,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TKey, TState> seedSelector,
 		Func<TState, TKey, TSource, TState> accumulator)
 	{
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		return source.ScanBy(
 			(s, ct) => new ValueTask<TKey>(keySelector(s)),
@@ -68,9 +68,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TKey, ValueTask<TState>> seedSelector,
 		Func<TState, TKey, TSource, ValueTask<TState>> accumulator)
 	{
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		return source.ScanBy(
 			(s, ct) => keySelector(s),
@@ -143,9 +143,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TState, TKey, TSource, TState> accumulator,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		return source.ScanBy(
 			(s, ct) => new ValueTask<TKey>(keySelector(s)),
@@ -187,9 +187,9 @@ public static partial class AsyncSuperEnumerable
 		Func<TState, TKey, TSource, ValueTask<TState>> accumulator,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		return source.ScanBy(
 			(s, ct) => keySelector(s),
@@ -231,10 +231,10 @@ public static partial class AsyncSuperEnumerable
 		Func<TState, TKey, TSource, CancellationToken, ValueTask<TState>> accumulator,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		comparer ??= EqualityComparer<TKey>.Default;
 

--- a/Source/SuperLinq.Async/ScanRight.cs
+++ b/Source/SuperLinq.Async/ScanRight.cs
@@ -28,7 +28,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> ScanRight<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
 	{
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.ScanRight((a, b, ct) => new ValueTask<TSource>(func(a, b)));
 	}
@@ -59,7 +59,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> ScanRight<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
 	{
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.ScanRight((a, b, ct) => func(a, b));
 	}
@@ -90,8 +90,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> ScanRight<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, ValueTask<TSource>> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, func);
 
@@ -144,7 +144,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
 	{
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.ScanRight(seed, (a, b, ct) => new ValueTask<TAccumulate>(func(a, b)));
 	}
@@ -176,7 +176,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, ValueTask<TAccumulate>> func)
 	{
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return source.ScanRight(seed, (a, b, ct) => func(a, b));
 	}
@@ -208,8 +208,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, CancellationToken, ValueTask<TAccumulate>> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, seed, func);
 

--- a/Source/SuperLinq.Async/Segment.cs
+++ b/Source/SuperLinq.Async/Segment.cs
@@ -15,8 +15,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => new ValueTask<bool>(newSegmentPredicate(curr)));
 	}
@@ -34,8 +34,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, ValueTask<bool>> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => newSegmentPredicate(curr));
 	}
@@ -53,8 +53,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, int, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => new ValueTask<bool>(newSegmentPredicate(curr, index)));
 	}
@@ -72,8 +72,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, int, ValueTask<bool>> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => newSegmentPredicate(curr, index));
 	}
@@ -91,8 +91,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => new ValueTask<bool>(newSegmentPredicate(curr, prev, index)));
 	}
@@ -110,8 +110,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IEnumerable<T>> Segment<T>(this IAsyncEnumerable<T> source, Func<T, T, int, ValueTask<bool>> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Core(source, newSegmentPredicate);
 

--- a/Source/SuperLinq.Async/Sequence.cs
+++ b/Source/SuperLinq.Async/Sequence.cs
@@ -16,9 +16,11 @@ public static partial class AsyncSuperEnumerable
 	/// </exception>
 	public static IAsyncEnumerable<int> Range(int start, int count, int step)
 	{
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 		var max = start + ((count - 1) * (long)step);
-		Guard.IsBetweenOrEqualTo(max, int.MinValue, int.MaxValue, name: nameof(count));
+		ArgumentOutOfRangeException.ThrowIfLessThan(max, int.MinValue, nameof(count));
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(max, int.MaxValue, nameof(count));
+
 		return Core(start, count, step);
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/Source/SuperLinq.Async/Share.cs
+++ b/Source/SuperLinq.Async/Share.cs
@@ -43,13 +43,13 @@ public static partial class AsyncSuperEnumerable
 		public async ValueTask Reset(CancellationToken cancellationToken = default)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				_initialized = false;
 				_version++;
@@ -74,13 +74,13 @@ public static partial class AsyncSuperEnumerable
 		private void InitializeEnumerator(CancellationToken cancellationToken)
 		{
 			if (_disposed)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 			_lock.Wait(cancellationToken);
 			try
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -114,13 +114,13 @@ public static partial class AsyncSuperEnumerable
 				T? element;
 
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IAsyncBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IAsyncBuffer<T>>();
 
 				await _lock.WaitAsync(cancellationToken);
 				try
 				{
 					if (_disposed)
-						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 					if (!_initialized
 						|| version != _version)
 					{

--- a/Source/SuperLinq.Async/Share.cs
+++ b/Source/SuperLinq.Async/Share.cs
@@ -14,7 +14,7 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/></exception>
 	public static IAsyncBuffer<TSource> Share<TSource>(this IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return new SharedBuffer<TSource>(source);
 	}

--- a/Source/SuperLinq.Async/SkipUntil.cs
+++ b/Source/SuperLinq.Async/SkipUntil.cs
@@ -34,8 +34,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TSource> SkipUntil<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return Core(source, predicate);
 

--- a/Source/SuperLinq.Async/SortedMerge.cs
+++ b/Source/SuperLinq.Async/SortedMerge.cs
@@ -333,9 +333,9 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="otherSequences"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> SortedMergeBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, OrderByDirection direction, IComparer<TKey>? comparer, params IAsyncEnumerable<TSource>[] otherSequences)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(otherSequences);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(otherSequences);
 
 		if (otherSequences.Length == 0)
 			return source; // optimization for when otherSequences is empty

--- a/Source/SuperLinq.Async/Split.cs
+++ b/Source/SuperLinq.Async/Split.cs
@@ -173,9 +173,9 @@ public static partial class AsyncSuperEnumerable
 		TSource separator, IEqualityComparer<TSource>? comparer, int count,
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		comparer ??= EqualityComparer<TSource>.Default;
 		return Split(source, item => comparer.Equals(item, separator), count, resultSelector);
@@ -269,10 +269,10 @@ public static partial class AsyncSuperEnumerable
 		Func<TSource, bool> separatorFunc, int count,
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(separatorFunc);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(separatorFunc);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, separatorFunc, count, resultSelector);
 

--- a/Source/SuperLinq.Async/Split.cs
+++ b/Source/SuperLinq.Async/Split.cs
@@ -174,7 +174,7 @@ public static partial class AsyncSuperEnumerable
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		comparer ??= EqualityComparer<TSource>.Default;
@@ -271,7 +271,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(separatorFunc);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, separatorFunc, count, resultSelector);

--- a/Source/SuperLinq.Async/StartsWith.cs
+++ b/Source/SuperLinq.Async/StartsWith.cs
@@ -25,8 +25,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> StartsWith<T>(this IAsyncEnumerable<T> first, IEnumerable<T> second, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return StartsWith(first, second.ToAsyncEnumerable(), comparer: null, cancellationToken);
 	}
@@ -80,8 +80,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> StartsWith<T>(this IAsyncEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return StartsWith(first, second.ToAsyncEnumerable(), comparer, cancellationToken);
 	}
@@ -109,8 +109,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static ValueTask<bool> StartsWith<T>(this IAsyncEnumerable<T> first, IAsyncEnumerable<T> second, IEqualityComparer<T>? comparer, CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		comparer ??= EqualityComparer<T>.Default;
 

--- a/Source/SuperLinq.Async/SuperLinq.Async.csproj
+++ b/Source/SuperLinq.Async/SuperLinq.Async.csproj
@@ -115,10 +115,6 @@
 		<Using Include="System.Runtime.CompilerServices" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-		<Using Include="SuperLinq.Exceptions.ArgumentNullException" Alias="ArgumentNullException" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/Source/SuperLinq.Async/SuperLinq.Async.csproj
+++ b/Source/SuperLinq.Async/SuperLinq.Async.csproj
@@ -112,8 +112,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Using Include="CommunityToolkit.Diagnostics" />
 		<Using Include="System.Runtime.CompilerServices" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
+		<Using Include="SuperLinq.Exceptions.ArgumentNullException" Alias="ArgumentNullException" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/SuperLinq.Async/SuperLinq.Async.csproj
+++ b/Source/SuperLinq.Async/SuperLinq.Async.csproj
@@ -112,6 +112,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Using Include="SuperLinq.Exceptions" />
 		<Using Include="System.Runtime.CompilerServices" />
 	</ItemGroup>
 

--- a/Source/SuperLinq.Async/TagFirstLast.cs
+++ b/Source/SuperLinq.Async/TagFirstLast.cs
@@ -63,8 +63,8 @@ public static partial class AsyncSuperEnumerable
 	/// </example>
 	public static IAsyncEnumerable<TResult> TagFirstLast<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, resultSelector);
 

--- a/Source/SuperLinq.Async/Take.cs
+++ b/Source/SuperLinq.Async/Take.cs
@@ -14,7 +14,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Take<TSource>(this IAsyncEnumerable<TSource> source, Range range)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		var start = range.Start;
 		var end = range.End;

--- a/Source/SuperLinq.Async/TakeEvery.cs
+++ b/Source/SuperLinq.Async/TakeEvery.cs
@@ -25,7 +25,7 @@ public static partial class AsyncSuperEnumerable
 	/// </example>
 	public static IAsyncEnumerable<TSource> TakeEvery<TSource>(this IAsyncEnumerable<TSource> source, int step)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(step, 1);
 		return source.Where((e, i) => i % step == 0);
 	}

--- a/Source/SuperLinq.Async/TakeEvery.cs
+++ b/Source/SuperLinq.Async/TakeEvery.cs
@@ -26,7 +26,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> TakeEvery<TSource>(this IAsyncEnumerable<TSource> source, int step)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(step, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(step);
 		return source.Where((e, i) => i % step == 0);
 	}
 }

--- a/Source/SuperLinq.Async/TakeUntil.cs
+++ b/Source/SuperLinq.Async/TakeUntil.cs
@@ -34,8 +34,8 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<TSource> TakeUntil<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return Core(source, predicate);
 

--- a/Source/SuperLinq.Async/Throw.cs
+++ b/Source/SuperLinq.Async/Throw.cs
@@ -20,7 +20,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Throw<TSource>(Exception exception)
 	{
-		Guard.IsNotNull(exception);
+		ArgumentNullException.ThrowIfNull(exception);
 
 		return Core(exception);
 

--- a/Source/SuperLinq.Async/Timeout.cs
+++ b/Source/SuperLinq.Async/Timeout.cs
@@ -39,7 +39,7 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> Timeout<TSource>(this IAsyncEnumerable<TSource> source, TimeSpan timeout)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsBetween(timeout.TotalMilliseconds, -1, uint.MaxValue);
 
 		return Core(source, timeout);

--- a/Source/SuperLinq.Async/Timeout.cs
+++ b/Source/SuperLinq.Async/Timeout.cs
@@ -40,7 +40,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<TSource> Timeout<TSource>(this IAsyncEnumerable<TSource> source, TimeSpan timeout)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsBetween(timeout.TotalMilliseconds, -1, uint.MaxValue);
+		ArgumentOutOfRangeException.ThrowIfNegative(timeout.Milliseconds);
 
 		return Core(source, timeout);
 

--- a/Source/SuperLinq.Async/Timeout.cs
+++ b/Source/SuperLinq.Async/Timeout.cs
@@ -73,12 +73,12 @@ public static partial class AsyncSuperEnumerable
 #endif
 
 								_ = await moveNextTask.ConfigureAwait(false);
-								throw new TimeoutException("The operation has timed out.");
+								ThrowHelper.ThrowTimeoutException("The operation has timed out.");
 							}
 						}
 						catch (OperationCanceledException ex) when (cts.IsCancellationRequested)
 						{
-							throw new TimeoutException("The operation has timed out.", ex);
+							ThrowHelper.ThrowTimeoutException("The operation has timed out.", ex);
 						}
 					}
 

--- a/Source/SuperLinq.Async/Traverse.cs
+++ b/Source/SuperLinq.Async/Traverse.cs
@@ -25,7 +25,7 @@ public partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<T> TraverseBreadthFirst<T>(T root, Func<T, IAsyncEnumerable<T>> childrenSelector)
 	{
-		Guard.IsNotNull(childrenSelector);
+		ArgumentNullException.ThrowIfNull(childrenSelector);
 
 		return Core(root, childrenSelector);
 
@@ -72,7 +72,7 @@ public partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<T> TraverseDepthFirst<T>(T root, Func<T, IAsyncEnumerable<T>> childrenSelector)
 	{
-		Guard.IsNotNull(childrenSelector);
+		ArgumentNullException.ThrowIfNull(childrenSelector);
 
 		return Core(root, childrenSelector);
 

--- a/Source/SuperLinq.Async/TrySingle.cs
+++ b/Source/SuperLinq.Async/TrySingle.cs
@@ -86,8 +86,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TCardinality, T?, TResult> resultSelector,
 		CancellationToken cancellationToken = default)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, zero, one, many, resultSelector, cancellationToken);
 

--- a/Source/SuperLinq.Async/Using.cs
+++ b/Source/SuperLinq.Async/Using.cs
@@ -30,8 +30,8 @@ public static partial class AsyncSuperEnumerable
 		Func<TResource, IAsyncEnumerable<TSource>> enumerableFactory)
 		where TResource : IAsyncDisposable
 	{
-		Guard.IsNotNull(resourceFactory);
-		Guard.IsNotNull(enumerableFactory);
+		ArgumentNullException.ThrowIfNull(resourceFactory);
+		ArgumentNullException.ThrowIfNull(enumerableFactory);
 
 		return Core(resourceFactory, enumerableFactory);
 

--- a/Source/SuperLinq.Async/Where.cs
+++ b/Source/SuperLinq.Async/Where.cs
@@ -16,8 +16,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="filter"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<TSource> Where<TSource>(this IAsyncEnumerable<TSource> source, IAsyncEnumerable<bool> filter)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(filter);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(filter);
 
 		return Core(source, filter);
 

--- a/Source/SuperLinq.Async/WhereLag.cs
+++ b/Source/SuperLinq.Async/WhereLag.cs
@@ -29,7 +29,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLag(offset, default!, predicate.ToAsync());
 	}
@@ -61,7 +61,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLag(offset, default!, predicate);
 	}
@@ -90,7 +90,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLag(offset, defaultLagValue, predicate.ToAsync());
 	}
@@ -119,7 +119,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLagValue, predicate);
 

--- a/Source/SuperLinq.Async/WhereLag.cs
+++ b/Source/SuperLinq.Async/WhereLag.cs
@@ -27,8 +27,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLag<TSource>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLag(offset, default!, predicate.ToAsync());
@@ -59,8 +59,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLag<TSource>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLag(offset, default!, predicate);
@@ -88,8 +88,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLag<TSource>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLag(offset, defaultLagValue, predicate.ToAsync());
@@ -117,8 +117,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLag<TSource>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLagValue, predicate);

--- a/Source/SuperLinq.Async/WhereLead.cs
+++ b/Source/SuperLinq.Async/WhereLead.cs
@@ -27,8 +27,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLead<TSource>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLead(offset, default!, predicate.ToAsync());
@@ -59,8 +59,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLead<TSource>(this IAsyncEnumerable<TSource> source, int offset, Func<TSource, TSource?, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLead(offset, default!, predicate);
@@ -88,8 +88,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLead<TSource>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return source.WhereLead(offset, defaultLeadValue, predicate.ToAsync());
@@ -117,8 +117,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> WhereLead<TSource>(this IAsyncEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, ValueTask<bool>> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLeadValue, predicate);

--- a/Source/SuperLinq.Async/WhereLead.cs
+++ b/Source/SuperLinq.Async/WhereLead.cs
@@ -29,7 +29,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLead(offset, default!, predicate.ToAsync());
 	}
@@ -61,7 +61,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLead(offset, default!, predicate);
 	}
@@ -90,7 +90,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return source.WhereLead(offset, defaultLeadValue, predicate.ToAsync());
 	}
@@ -119,7 +119,7 @@ public static partial class AsyncSuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLeadValue, predicate);
 

--- a/Source/SuperLinq.Async/While.cs
+++ b/Source/SuperLinq.Async/While.cs
@@ -23,8 +23,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> While<TSource>(Func<bool> condition, IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return While(condition.ToAsync(), source);
 	}
@@ -50,8 +50,8 @@ public static partial class AsyncSuperEnumerable
 	/// </remarks>
 	public static IAsyncEnumerable<TSource> While<TSource>(Func<ValueTask<bool>> condition, IAsyncEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(condition, source);
 

--- a/Source/SuperLinq.Async/Window.cs
+++ b/Source/SuperLinq.Async/Window.cs
@@ -16,7 +16,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<IList<TSource>> Window<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return Core(source, size);
 

--- a/Source/SuperLinq.Async/Window.cs
+++ b/Source/SuperLinq.Async/Window.cs
@@ -15,7 +15,7 @@ public static partial class AsyncSuperEnumerable
 	/// <returns>A series of sequences representing each sliding window subsequence</returns>
 	public static IAsyncEnumerable<IList<TSource>> Window<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return Core(source, size);

--- a/Source/SuperLinq.Async/WindowLeft.cs
+++ b/Source/SuperLinq.Async/WindowLeft.cs
@@ -39,7 +39,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<IList<TSource>> WindowLeft<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return Core(source, size);
 

--- a/Source/SuperLinq.Async/WindowLeft.cs
+++ b/Source/SuperLinq.Async/WindowLeft.cs
@@ -38,7 +38,7 @@ public static partial class AsyncSuperEnumerable
 	/// </example>
 	public static IAsyncEnumerable<IList<TSource>> WindowLeft<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return Core(source, size);

--- a/Source/SuperLinq.Async/WindowRight.cs
+++ b/Source/SuperLinq.Async/WindowRight.cs
@@ -39,7 +39,7 @@ public static partial class AsyncSuperEnumerable
 
 	public static IAsyncEnumerable<IList<TSource>> WindowRight<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return Core(source, size);

--- a/Source/SuperLinq.Async/WindowRight.cs
+++ b/Source/SuperLinq.Async/WindowRight.cs
@@ -40,7 +40,7 @@ public static partial class AsyncSuperEnumerable
 	public static IAsyncEnumerable<IList<TSource>> WindowRight<TSource>(this IAsyncEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return Core(source, size);
 

--- a/Source/SuperLinq.Async/ZipMap.cs
+++ b/Source/SuperLinq.Async/ZipMap.cs
@@ -19,8 +19,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<(TSource item, TResult result)> ZipMap<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return source.ZipMap((x, _) => new ValueTask<TResult>(selector(x)));
 	}
@@ -42,8 +42,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<(TSource item, TResult result)> ZipMap<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TResult>> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return source.ZipMap((x, _) => selector(x));
 	}
@@ -65,8 +65,8 @@ public static partial class AsyncSuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
 	public static IAsyncEnumerable<(TSource item, TResult result)> ZipMap<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TResult>> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return Core(source, selector);
 

--- a/Source/SuperLinq/AggregateBy.cs
+++ b/Source/SuperLinq/AggregateBy.cs
@@ -105,10 +105,10 @@ public static partial class SuperEnumerable
 		Func<TAccumulate, TSource, TAccumulate> func,
 		IEqualityComparer<TKey>? comparer = null) where TKey : notnull
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, keySelector, seedSelector, func, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq/AggregateRight.cs
+++ b/Source/SuperLinq/AggregateRight.cs
@@ -24,8 +24,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static TSource AggregateRight<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		var list = source is IList<TSource> l ? l : source.ToList();
 
@@ -67,8 +67,8 @@ public static partial class SuperEnumerable
 
 	public static TAccumulate AggregateRight<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		var list = source is IList<TSource> l ? l : source.ToList();
 
@@ -109,9 +109,9 @@ public static partial class SuperEnumerable
 
 	public static TResult AggregateRight<TSource, TAccumulate, TResult>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return resultSelector(source.AggregateRight(seed, func));
 	}

--- a/Source/SuperLinq/Assert.cs
+++ b/Source/SuperLinq/Assert.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace SuperLinq;
 

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -21,7 +21,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		if (source is IList<TSource> list)
@@ -75,7 +75,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_ = _source.CopyTo(array, arrayIndex);
@@ -113,7 +113,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -22,7 +22,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		if (source is IList<TSource> list)
 			return new AssertCountListIterator<TSource>(list, count);
@@ -41,7 +41,8 @@ public static partial class SuperEnumerable
 					break;
 				yield return item;
 			}
-			Guard.IsEqualTo(c, count, $"{nameof(source)}.Count()");
+
+			ArgumentOutOfRangeException.ThrowIfNotEqual(c, count, $"{nameof(source)}.Count()");
 		}
 	}
 
@@ -60,14 +61,14 @@ public static partial class SuperEnumerable
 		{
 			get
 			{
-				Guard.IsEqualTo(_source.GetCollectionCount(), _count, "source.Count()");
+				ArgumentOutOfRangeException.ThrowIfNotEqual(_source.GetCollectionCount(), _count, "source.Count()");
 				return _count;
 			}
 		}
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			Guard.IsEqualTo(_source.GetCollectionCount(), _count, "source.Count()");
+			ArgumentOutOfRangeException.ThrowIfNotEqual(_source.GetCollectionCount(), _count, "source.Count()");
 
 			foreach (var item in _source)
 				yield return item;
@@ -76,7 +77,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_ = _source.CopyTo(array, arrayIndex);
 		}
@@ -97,7 +99,7 @@ public static partial class SuperEnumerable
 		{
 			get
 			{
-				Guard.IsEqualTo(_source.Count, _count, "source.Count()");
+				ArgumentOutOfRangeException.ThrowIfNotEqual(_source.Count, _count, "source.Count()");
 				return _count;
 			}
 		}
@@ -114,14 +116,17 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 		}
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _source[index];
 		}
 	}

--- a/Source/SuperLinq/Batch.Buffered.cs
+++ b/Source/SuperLinq/Batch.Buffered.cs
@@ -34,7 +34,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return BatchImpl(source, new TSource[size], size, resultSelector);
 	}
@@ -111,7 +111,8 @@ public static partial class SuperEnumerable
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(array);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
+		ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
+		ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(size, array.Length);
 
 		return BatchImpl(source, array, size, resultSelector);
 	}

--- a/Source/SuperLinq/Batch.Buffered.cs
+++ b/Source/SuperLinq/Batch.Buffered.cs
@@ -32,8 +32,8 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return BatchImpl(source, new TSource[size], size, resultSelector);
@@ -67,9 +67,9 @@ public static partial class SuperEnumerable
 		TSource[] array,
 		Func<IReadOnlyList<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return BatchImpl(source, array, array.Length, resultSelector);
 	}
@@ -108,9 +108,9 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
 
 		return BatchImpl(source, array, size, resultSelector);

--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -25,7 +25,7 @@ public static partial class SuperEnumerable
 	{
 		// yes this operator duplicates on net6+; but no name overlap, so leave alone
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		if (source is IList<TSource> list)
 			return new BatchIterator<TSource>(list, size);
@@ -112,7 +112,8 @@ public static partial class SuperEnumerable
 
 		protected override IList<T> ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			var start = index * _size;
 			var max = (uint)Math.Min(_source.Count, start + _size);

--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -24,7 +24,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
 	{
 		// yes this operator duplicates on net6+; but no name overlap, so leave alone
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/BindByIndex.cs
+++ b/Source/SuperLinq/BindByIndex.cs
@@ -51,10 +51,10 @@ public static partial class SuperEnumerable
 		Func<TSource, int, TResult> resultSelector,
 		Func<int, TResult> missingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(indices);
-		Guard.IsNotNull(resultSelector);
-		Guard.IsNotNull(missingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(indices);
+		ArgumentNullException.ThrowIfNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(missingSelector);
 
 		return Core(source, indices, resultSelector, missingSelector);
 

--- a/Source/SuperLinq/BindByIndex.cs
+++ b/Source/SuperLinq/BindByIndex.cs
@@ -18,9 +18,7 @@ public static partial class SuperEnumerable
 		this IEnumerable<TSource> source,
 		IEnumerable<int> indices)
 	{
-#pragma warning disable MA0015
-		return BindByIndex(source, indices, static (e, i) => e, static i => throw new ArgumentOutOfRangeException(nameof(indices), "Index is greater than the length of the first sequence."));
-#pragma warning restore MA0015
+		return BindByIndex(source, indices, static (e, i) => e, static i => ThrowHelper.ThrowArgumentOutOfRangeException<TSource>(nameof(indices), "Index is greater than the length of the first sequence."));
 	}
 
 	/// <summary>
@@ -61,7 +59,7 @@ public static partial class SuperEnumerable
 		static IEnumerable<TResult> Core(IEnumerable<TSource> source, IEnumerable<int> indices, Func<TSource, int, TResult> resultSelector, Func<int, TResult> missingSelector)
 		{
 			// keeps track of the order of indices to know what order items should be output in
-			var lookup = indices.Index().ToDictionary(x => { Guard.IsGreaterThanOrEqualTo(x.item, 0, nameof(indices)); return x.item; }, x => x.index);
+			var lookup = indices.Index().ToDictionary(x => { ArgumentOutOfRangeException.ThrowIfNegative(x.item, nameof(indices)); return x.item; }, x => x.index);
 			// keep track of items out of output order
 			var lookback = new Dictionary<int, TSource>();
 

--- a/Source/SuperLinq/Buffer.cs
+++ b/Source/SuperLinq/Buffer.cs
@@ -55,8 +55,8 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<TSource>> Buffer<TSource>(this IEnumerable<TSource> source, int count, int skip)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
-		Guard.IsGreaterThan(skip, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(skip);
 
 		return Core(source, count, skip);
 

--- a/Source/SuperLinq/Buffer.cs
+++ b/Source/SuperLinq/Buffer.cs
@@ -54,7 +54,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<IList<TSource>> Buffer<TSource>(this IEnumerable<TSource> source, int count, int skip)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 		Guard.IsGreaterThan(skip, 0);
 

--- a/Source/SuperLinq/Case.cs
+++ b/Source/SuperLinq/Case.cs
@@ -54,9 +54,9 @@ public static partial class SuperEnumerable
 		IEnumerable<TResult> defaultSource)
 		where TValue : notnull
 	{
-		Guard.IsNotNull(selector);
-		Guard.IsNotNull(sources);
-		Guard.IsNotNull(defaultSource);
+		ArgumentNullException.ThrowIfNull(selector);
+		ArgumentNullException.ThrowIfNull(sources);
+		ArgumentNullException.ThrowIfNull(defaultSource);
 
 		return Core(selector, sources, defaultSource);
 

--- a/Source/SuperLinq/Catch.cs
+++ b/Source/SuperLinq/Catch.cs
@@ -21,8 +21,8 @@ public static partial class SuperEnumerable
 		Func<TException, IEnumerable<TSource>> handler)
 		where TException : Exception
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(handler);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(handler);
 
 		return Core(source, handler);
 
@@ -70,8 +70,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Catch<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return Catch(new[] { first, second, });
 	}
@@ -88,7 +88,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Catch<TSource>(params IEnumerable<TSource>[] sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.AsEnumerable().Catch();
 	}
@@ -105,7 +105,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Catch<TSource>(this IEnumerable<IEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 
@@ -126,7 +126,7 @@ public static partial class SuperEnumerable
 			// make it outside of the inner `while (true)`
 			while (true)
 			{
-				Guard.IsNotNull(source);
+				ArgumentNullException.ThrowIfNull(source);
 				using var e = source.GetEnumerator();
 
 				while (true)

--- a/Source/SuperLinq/Choose.cs
+++ b/Source/SuperLinq/Choose.cs
@@ -33,8 +33,8 @@ public static partial class SuperEnumerable
 		this IEnumerable<T> source,
 		Func<T, (bool, TResult)> chooser)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(chooser);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(chooser);
 
 		return Core(source, chooser);
 

--- a/Source/SuperLinq/CollectionEqual.cs
+++ b/Source/SuperLinq/CollectionEqual.cs
@@ -79,8 +79,8 @@ public static partial class SuperEnumerable
 		IEnumerable<TSource> second,
 		IEqualityComparer<TSource>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		var cmp = ValueTupleEqualityComparer.Create<TSource, int>(comparer, comparer2: null);
 		var firstSet = first.CountBy(Identity, comparer)

--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -31,7 +31,8 @@ public partial class SuperEnumerable
 		public virtual void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_ = SuperEnumerable.CopyTo(GetEnumerable(), array, arrayIndex);
 		}

--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -10,11 +10,11 @@ public partial class SuperEnumerable
 	{
 		public bool IsReadOnly => true;
 		public void Add(T item) =>
-			throw new NotSupportedException();
+			ThrowHelper.ThrowNotSupportedException();
 		public bool Remove(T item) =>
-			throw new NotSupportedException();
+			ThrowHelper.ThrowNotSupportedException<bool>();
 		public void Clear() =>
-			throw new NotSupportedException();
+			ThrowHelper.ThrowNotSupportedException();
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/Source/SuperLinq/CollectionIterator.cs
+++ b/Source/SuperLinq/CollectionIterator.cs
@@ -30,7 +30,7 @@ public partial class SuperEnumerable
 
 		public virtual void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_ = SuperEnumerable.CopyTo(GetEnumerable(), array, arrayIndex);

--- a/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
+++ b/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
@@ -190,7 +190,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// </remarks>
 	public UpdatablePriorityQueue(IEnumerable<(TElement Element, TPriority Priority)> items, IComparer<TPriority>? priorityComparer, IEqualityComparer<TElement>? elementComparer)
 	{
-		Guard.IsNotNull(items);
+		ArgumentNullException.ThrowIfNull(items);
 
 		_nodes = items.ToArray();
 		_priorityComparer = InitializeComparer(priorityComparer);
@@ -458,7 +458,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// <remarks>Any existing elements will be unconditionally updated to the new priority.</remarks>
 	public void EnqueueRange(IEnumerable<(TElement Element, TPriority Priority)> items)
 	{
-		Guard.IsNotNull(items);
+		ArgumentNullException.ThrowIfNull(items);
 
 		var count = 0;
 		var collection = items as ICollection<(TElement Element, TPriority Priority)>;
@@ -522,7 +522,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// <remarks>Any existing elements will be unconditionally updated to the new priority.</remarks>
 	public void EnqueueRange(IEnumerable<TElement> elements, TPriority priority)
 	{
-		Guard.IsNotNull(elements);
+		ArgumentNullException.ThrowIfNull(elements);
 
 		int count;
 		if (elements is ICollection<(TElement Element, TPriority Priority)> collection &&
@@ -575,7 +575,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// <remarks>Any existing elements will be updated to the new priority if and only if the new priority is lower than the existing priority.</remarks>
 	public void EnqueueRangeMinimum(IEnumerable<(TElement Element, TPriority Priority)> items)
 	{
-		Guard.IsNotNull(items);
+		ArgumentNullException.ThrowIfNull(items);
 
 		var count = 0;
 		var collection = items as ICollection<(TElement Element, TPriority Priority)>;
@@ -639,7 +639,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// <remarks>Any existing elements will be updated to the new priority if and only if the new priority is lower than the existing priority.</remarks>
 	public void EnqueueRangeMinimum(IEnumerable<TElement> elements, TPriority priority)
 	{
-		Guard.IsNotNull(elements);
+		ArgumentNullException.ThrowIfNull(elements);
 
 		int count;
 		if (elements is ICollection<(TElement Element, TPriority Priority)> collection &&
@@ -1069,7 +1069,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 
 		void ICollection.CopyTo(Array array, int index)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 
 			try
 			{
@@ -1174,7 +1174,7 @@ internal sealed class PriorityQueueDebugView<TElement, TPriority>
 
 	public PriorityQueueDebugView(UpdatablePriorityQueue<TElement, TPriority> queue)
 	{
-		Guard.IsNotNull(queue);
+		ArgumentNullException.ThrowIfNull(queue);
 
 		_queue = queue;
 		_sort = true;
@@ -1182,7 +1182,9 @@ internal sealed class PriorityQueueDebugView<TElement, TPriority>
 
 	public PriorityQueueDebugView(UpdatablePriorityQueue<TElement, TPriority>.UnorderedItemsCollection collection)
 	{
-		_queue = collection?.Queue ?? throw new ArgumentNullException(nameof(collection));
+		ArgumentNullException.ThrowIfNull(collection);
+
+		_queue = collection.Queue;
 	}
 
 	[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]

--- a/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
+++ b/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
@@ -142,7 +142,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// </exception>
 	public UpdatablePriorityQueue(int initialCapacity, IComparer<TPriority>? priorityComparer, IEqualityComparer<TElement>? elementComparer)
 	{
-		Guard.IsGreaterThanOrEqualTo(initialCapacity, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(initialCapacity);
 
 		_nodes = new (TElement, TPriority)[initialCapacity];
 		_priorityComparer = InitializeComparer(priorityComparer);
@@ -708,7 +708,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 	/// <returns>The current capacity of the <see cref="UpdatablePriorityQueue{TElement, TPriority}"/>.</returns>
 	public int EnsureCapacity(int capacity)
 	{
-		Guard.IsGreaterThanOrEqualTo(capacity, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(capacity);
 
 		if (_nodes.Length < capacity)
 		{
@@ -1071,14 +1071,7 @@ public class UpdatablePriorityQueue<TElement, TPriority>
 		{
 			ArgumentNullException.ThrowIfNull(array);
 
-			try
-			{
-				Array.Copy(Queue._nodes, 0, array, index, Queue.Count);
-			}
-			catch (ArrayTypeMismatchException)
-			{
-				ThrowHelper.ThrowArrayTypeMismatchException();
-			}
+			Array.Copy(Queue._nodes, 0, array, index, Queue.Count);
 		}
 
 		/// <summary>

--- a/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
+++ b/Source/SuperLinq/Collections/UpdatablePriorityQueue.cs
@@ -6,6 +6,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace SuperLinq.Collections;
 

--- a/Source/SuperLinq/Consume.cs
+++ b/Source/SuperLinq/Consume.cs
@@ -11,7 +11,7 @@ public static partial class SuperEnumerable
 
 	public static void Consume<T>(this IEnumerable<T> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		foreach (var _ in source)
 		{
 		}

--- a/Source/SuperLinq/CopyTo.cs
+++ b/Source/SuperLinq/CopyTo.cs
@@ -176,7 +176,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(list);
-		Guard.IsGreaterThanOrEqualTo(index, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(index);
 
 		if (list is TSource[] array)
 		{

--- a/Source/SuperLinq/CopyTo.cs
+++ b/Source/SuperLinq/CopyTo.cs
@@ -26,7 +26,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static int CopyTo<TSource>(this IEnumerable<TSource> source, Span<TSource> span)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (source is TSource[] arr)
 		{
@@ -83,8 +83,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static int CopyTo<TSource>(this IEnumerable<TSource> source, TSource[] array)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
 
 		return CopyTo(source, array, 0);
 	}
@@ -174,8 +174,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list, int index)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(list);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(list);
 		Guard.IsGreaterThanOrEqualTo(index, 0);
 
 		if (list is TSource[] array)

--- a/Source/SuperLinq/CountBy.cs
+++ b/Source/SuperLinq/CountBy.cs
@@ -32,8 +32,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<(TKey key, int count)> CountBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq/CountDown.cs
+++ b/Source/SuperLinq/CountDown.cs
@@ -73,8 +73,8 @@ public static partial class SuperEnumerable
 		this IEnumerable<TSource> source,
 		int count, Func<TSource, int?, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/CountDown.cs
+++ b/Source/SuperLinq/CountDown.cs
@@ -75,7 +75,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		if (source is IList<TSource> list)
 			return new CountDownListIterator<TSource, TResult>(list, count, resultSelector);
@@ -161,7 +161,9 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _resultSelector(
 				_source[index],
 				_source.Count - index < _count ? _source.Count - index - 1 : null);

--- a/Source/SuperLinq/CountMethods.cs
+++ b/Source/SuperLinq/CountMethods.cs
@@ -24,7 +24,7 @@ public static partial class SuperEnumerable
 
 	public static bool AtLeast<T>(this IEnumerable<T> source, int count)
 	{
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, count, count, int.MaxValue);
 	}
@@ -51,7 +51,7 @@ public static partial class SuperEnumerable
 
 	public static bool AtMost<T>(this IEnumerable<T> source, int count)
 	{
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, count + 1, 0, count);
 	}
@@ -77,7 +77,7 @@ public static partial class SuperEnumerable
 
 	public static bool Exactly<T>(this IEnumerable<T> source, int count)
 	{
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		return QuantityIterator(source, count + 1, count, count);
 	}
@@ -106,8 +106,8 @@ public static partial class SuperEnumerable
 
 	public static bool CountBetween<T>(this IEnumerable<T> source, int min, int max)
 	{
-		Guard.IsGreaterThanOrEqualTo(min, 0);
-		Guard.IsGreaterThanOrEqualTo(max, min);
+		ArgumentOutOfRangeException.ThrowIfNegative(min);
+		ArgumentOutOfRangeException.ThrowIfLessThan(max, min);
 
 		return QuantityIterator(source, max + 1, min, max);
 	}
@@ -178,7 +178,7 @@ public static partial class SuperEnumerable
 	private static int CountUpTo<T>(this IEnumerable<T> source, int max)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(max, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(max);
 
 		var count = 0;
 

--- a/Source/SuperLinq/CountMethods.cs
+++ b/Source/SuperLinq/CountMethods.cs
@@ -114,7 +114,7 @@ public static partial class SuperEnumerable
 
 	private static bool QuantityIterator<T>(IEnumerable<T> source, int limit, int min, int max)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		var count = source.TryGetCollectionCount() ?? source.CountUpTo(limit);
 
@@ -144,8 +144,8 @@ public static partial class SuperEnumerable
 
 	public static int CompareCount<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		if (first.TryGetCollectionCount() is int firstCount)
 		{
@@ -177,7 +177,7 @@ public static partial class SuperEnumerable
 
 	private static int CountUpTo<T>(this IEnumerable<T> source, int max)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(max, 0);
 
 		var count = 0;

--- a/Source/SuperLinq/Debug.cs
+++ b/Source/SuperLinq/Debug.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace SuperLinq;
 

--- a/Source/SuperLinq/Defer.cs
+++ b/Source/SuperLinq/Defer.cs
@@ -15,7 +15,7 @@ public static partial class SuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IEnumerable<TResult> Defer<TResult>(Func<IEnumerable<TResult>> enumerableFactory)
 	{
-		Guard.IsNotNull(enumerableFactory);
+		ArgumentNullException.ThrowIfNull(enumerableFactory);
 
 		return Core(enumerableFactory);
 

--- a/Source/SuperLinq/DensePartialSort.cs
+++ b/Source/SuperLinq/DensePartialSort.cs
@@ -239,7 +239,7 @@ public static partial class SuperEnumerable
 		OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;

--- a/Source/SuperLinq/DensePartialSort.cs
+++ b/Source/SuperLinq/DensePartialSort.cs
@@ -238,9 +238,9 @@ public static partial class SuperEnumerable
 		IComparer<TKey>? comparer,
 		OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;
 		if (direction == OrderByDirection.Descending)

--- a/Source/SuperLinq/DistinctBy.cs
+++ b/Source/SuperLinq/DistinctBy.cs
@@ -64,8 +64,8 @@ public static partial class SuperEnumerable
 		IEqualityComparer<TKey>? comparer)
 #endif
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq/DistinctUntilChanged.cs
+++ b/Source/SuperLinq/DistinctUntilChanged.cs
@@ -24,7 +24,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> DistinctUntilChanged<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return DistinctUntilChanged(source, Identity, comparer);
 	}
 
@@ -57,8 +57,8 @@ public static partial class SuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(source, keySelector, comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq/Do.cs
+++ b/Source/SuperLinq/Do.cs
@@ -34,9 +34,9 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Do<TSource>(this IEnumerable<TSource> source, Action<TSource> onNext, Action onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return DoCore(source, onNext, onCompleted);
 	}
@@ -86,10 +86,10 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Do<TSource>(this IEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(onNext);
-		Guard.IsNotNull(onError);
-		Guard.IsNotNull(onCompleted);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(onNext);
+		ArgumentNullException.ThrowIfNull(onError);
+		ArgumentNullException.ThrowIfNull(onCompleted);
 
 		return DoCore(source, onNext, onError, onCompleted);
 	}

--- a/Source/SuperLinq/DoWhile.cs
+++ b/Source/SuperLinq/DoWhile.cs
@@ -23,8 +23,8 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> DoWhile<TSource>(this IEnumerable<TSource> source, Func<bool> condition)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(condition);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(condition);
 
 		return Core(source, condition);
 

--- a/Source/SuperLinq/ElementAt.cs
+++ b/Source/SuperLinq/ElementAt.cs
@@ -25,7 +25,7 @@ public static partial class SuperEnumerable
 	public static TSource ElementAt<TSource>(IEnumerable<TSource> source, Index index)
 #endif
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (!index.IsFromEnd)
 		{
@@ -62,7 +62,7 @@ public static partial class SuperEnumerable
 	public static TSource? ElementAtOrDefault<TSource>(IEnumerable<TSource> source, Index index)
 #endif
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (!index.IsFromEnd)
 		{

--- a/Source/SuperLinq/EndsWith.cs
+++ b/Source/SuperLinq/EndsWith.cs
@@ -47,8 +47,8 @@ public static partial class SuperEnumerable
 
 	public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		if (first.TryGetCollectionCount() is int firstCount &&
 			second.TryGetCollectionCount() is int secondCount &&

--- a/Source/SuperLinq/Evaluate.cs
+++ b/Source/SuperLinq/Evaluate.cs
@@ -17,7 +17,7 @@ public partial class SuperEnumerable
 
 	public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)
 	{
-		Guard.IsNotNull(functions);
+		ArgumentNullException.ThrowIfNull(functions);
 		return functions.Select(f => f());
 	}
 }

--- a/Source/SuperLinq/ExceptBy.cs
+++ b/Source/SuperLinq/ExceptBy.cs
@@ -59,9 +59,9 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? keyComparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return Core(first, second, keySelector, keyComparer);
 

--- a/Source/SuperLinq/Exceptions/ArgumentNullException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentNullException.cs
@@ -8,9 +8,10 @@ namespace SuperLinq.Exceptions;
 
 #pragma warning disable RS0016
 #pragma warning disable CA1711
+#pragma warning disable CS1591
 
 [Browsable(false)]
-public static class ArgumentNullException
+internal static class ArgumentNullException
 {
 	/// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
 	/// <param name="argument">The reference type argument to validate as non-null.</param>

--- a/Source/SuperLinq/Exceptions/ArgumentNullException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentNullException.cs
@@ -3,12 +3,9 @@ global using ArgumentNullException = SuperLinq.Exceptions.ArgumentNullException;
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace SuperLinq.Exceptions;
-
-#pragma warning disable RS0016
-#pragma warning disable CA1711
-#pragma warning disable CS1591
 
 [Browsable(false)]
 internal static class ArgumentNullException

--- a/Source/SuperLinq/Exceptions/ArgumentNullException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentNullException.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 namespace SuperLinq.Exceptions;
 
 [Browsable(false)]
+[ExcludeFromCodeCoverage]
 internal static class ArgumentNullException
 {
 	/// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>

--- a/Source/SuperLinq/Exceptions/ArgumentNullException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentNullException.cs
@@ -1,0 +1,30 @@
+﻿#if !NET6_0_OR_GREATER
+global using ArgumentNullException = SuperLinq.Exceptions.ArgumentNullException;
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq.Exceptions;
+
+#pragma warning disable RS0016
+#pragma warning disable CA1711
+
+[Browsable(false)]
+public static class ArgumentNullException
+{
+	/// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
+	/// <param name="argument">The reference type argument to validate as non-null.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+	public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+	{
+		if (argument is null)
+		{
+			Throw(paramName);
+		}
+	}
+
+	[DoesNotReturn]
+	private static void Throw(string? paramName) =>
+		throw new System.ArgumentNullException(paramName);
+}
+#endif

--- a/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 namespace SuperLinq.Exceptions;
 
 [Browsable(false)]
+[ExcludeFromCodeCoverage]
 internal static class ArgumentOutOfRangeException
 {
 	[DoesNotReturn]

--- a/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
@@ -3,15 +3,12 @@ global using ArgumentOutOfRangeException = SuperLinq.Exceptions.ArgumentOutOfRan
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace SuperLinq.Exceptions;
 
-#pragma warning disable RS0016
-#pragma warning disable CA1711
-#pragma warning disable CS1591
-
 [Browsable(false)]
-public static class ArgumentOutOfRangeException
+internal static class ArgumentOutOfRangeException
 {
 	[DoesNotReturn]
 	private static void ThrowZero(long value, string? paramName) =>

--- a/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
+++ b/Source/SuperLinq/Exceptions/ArgumentOutOfRangeException.cs
@@ -1,0 +1,226 @@
+﻿#if !NET8_0_OR_GREATER
+global using ArgumentOutOfRangeException = SuperLinq.Exceptions.ArgumentOutOfRangeException;
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq.Exceptions;
+
+#pragma warning disable RS0016
+#pragma warning disable CA1711
+#pragma warning disable CS1591
+
+[Browsable(false)]
+public static class ArgumentOutOfRangeException
+{
+	[DoesNotReturn]
+	private static void ThrowZero(long value, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be not be zero.");
+
+	[DoesNotReturn]
+	private static void ThrowNegative(long value, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be a non-negative value.");
+
+	[DoesNotReturn]
+	private static void ThrowNegativeOrZero(long value, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be a non-negative and non-zero value.");
+
+	[DoesNotReturn]
+	private static void ThrowGreater(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be less than or equal to '{other}'.");
+
+	[DoesNotReturn]
+	private static void ThrowGreaterEqual(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be less than '{other}'.");
+
+	[DoesNotReturn]
+	private static void ThrowLess(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be greater than or equal to '{other}'.");
+
+	[DoesNotReturn]
+	private static void ThrowLessEqual(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be greater than '{other}'.");
+
+	[DoesNotReturn]
+	private static void ThrowEqual(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must not be equal to '{other}'.");
+
+	[DoesNotReturn]
+	private static void ThrowNotEqual(long value, int other, string? paramName) =>
+		throw new System.ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must be equal to '{other}'.");
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is zero.</summary>
+	/// <param name="value">The argument to validate as non-zero.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value == 0)
+			ThrowZero(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
+	/// <param name="value">The argument to validate as non-negative.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value < 0)
+			ThrowNegative(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative or zero.</summary>
+	/// <param name="value">The argument to validate as non-zero or non-negative.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNegativeOrZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value <= 0)
+			ThrowNegativeOrZero(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is equal to <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as not equal to <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfEqual(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value == other)
+			ThrowEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not equal to <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as equal to <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNotEqual(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value != other)
+			ThrowNotEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as less or equal than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfGreaterThan(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value > other)
+			ThrowGreater(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than or equal <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as less than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfGreaterThanOrEqual(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value >= other)
+			ThrowGreaterEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as greatar than or equal than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfLessThan(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value < other)
+			ThrowLess(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than or equal <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as greatar than than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfLessThanOrEqual(int value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value <= other)
+			ThrowLessEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is zero.</summary>
+	/// <param name="value">The argument to validate as non-zero.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfZero(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value == 0)
+			ThrowZero(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
+	/// <param name="value">The argument to validate as non-negative.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNegative(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value < 0)
+			ThrowNegative(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative or zero.</summary>
+	/// <param name="value">The argument to validate as non-zero or non-negative.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNegativeOrZero(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value <= 0)
+			ThrowNegativeOrZero(value, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is equal to <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as not equal to <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfEqual(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value == other)
+			ThrowEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not equal to <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as equal to <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfNotEqual(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value != other)
+			ThrowNotEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as less or equal than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfGreaterThan(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value > other)
+			ThrowGreater(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is greater than or equal <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as less than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfGreaterThanOrEqual(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value >= other)
+			ThrowGreaterEqual(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as greatar than or equal than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfLessThan(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value < other)
+			ThrowLess(value, other, paramName);
+	}
+
+	/// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is less than or equal <paramref name="other"/>.</summary>
+	/// <param name="value">The argument to validate as greatar than than <paramref name="other"/>.</param>
+	/// <param name="other">The value to compare with <paramref name="value"/>.</param>
+	/// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+	public static void ThrowIfLessThanOrEqual(long value, int other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+	{
+		if (value <= other)
+			ThrowLessEqual(value, other, paramName);
+	}
+}
+#endif

--- a/Source/SuperLinq/Exceptions/ThrowHelper.cs
+++ b/Source/SuperLinq/Exceptions/ThrowHelper.cs
@@ -1,16 +1,17 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
-namespace SuperLinq;
+namespace SuperLinq.Exceptions;
 
 internal static class ThrowHelper
 {
 	[DoesNotReturn]
 	public static void ThrowArgumentException(string param, string message) =>
-		throw new ArgumentException(param, message);
+		throw new ArgumentException(message, param);
 
 	[DoesNotReturn]
 	public static T ThrowArgumentException<T>(string param, string message) =>
-		throw new ArgumentException(param, message);
+		throw new ArgumentException(message, param);
 
 	[DoesNotReturn]
 	public static void ThrowArgumentOutOfRangeException(string param) =>
@@ -47,4 +48,12 @@ internal static class ThrowHelper
 	[DoesNotReturn]
 	public static void ThrowObjectDisposedException(string type) =>
 		throw new ObjectDisposedException(type);
+
+	[DoesNotReturn]
+	public static void ThrowUnreachableException() =>
+		throw new UnreachableException();
+
+	[DoesNotReturn]
+	public static void ThrowTimeoutException(string message, Exception? ex = default) =>
+		throw new TimeoutException(message, ex);
 }

--- a/Source/SuperLinq/Exceptions/ThrowHelper.cs
+++ b/Source/SuperLinq/Exceptions/ThrowHelper.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace SuperLinq.Exceptions;
 
+[ExcludeFromCodeCoverage]
 internal static class ThrowHelper
 {
 	[DoesNotReturn]

--- a/Source/SuperLinq/Exceptions/ThrowHelper.cs
+++ b/Source/SuperLinq/Exceptions/ThrowHelper.cs
@@ -47,8 +47,8 @@ internal static class ThrowHelper
 		throw new NotSupportedException();
 
 	[DoesNotReturn]
-	public static void ThrowObjectDisposedException(string type) =>
-		throw new ObjectDisposedException(type);
+	public static void ThrowObjectDisposedException<T>() =>
+		throw new ObjectDisposedException(typeof(T).Name);
 
 	[DoesNotReturn]
 	public static void ThrowUnreachableException() =>

--- a/Source/SuperLinq/Exclude.cs
+++ b/Source/SuperLinq/Exclude.cs
@@ -16,7 +16,7 @@ public static partial class SuperEnumerable
 	/// </exception>
 	public static IEnumerable<T> Exclude<T>(this IEnumerable<T> sequence, int startIndex, int count)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 		Guard.IsGreaterThanOrEqualTo(startIndex, 0);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 

--- a/Source/SuperLinq/Exclude.cs
+++ b/Source/SuperLinq/Exclude.cs
@@ -17,8 +17,8 @@ public static partial class SuperEnumerable
 	public static IEnumerable<T> Exclude<T>(this IEnumerable<T> sequence, int startIndex, int count)
 	{
 		ArgumentNullException.ThrowIfNull(sequence);
-		Guard.IsGreaterThanOrEqualTo(startIndex, 0);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		if (count == 0)
 			return sequence;
@@ -72,7 +72,8 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			return index < _startIndex
 				? _source[index]

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -37,8 +37,8 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="fallback"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, IEnumerable<T> fallback)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(fallback);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(fallback);
 
 		return source.TryGetCollectionCount() is not null
 			   && fallback.TryGetCollectionCount() is not null

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -144,7 +144,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, Count);
 
 			_source.CopyTo(array, arrayIndex);
 

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -45,8 +45,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return source is ICollection<T> coll
 			? new FillBackwardCollection<T>(coll, predicate, fillSelector: default)
@@ -78,9 +78,9 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return source is ICollection<T> coll
 			? new FillBackwardCollection<T>(coll, predicate, fillSelector)
@@ -143,7 +143,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/FillForward.cs
+++ b/Source/SuperLinq/FillForward.cs
@@ -132,7 +132,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, Count);
 
 			_source.CopyTo(array, arrayIndex);
 

--- a/Source/SuperLinq/FillForward.cs
+++ b/Source/SuperLinq/FillForward.cs
@@ -45,8 +45,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> FillForward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return source is ICollection<T> coll
 			? new FillForwardCollection<T>(coll, predicate, fillSelector: default)
@@ -78,9 +78,9 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> FillForward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(fillSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(fillSelector);
 
 		return source is ICollection<T> coll
 			? new FillForwardCollection<T>(coll, predicate, fillSelector)
@@ -131,7 +131,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/Finally.cs
+++ b/Source/SuperLinq/Finally.cs
@@ -19,8 +19,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Finally<TSource>(this IEnumerable<TSource> source, Action finallyAction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(finallyAction);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(finallyAction);
 
 		return Core(source, finallyAction);
 

--- a/Source/SuperLinq/FindIndex.cs
+++ b/Source/SuperLinq/FindIndex.cs
@@ -107,8 +107,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static int FindIndex<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, Index index, int count)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		if (source.TryGetCollectionCount() is int length)

--- a/Source/SuperLinq/FindIndex.cs
+++ b/Source/SuperLinq/FindIndex.cs
@@ -109,7 +109,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		if (source.TryGetCollectionCount() is int length)
 		{

--- a/Source/SuperLinq/FindLastIndex.cs
+++ b/Source/SuperLinq/FindLastIndex.cs
@@ -111,8 +111,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static int FindLastIndex<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, Index index, int count)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 
 		if (source.TryGetCollectionCount() is int length)

--- a/Source/SuperLinq/FindLastIndex.cs
+++ b/Source/SuperLinq/FindLastIndex.cs
@@ -113,7 +113,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		if (source.TryGetCollectionCount() is int length)
 		{

--- a/Source/SuperLinq/Flatten.cs
+++ b/Source/SuperLinq/Flatten.cs
@@ -41,7 +41,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<object?> Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
 	{
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return Flatten(source, obj => obj is IEnumerable inner && predicate(inner) ? inner : null);
 	}
@@ -70,8 +70,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<object?> Flatten(this IEnumerable source, Func<object?, IEnumerable?> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return Core(); IEnumerable<object?> Core()
 		{

--- a/Source/SuperLinq/ForEach.cs
+++ b/Source/SuperLinq/ForEach.cs
@@ -15,8 +15,8 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		foreach (var element in source)
 			action(element);
@@ -37,8 +37,8 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource, int> action)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		var index = 0;
 		foreach (var element in source)

--- a/Source/SuperLinq/From.cs
+++ b/Source/SuperLinq/From.cs
@@ -16,7 +16,7 @@ public partial class SuperEnumerable
 
 	public static IEnumerable<T> From<T>(Func<T> function)
 	{
-		Guard.IsNotNull(function);
+		ArgumentNullException.ThrowIfNull(function);
 		return Core(function);
 
 		static IEnumerable<T> Core(Func<T> function)
@@ -40,8 +40,8 @@ public partial class SuperEnumerable
 
 	public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2)
 	{
-		Guard.IsNotNull(function1);
-		Guard.IsNotNull(function2);
+		ArgumentNullException.ThrowIfNull(function1);
+		ArgumentNullException.ThrowIfNull(function2);
 		return Core(function1, function2);
 
 		static IEnumerable<T> Core(Func<T> function1, Func<T> function2)
@@ -67,9 +67,9 @@ public partial class SuperEnumerable
 
 	public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2, Func<T> function3)
 	{
-		Guard.IsNotNull(function1);
-		Guard.IsNotNull(function2);
-		Guard.IsNotNull(function3);
+		ArgumentNullException.ThrowIfNull(function1);
+		ArgumentNullException.ThrowIfNull(function2);
+		ArgumentNullException.ThrowIfNull(function3);
 		return Core(function1, function2, function3);
 
 		static IEnumerable<T> Core(Func<T> function1, Func<T> function2, Func<T> function3)

--- a/Source/SuperLinq/FullGroupJoin.cs
+++ b/Source/SuperLinq/FullGroupJoin.cs
@@ -120,11 +120,11 @@ public static partial class SuperEnumerable
 		Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(comparer ?? EqualityComparer<TKey>.Default);
 

--- a/Source/SuperLinq/FullJoin.cs
+++ b/Source/SuperLinq/FullJoin.cs
@@ -52,7 +52,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TResult> secondSelector,
 		Func<TSource, TSource, TResult> bothSelector)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return FullJoin(
 			first, second,
@@ -115,7 +115,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TSource, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return FullJoin(
 			first, second,
@@ -178,13 +178,13 @@ public static partial class SuperEnumerable
 		Func<TSecond, TResult> secondSelector,
 		Func<TFirst, TSecond, TResult> bothSelector)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(secondSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 			first, second,
@@ -254,13 +254,13 @@ public static partial class SuperEnumerable
 		Func<TFirst, TSecond, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(secondSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 				first, second,

--- a/Source/SuperLinq/Generate.cs
+++ b/Source/SuperLinq/Generate.cs
@@ -24,7 +24,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<TResult> Generate<TResult>(TResult initial, Func<TResult, TResult> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Core(initial, generator);
 

--- a/Source/SuperLinq/GenerateByIndex.cs
+++ b/Source/SuperLinq/GenerateByIndex.cs
@@ -22,7 +22,7 @@ public static partial class SuperEnumerable
 	[Obsolete("Will be removed in v6.0.0; better implemented as `Enumerable.Range().Select()`")]
 	public static IEnumerable<TResult> GenerateByIndex<TResult>(Func<int, TResult> generator)
 	{
-		Guard.IsNotNull(generator);
+		ArgumentNullException.ThrowIfNull(generator);
 
 		return Sequence(0, int.MaxValue)
 			.Select(generator);

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Aggregate.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Aggregate.g.cs
@@ -27,10 +27,10 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator2">The second accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, global::System.Func<TAccumulate1, TAccumulate2, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -90,11 +90,11 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator3">The third accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -161,12 +161,12 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator4">The fourth accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, TAccumulate4 seed4, global::System.Func<TAccumulate4, T, TAccumulate4> accumulator4, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator4);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(accumulator4);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -240,13 +240,13 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator5">The fifth accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, TAccumulate4 seed4, global::System.Func<TAccumulate4, T, TAccumulate4> accumulator4, TAccumulate5 seed5, global::System.Func<TAccumulate5, T, TAccumulate5> accumulator5, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator4);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator5);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(accumulator4);
+        ArgumentNullException.ThrowIfNull(accumulator5);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -327,14 +327,14 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator6">The sixth accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, TAccumulate4 seed4, global::System.Func<TAccumulate4, T, TAccumulate4> accumulator4, TAccumulate5 seed5, global::System.Func<TAccumulate5, T, TAccumulate5> accumulator5, TAccumulate6 seed6, global::System.Func<TAccumulate6, T, TAccumulate6> accumulator6, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator4);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator5);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator6);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(accumulator4);
+        ArgumentNullException.ThrowIfNull(accumulator5);
+        ArgumentNullException.ThrowIfNull(accumulator6);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -422,15 +422,15 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator7">The seventh accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, TAccumulate4 seed4, global::System.Func<TAccumulate4, T, TAccumulate4> accumulator4, TAccumulate5 seed5, global::System.Func<TAccumulate5, T, TAccumulate5> accumulator5, TAccumulate6 seed6, global::System.Func<TAccumulate6, T, TAccumulate6> accumulator6, TAccumulate7 seed7, global::System.Func<TAccumulate7, T, TAccumulate7> accumulator7, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator4);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator5);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator6);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator7);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(accumulator4);
+        ArgumentNullException.ThrowIfNull(accumulator5);
+        ArgumentNullException.ThrowIfNull(accumulator6);
+        ArgumentNullException.ThrowIfNull(accumulator7);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);
@@ -525,16 +525,16 @@ public static partial class SuperEnumerable
     /// <param name = "accumulator8">The eighth accumulator.</param>
     public static TResult Aggregate<T, TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TAccumulate8, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, TAccumulate1 seed1, global::System.Func<TAccumulate1, T, TAccumulate1> accumulator1, TAccumulate2 seed2, global::System.Func<TAccumulate2, T, TAccumulate2> accumulator2, TAccumulate3 seed3, global::System.Func<TAccumulate3, T, TAccumulate3> accumulator3, TAccumulate4 seed4, global::System.Func<TAccumulate4, T, TAccumulate4> accumulator4, TAccumulate5 seed5, global::System.Func<TAccumulate5, T, TAccumulate5> accumulator5, TAccumulate6 seed6, global::System.Func<TAccumulate6, T, TAccumulate6> accumulator6, TAccumulate7 seed7, global::System.Func<TAccumulate7, T, TAccumulate7> accumulator7, TAccumulate8 seed8, global::System.Func<TAccumulate8, T, TAccumulate8> accumulator8, global::System.Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TAccumulate8, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator1);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator2);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator3);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator4);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator5);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator6);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator7);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(accumulator8);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(accumulator1);
+        ArgumentNullException.ThrowIfNull(accumulator2);
+        ArgumentNullException.ThrowIfNull(accumulator3);
+        ArgumentNullException.ThrowIfNull(accumulator4);
+        ArgumentNullException.ThrowIfNull(accumulator5);
+        ArgumentNullException.ThrowIfNull(accumulator6);
+        ArgumentNullException.ThrowIfNull(accumulator7);
+        ArgumentNullException.ThrowIfNull(accumulator8);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         foreach (var item in source)
         {
             seed1 = accumulator1(seed1, item);

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Cartesian.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Cartesian.g.cs
@@ -28,9 +28,9 @@ public static partial class SuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1, T2, TResult> resultSelector)
         {
@@ -91,10 +91,10 @@ public static partial class SuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1, T2, T3, TResult> resultSelector)
         {
@@ -161,11 +161,11 @@ public static partial class SuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, T4, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1, T2, T3, T4, TResult> resultSelector)
         {
@@ -238,12 +238,12 @@ public static partial class SuperEnumerable
     /// <param name = "fifth">The fifth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, T4, T5, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Func<T1, T2, T3, T4, T5, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(fifth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, fifth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Func<T1, T2, T3, T4, T5, TResult> resultSelector)
         {
@@ -322,13 +322,13 @@ public static partial class SuperEnumerable
     /// <param name = "sixth">The sixth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, T4, T5, T6, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(sixth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(fifth);
+        ArgumentNullException.ThrowIfNull(sixth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, fifth, sixth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
         {
@@ -413,14 +413,14 @@ public static partial class SuperEnumerable
     /// <param name = "seventh">The seventh sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, T4, T5, T6, T7, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(sixth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(seventh);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(fifth);
+        ArgumentNullException.ThrowIfNull(sixth);
+        ArgumentNullException.ThrowIfNull(seventh);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, fifth, sixth, seventh, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
         {
@@ -511,15 +511,15 @@ public static partial class SuperEnumerable
     /// <param name = "eighth">The eighth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> Cartesian<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Collections.Generic.IEnumerable<T8> eighth, global::System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fifth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(sixth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(seventh);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(eighth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(fifth);
+        ArgumentNullException.ThrowIfNull(sixth);
+        ArgumentNullException.ThrowIfNull(seventh);
+        ArgumentNullException.ThrowIfNull(eighth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         return Core(first, second, third, fourth, fifth, sixth, seventh, eighth, resultSelector);
         static global::System.Collections.Generic.IEnumerable<TResult> Core(global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Collections.Generic.IEnumerable<T5> fifth, global::System.Collections.Generic.IEnumerable<T6> sixth, global::System.Collections.Generic.IEnumerable<T7> seventh, global::System.Collections.Generic.IEnumerable<T8> eighth, global::System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
         {

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
@@ -116,7 +116,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsLessThan(index, Count);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index]);
         }
     }
@@ -250,7 +251,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsLessThan(index, Count);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index]);
         }
     }
@@ -399,7 +401,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsLessThan(index, Count);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/EquiZip.g.cs
@@ -28,9 +28,9 @@ public static partial class SuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> EquiZip<TFirst, TSecond, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2)
         {
             return new EquiZipIterator<TFirst, TSecond, TResult>(list1, list2, resultSelector);
@@ -47,14 +47,14 @@ public static partial class SuperEnumerable
                 {
                     if (e2.MoveNext())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!e2.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current);
             }
         }
@@ -98,7 +98,7 @@ public static partial class SuperEnumerable
                 var count = _list1.Count;
                 if (_list2.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
                 }
 
                 return count;
@@ -116,7 +116,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            Guard.IsLessThan(index, Count);
             return _resultSelector(_list1[index], _list2[index]);
         }
     }
@@ -149,10 +149,10 @@ public static partial class SuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> EquiZip<TFirst, TSecond, TThird, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3)
         {
             return new EquiZipIterator<TFirst, TSecond, TThird, TResult>(list1, list2, list3, resultSelector);
@@ -170,16 +170,16 @@ public static partial class SuperEnumerable
                 {
                     if (e2.MoveNext() || e3.MoveNext())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!e2.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 if (!e3.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current, e3.Current);
             }
         }
@@ -227,12 +227,12 @@ public static partial class SuperEnumerable
                 var count = _list1.Count;
                 if (_list2.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
                 }
 
                 if (_list3.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
                 }
 
                 return count;
@@ -250,7 +250,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            Guard.IsLessThan(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index]);
         }
     }
@@ -285,11 +285,11 @@ public static partial class SuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> EquiZip<TFirst, TSecond, TThird, TFourth, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3 && fourth is global::System.Collections.Generic.IList<TFourth> list4)
         {
             return new EquiZipIterator<TFirst, TSecond, TThird, TFourth, TResult>(list1, list2, list3, list4, resultSelector);
@@ -308,18 +308,18 @@ public static partial class SuperEnumerable
                 {
                     if (e2.MoveNext() || e3.MoveNext() || e4.MoveNext())
                     {
-                        global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
+                        ThrowHelper.ThrowInvalidOperationException("First sequence too short.");
                     }
 
                     yield break;
                 }
 
                 if (!e2.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Second sequence too short.");
                 if (!e3.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Third sequence too short.");
                 if (!e4.MoveNext())
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException("Fourth sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException("Fourth sequence too short.");
                 yield return resultSelector(e1.Current, e2.Current, e3.Current, e4.Current);
             }
         }
@@ -371,17 +371,17 @@ public static partial class SuperEnumerable
                 var count = _list1.Count;
                 if (_list2.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list2.Count ? "First" : "Second") + " sequence too short.");
                 }
 
                 if (_list3.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list3.Count ? "First" : "Third") + " sequence too short.");
                 }
 
                 if (_list4.Count != count)
                 {
-                    global::CommunityToolkit.Diagnostics.ThrowHelper.ThrowInvalidOperationException((count < _list4.Count ? "First" : "Fourth") + " sequence too short.");
+                    ThrowHelper.ThrowInvalidOperationException((count < _list4.Count ? "First" : "Fourth") + " sequence too short.");
                 }
 
                 return count;
@@ -399,7 +399,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsLessThan(index, Count);
+            Guard.IsLessThan(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Fold.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/Fold.g.cs
@@ -19,8 +19,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(1).ToList();
         return folder(elements[0]);
     }
@@ -42,8 +42,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(2).ToList();
         return folder(elements[0], elements[1]);
     }
@@ -65,8 +65,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(3).ToList();
         return folder(elements[0], elements[1], elements[2]);
     }
@@ -88,8 +88,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(4).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3]);
     }
@@ -111,8 +111,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(5).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4]);
     }
@@ -134,8 +134,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(6).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
     }
@@ -157,8 +157,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(7).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
     }
@@ -180,8 +180,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(8).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
     }
@@ -203,8 +203,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(9).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
     }
@@ -226,8 +226,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(10).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
     }
@@ -249,8 +249,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(11).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
     }
@@ -272,8 +272,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(12).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
     }
@@ -295,8 +295,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(13).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
     }
@@ -318,8 +318,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(14).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
     }
@@ -341,8 +341,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(15).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
     }
@@ -364,8 +364,8 @@ public static partial class SuperEnumerable
     /// </exception>
     public static TResult Fold<T, TResult>(this global::System.Collections.Generic.IEnumerable<T> source, global::System.Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(folder);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(folder);
         var elements = source.AssertCount(16).ToList();
         return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ToDelimitedString.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ToDelimitedString.g.cs
@@ -22,8 +22,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Boolean> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Boolean e) => sb.Append(e);
     }
@@ -48,8 +48,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Byte> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Byte e) => sb.Append(e);
     }
@@ -74,8 +74,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Char> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Char e) => sb.Append(e);
     }
@@ -100,8 +100,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Decimal> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Decimal e) => sb.Append(e);
     }
@@ -126,8 +126,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Double> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Double e) => sb.Append(e);
     }
@@ -152,8 +152,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Int16> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Int16 e) => sb.Append(e);
     }
@@ -178,8 +178,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Int32> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Int32 e) => sb.Append(e);
     }
@@ -204,8 +204,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Int64> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Int64 e) => sb.Append(e);
     }
@@ -230,8 +230,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.SByte> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.SByte e) => sb.Append(e);
     }
@@ -256,8 +256,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.Single> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.Single e) => sb.Append(e);
     }
@@ -282,8 +282,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.String> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.String e) => sb.Append(e);
     }
@@ -308,8 +308,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.UInt16> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.UInt16 e) => sb.Append(e);
     }
@@ -334,8 +334,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.UInt32> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.UInt32 e) => sb.Append(e);
     }
@@ -360,8 +360,8 @@ public static partial class SuperEnumerable
     /// </remarks>
     public static global::System.String ToDelimitedString(this global::System.Collections.Generic.IEnumerable<global::System.UInt64> source, global::System.String delimiter)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(source);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(delimiter);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(delimiter);
         return ToDelimitedStringImpl(source, delimiter, Builder);
         static global::System.Text.StringBuilder Builder(global::System.Text.StringBuilder sb, global::System.UInt64 e) => sb.Append(e);
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
@@ -102,7 +102,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default);
         }
     }
@@ -204,7 +205,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default);
         }
     }
@@ -315,7 +317,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default, index < _list4.Count ? _list4[index] : default);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipLongest.g.cs
@@ -36,9 +36,9 @@ public static partial class SuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipLongest<T1, T2, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Func<T1?, T2?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2)
         {
             return new ZipLongestIterator<T1, T2, TResult>(list1, list2, resultSelector);
@@ -102,7 +102,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default);
         }
     }
@@ -131,10 +131,10 @@ public static partial class SuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipLongest<T1, T2, T3, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Func<T1?, T2?, T3?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2 && third is global::System.Collections.Generic.IList<T3> list3)
         {
             return new ZipLongestIterator<T1, T2, T3, TResult>(list1, list2, list3, resultSelector);
@@ -204,7 +204,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default);
         }
     }
@@ -235,11 +235,11 @@ public static partial class SuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipLongest<T1, T2, T3, T4, TResult>(this global::System.Collections.Generic.IEnumerable<T1> first, global::System.Collections.Generic.IEnumerable<T2> second, global::System.Collections.Generic.IEnumerable<T3> third, global::System.Collections.Generic.IEnumerable<T4> fourth, global::System.Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<T1> list1 && second is global::System.Collections.Generic.IList<T2> list2 && third is global::System.Collections.Generic.IList<T3> list3 && fourth is global::System.Collections.Generic.IList<T4> list4)
         {
             return new ZipLongestIterator<T1, T2, T3, T4, TResult>(list1, list2, list3, list4, resultSelector);
@@ -315,7 +315,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(index < _list1.Count ? _list1[index] : default, index < _list2.Count ? _list2[index] : default, index < _list3.Count ? _list3[index] : default, index < _list4.Count ? _list4[index] : default);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
@@ -22,9 +22,9 @@ public static partial class SuperEnumerable
     /// <param name = "second">The second sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipShortest<TFirst, TSecond, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Func<TFirst, TSecond, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2)
         {
             return new ZipShortestIterator<TFirst, TSecond, TResult>(list1, list2, resultSelector);
@@ -86,7 +86,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index]);
         }
     }
@@ -113,10 +113,10 @@ public static partial class SuperEnumerable
     /// <param name = "third">The third sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipShortest<TFirst, TSecond, TThird, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Func<TFirst, TSecond, TThird, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3)
         {
             return new ZipShortestIterator<TFirst, TSecond, TThird, TResult>(list1, list2, list3, resultSelector);
@@ -183,7 +183,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index], _list3[index]);
         }
     }
@@ -212,11 +212,11 @@ public static partial class SuperEnumerable
     /// <param name = "fourth">The fourth sequence of elements.</param>
     public static global::System.Collections.Generic.IEnumerable<TResult> ZipShortest<TFirst, TSecond, TThird, TFourth, TResult>(this global::System.Collections.Generic.IEnumerable<TFirst> first, global::System.Collections.Generic.IEnumerable<TSecond> second, global::System.Collections.Generic.IEnumerable<TThird> third, global::System.Collections.Generic.IEnumerable<TFourth> fourth, global::System.Func<TFirst, TSecond, TThird, TFourth, TResult> resultSelector)
     {
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(first);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(second);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(third);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(fourth);
-        global::CommunityToolkit.Diagnostics.Guard.IsNotNull(resultSelector);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(third);
+        ArgumentNullException.ThrowIfNull(fourth);
+        ArgumentNullException.ThrowIfNull(resultSelector);
         if (first is global::System.Collections.Generic.IList<TFirst> list1 && second is global::System.Collections.Generic.IList<TSecond> list2 && third is global::System.Collections.Generic.IList<TThird> list3 && fourth is global::System.Collections.Generic.IList<TFourth> list4)
         {
             return new ZipShortestIterator<TFirst, TSecond, TThird, TFourth, TResult>(list1, list2, list3, list4, resultSelector);
@@ -288,7 +288,7 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            global::CommunityToolkit.Diagnostics.Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
             return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
         }
     }

--- a/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
+++ b/Source/SuperLinq/Generated/SuperLinq.Generator/SuperLinq.Generator.Generator/ZipShortest.g.cs
@@ -86,7 +86,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index]);
         }
     }
@@ -183,7 +184,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index]);
         }
     }
@@ -288,7 +290,8 @@ public static partial class SuperEnumerable
 
         protected override TResult ElementAt(int index)
         {
-            Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
             return _resultSelector(_list1[index], _list2[index], _list3[index], _list4[index]);
         }
     }

--- a/Source/SuperLinq/GetShortestPath.A-Star.cs
+++ b/Source/SuperLinq/GetShortestPath.A-Star.cs
@@ -144,9 +144,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -281,9 +281,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -316,7 +316,7 @@ public partial class SuperEnumerable
 
 				var cost = from.traversed;
 				var newStates = getNeighbors(current, cost);
-				Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+				ArgumentNullException.ThrowIfNull(newStates, $"{nameof(getNeighbors)}()");
 
 				foreach (var (s, p, h) in newStates)
 					queue.EnqueueMinimum(s, (current, h, p));

--- a/Source/SuperLinq/GetShortestPath.Dijkstra.cs
+++ b/Source/SuperLinq/GetShortestPath.Dijkstra.cs
@@ -136,9 +136,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -264,9 +264,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -292,7 +292,7 @@ public partial class SuperEnumerable
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
-			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+			ArgumentNullException.ThrowIfNull(newStates, $"{nameof(getNeighbors)}()");
 
 			foreach (var (s, p) in newStates)
 			{

--- a/Source/SuperLinq/GetShortestPathCost.A-Star.cs
+++ b/Source/SuperLinq/GetShortestPathCost.A-Star.cs
@@ -142,9 +142,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -272,9 +272,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -302,7 +302,7 @@ public partial class SuperEnumerable
 					break;
 
 				var newStates = getNeighbors(current, costs.traversed);
-				Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+				ArgumentNullException.ThrowIfNull(newStates, $"{nameof(getNeighbors)}()");
 
 				foreach (var (s, p, h) in newStates)
 					queue.EnqueueMinimum(s, (h, p));

--- a/Source/SuperLinq/GetShortestPathCost.Dijkstra.cs
+++ b/Source/SuperLinq/GetShortestPathCost.Dijkstra.cs
@@ -132,9 +132,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(end);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(end);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 
@@ -256,9 +256,9 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -275,7 +275,7 @@ public partial class SuperEnumerable
 				break;
 
 			var newStates = getNeighbors(current, cost);
-			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+			ArgumentNullException.ThrowIfNull(newStates, $"{nameof(getNeighbors)}()");
 
 			foreach (var (s, p) in newStates)
 			{

--- a/Source/SuperLinq/GetShortestPaths.cs
+++ b/Source/SuperLinq/GetShortestPaths.cs
@@ -145,8 +145,8 @@ public partial class SuperEnumerable
 		where TState : notnull
 		where TCost : notnull
 	{
-		Guard.IsNotNull(start);
-		Guard.IsNotNull(getNeighbors);
+		ArgumentNullException.ThrowIfNull(start);
+		ArgumentNullException.ThrowIfNull(getNeighbors);
 
 		stateComparer ??= EqualityComparer<TState>.Default;
 		costComparer ??= Comparer<TCost>.Default;
@@ -166,7 +166,7 @@ public partial class SuperEnumerable
 
 			var cost = from.cost;
 			var newStates = getNeighbors(current, cost);
-			Guard.IsNotNull(newStates, $"{nameof(getNeighbors)}()");
+			ArgumentNullException.ThrowIfNull(newStates, $"{nameof(getNeighbors)}()");
 
 			foreach (var (s, p) in newStates)
 			{

--- a/Source/SuperLinq/GroupAdjacent.cs
+++ b/Source/SuperLinq/GroupAdjacent.cs
@@ -65,8 +65,8 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return GroupAdjacent(source, keySelector, Identity, comparer);
 	}
@@ -105,9 +105,9 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		Func<TSource, TElement> elementSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(elementSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(elementSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, elementSelector,
@@ -153,9 +153,9 @@ public static partial class SuperEnumerable
 		Func<TSource, TElement> elementSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(elementSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(elementSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, elementSelector,
@@ -197,9 +197,9 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, Identity,
@@ -244,9 +244,9 @@ public static partial class SuperEnumerable
 		Func<TKey, IEnumerable<TSource>, TResult> resultSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return GroupAdjacentImpl(
 			source, keySelector, Identity,

--- a/Source/SuperLinq/HasDuplicates.cs
+++ b/Source/SuperLinq/HasDuplicates.cs
@@ -68,8 +68,8 @@ public static partial class SuperEnumerable
 	public static bool HasDuplicates<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		var enumeratedElements = source.TryGetCollectionCount() is { } collectionCount
 			? new HashSet<TKey>(collectionCount, comparer)

--- a/Source/SuperLinq/If.cs
+++ b/Source/SuperLinq/If.cs
@@ -44,9 +44,9 @@ public static partial class SuperEnumerable
 		IEnumerable<TResult> thenSource,
 		IEnumerable<TResult> elseSource)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(thenSource);
-		Guard.IsNotNull(elseSource);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(thenSource);
+		ArgumentNullException.ThrowIfNull(elseSource);
 
 		return Case(
 			condition,

--- a/Source/SuperLinq/Index.cs
+++ b/Source/SuperLinq/Index.cs
@@ -95,7 +95,9 @@ public static partial class SuperEnumerable
 
 		protected override (int index, T item) ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return (_startIndex + index, _source[index]);
 		}
 	}

--- a/Source/SuperLinq/Index.cs
+++ b/Source/SuperLinq/Index.cs
@@ -33,7 +33,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<(int index, TSource item)> Index<TSource>(this IEnumerable<TSource> source, int startIndex)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (source is IList<TSource> list)
 			return new IndexListIterator<TSource>(list, startIndex);

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -30,7 +30,7 @@ public static partial class SuperEnumerable
 	/// </exception>
 	public static IEnumerable<T> Insert<T>(this IEnumerable<T> first, IEnumerable<T> second, int index)
 	{
-		Guard.IsGreaterThanOrEqualTo(index, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(index);
 
 		return Insert(first, second, (Index)index);
 	}
@@ -149,7 +149,9 @@ public static partial class SuperEnumerable
 			{
 				var fCount = _first.GetCollectionCount();
 				var idx = _index.GetOffset(fCount);
-				Guard.IsBetweenOrEqualTo(idx, 0, fCount);
+				ArgumentOutOfRangeException.ThrowIfNegative(idx);
+				ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, fCount);
+
 				return fCount + _second.GetCollectionCount();
 			}
 		}
@@ -158,7 +160,8 @@ public static partial class SuperEnumerable
 		{
 			var fCount = _first.GetCollectionCount();
 			var idx = _index.GetOffset(fCount);
-			Guard.IsBetweenOrEqualTo(idx, 0, fCount);
+			ArgumentOutOfRangeException.ThrowIfNegative(idx);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, fCount);
 
 			return InsertCore(_first, _second, idx);
 		}
@@ -166,7 +169,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_ = _first.CopyTo(array, arrayIndex);
 
@@ -197,7 +201,9 @@ public static partial class SuperEnumerable
 			get
 			{
 				var idx = _index.GetOffset(_first.Count);
-				Guard.IsBetweenOrEqualTo(idx, 0, _first.Count);
+				ArgumentOutOfRangeException.ThrowIfNegative(idx);
+				ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
+
 				return _first.Count + _second.Count;
 			}
 		}
@@ -205,7 +211,8 @@ public static partial class SuperEnumerable
 		protected override IEnumerable<T> GetEnumerable()
 		{
 			var idx = _index.GetOffset(_first.Count);
-			Guard.IsBetweenOrEqualTo(idx, 0, _first.Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(idx);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
 
 			for (var i = 0; i < (uint)idx; i++)
 				yield return _first[i];
@@ -222,7 +229,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_first.CopyTo(array, arrayIndex);
 
@@ -236,9 +244,12 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			var idx = _index.GetOffset(_first.Count);
-			Guard.IsBetweenOrEqualTo(idx, 0, _first.Count);
-			Guard.IsBetweenOrEqualTo(index, 0, _first.Count + _second.Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(idx);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
 
 			return index < idx ? _first[index] :
 				index < idx + _second.Count ? _second[index - idx] :

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -63,8 +63,8 @@ public static partial class SuperEnumerable
 	/// </exception>
 	public static IEnumerable<T> Insert<T>(this IEnumerable<T> first, IEnumerable<T> second, Index index)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		if (first is IList<T> fList && second is IList<T> sList)
 			return new InsertListIterator<T>(fList, sList, index);
@@ -165,7 +165,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_ = _first.CopyTo(array, arrayIndex);
@@ -221,7 +221,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_first.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/Interleave.cs
+++ b/Source/SuperLinq/Interleave.cs
@@ -28,11 +28,11 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException">Any of the items in <paramref name="otherSources"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<T> Interleave<T>(this IEnumerable<T> source, params IEnumerable<T>[] otherSources)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(otherSources);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(otherSources);
 
 		foreach (var s in otherSources)
-			Guard.IsNotNull(s, nameof(otherSources));
+			ArgumentNullException.ThrowIfNull(s, nameof(otherSources));
 
 		if (source is ICollection<T> && otherSources.All(s => s is ICollection<T>))
 			return new InterleaveIterator<T>(otherSources.Prepend(source).Cast<ICollection<T>>());
@@ -61,7 +61,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<T> Interleave<T>(this IEnumerable<IEnumerable<T>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		if (sources is IEnumerable<ICollection<T>> sourcesColl)
 			return new InterleaveIterator<T>(sourcesColl.ToList());

--- a/Source/SuperLinq/Join.MergeJoin.cs
+++ b/Source/SuperLinq/Join.MergeJoin.cs
@@ -14,7 +14,7 @@ public static partial class SuperEnumerable
 		}
 
 		public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => _comparer.Compare(x, y) == 0;
-		public int GetHashCode([DisallowNull] TKey obj) => throw new NotSupportedException();
+		public int GetHashCode([DisallowNull] TKey obj) => ThrowHelper.ThrowNotSupportedException<int>();
 	}
 
 	private static IEnumerable<TResult> MergeJoin<TLeft, TRight, TKey, TResult>(

--- a/Source/SuperLinq/Join.cs
+++ b/Source/SuperLinq/Join.cs
@@ -22,17 +22,17 @@ public static partial class SuperEnumerable
 		Func<TRight, TResult>? rightResultSelector,
 		Func<TLeft, TRight, TResult> bothResultSelector)
 	{
-		Guard.IsNotNull(left);
-		Guard.IsNotNull(right);
-		Guard.IsNotNull(leftKeySelector);
-		Guard.IsNotNull(rightKeySelector);
+		ArgumentNullException.ThrowIfNull(left);
+		ArgumentNullException.ThrowIfNull(right);
+		ArgumentNullException.ThrowIfNull(leftKeySelector);
+		ArgumentNullException.ThrowIfNull(rightKeySelector);
 
 		if (joinOperation.HasFlag(JoinOperation.LeftOuter))
-			Guard.IsNotNull(leftResultSelector);
+			ArgumentNullException.ThrowIfNull(leftResultSelector);
 		if (joinOperation.HasFlag(JoinOperation.RightOuter))
-			Guard.IsNotNull(rightResultSelector);
+			ArgumentNullException.ThrowIfNull(rightResultSelector);
 
-		Guard.IsNotNull(bothResultSelector);
+		ArgumentNullException.ThrowIfNull(bothResultSelector);
 
 		return joinType switch
 		{
@@ -85,18 +85,18 @@ public static partial class SuperEnumerable
 		TComparer comparer)
 		where TComparer : notnull, IComparer<TKey>, IEqualityComparer<TKey>
 	{
-		Guard.IsNotNull(left);
-		Guard.IsNotNull(right);
-		Guard.IsNotNull(leftKeySelector);
-		Guard.IsNotNull(rightKeySelector);
+		ArgumentNullException.ThrowIfNull(left);
+		ArgumentNullException.ThrowIfNull(right);
+		ArgumentNullException.ThrowIfNull(leftKeySelector);
+		ArgumentNullException.ThrowIfNull(rightKeySelector);
 
 		if (joinOperation.HasFlag(JoinOperation.LeftOuter))
-			Guard.IsNotNull(leftResultSelector);
+			ArgumentNullException.ThrowIfNull(leftResultSelector);
 		if (joinOperation.HasFlag(JoinOperation.RightOuter))
-			Guard.IsNotNull(rightResultSelector);
+			ArgumentNullException.ThrowIfNull(rightResultSelector);
 
-		Guard.IsNotNull(bothResultSelector);
-		Guard.IsNotNull(comparer);
+		ArgumentNullException.ThrowIfNull(bothResultSelector);
+		ArgumentNullException.ThrowIfNull(comparer);
 
 		return joinType switch
 		{

--- a/Source/SuperLinq/Lag.cs
+++ b/Source/SuperLinq/Lag.cs
@@ -59,8 +59,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/Lag.cs
+++ b/Source/SuperLinq/Lag.cs
@@ -61,7 +61,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		if (source is IList<TSource> list)
 			return new LagIterator<TSource, TResult>(list, offset, defaultLagValue, resultSelector);
@@ -109,7 +109,9 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _resultSelector(
 				_source[index],
 				index < _offset ? _defaultLagValue : _source[index - _offset]);

--- a/Source/SuperLinq/Lead.cs
+++ b/Source/SuperLinq/Lead.cs
@@ -66,7 +66,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(resultSelector);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		if (source is IList<TSource> list)
 			return new LeadIterator<TSource, TResult>(list, offset, defaultLeadValue, resultSelector);
@@ -118,7 +118,9 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _resultSelector(
 				_source[index],
 				index < Math.Max(_source.Count - _offset, 0)

--- a/Source/SuperLinq/Lead.cs
+++ b/Source/SuperLinq/Lead.cs
@@ -64,8 +64,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/LeftJoin.cs
+++ b/Source/SuperLinq/LeftJoin.cs
@@ -45,7 +45,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TResult> firstSelector,
 		Func<TSource, TSource, TResult> bothSelector)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return LeftJoin(
 			first, second,
@@ -101,7 +101,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TSource, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return LeftJoin(
 			first, second,
@@ -157,12 +157,12 @@ public static partial class SuperEnumerable
 		Func<TFirst, TResult> firstSelector,
 		Func<TFirst, TSecond, TResult> bothSelector)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 			first, second,
@@ -225,12 +225,12 @@ public static partial class SuperEnumerable
 		Func<TFirst, TSecond, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 				first, second,

--- a/Source/SuperLinq/ListIterator.cs
+++ b/Source/SuperLinq/ListIterator.cs
@@ -8,14 +8,14 @@ public partial class SuperEnumerable
 	private abstract class ListIterator<T> : CollectionIterator<T>, IList<T>, IReadOnlyList<T>
 	{
 		public void Insert(int index, T item) =>
-			throw new NotSupportedException();
+			ThrowHelper.ThrowNotSupportedException();
 		public void RemoveAt(int index) =>
-			throw new NotSupportedException();
+			ThrowHelper.ThrowNotSupportedException();
 
 		public T this[int index]
 		{
 			get => ElementAt(index);
-			set => throw new NotSupportedException();
+			set => ThrowHelper.ThrowNotSupportedException();
 		}
 
 		protected abstract T ElementAt(int index);

--- a/Source/SuperLinq/Lookup.cs
+++ b/Source/SuperLinq/Lookup.cs
@@ -224,7 +224,8 @@ internal sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
 		{
 			get
 			{
-				Guard.IsBetween(index, -1, _count);
+				ArgumentOutOfRangeException.ThrowIfNegative(index);
+				ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
 				return _elements[index];
 			}
 

--- a/Source/SuperLinq/Lookup.cs
+++ b/Source/SuperLinq/Lookup.cs
@@ -229,16 +229,13 @@ internal sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
 				return _elements[index];
 			}
 
-			set => ThrowModificationNotSupportedException();
+			set => ThrowHelper.ThrowNotSupportedException();
 		}
 
-		void ICollection<TElement>.Add(TElement item) => ThrowModificationNotSupportedException();
-		void ICollection<TElement>.Clear() => ThrowModificationNotSupportedException();
-		bool ICollection<TElement>.Remove(TElement item) { ThrowModificationNotSupportedException(); return false; }
-		void IList<TElement>.Insert(int index, TElement item) => ThrowModificationNotSupportedException();
-		void IList<TElement>.RemoveAt(int index) => ThrowModificationNotSupportedException();
-
-		[DoesNotReturn]
-		private static void ThrowModificationNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");
+		void ICollection<TElement>.Add(TElement item) => ThrowHelper.ThrowNotSupportedException();
+		void ICollection<TElement>.Clear() => ThrowHelper.ThrowNotSupportedException();
+		bool ICollection<TElement>.Remove(TElement item) => ThrowHelper.ThrowNotSupportedException<bool>();
+		void IList<TElement>.Insert(int index, TElement item) => ThrowHelper.ThrowNotSupportedException();
+		void IList<TElement>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
 	}
 }

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -42,7 +42,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IBuffer<TSource> Memoize<TSource>(this IEnumerable<TSource> source, bool forceCache = true)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return (source, forceCache) switch
 		{
@@ -107,7 +107,7 @@ public static partial class SuperEnumerable
 
 				if (_exceptionIndex == -1)
 				{
-					Guard.IsNotNull(_exception);
+					ArgumentNullException.ThrowIfNull(_exception);
 					_exception.Throw();
 				}
 

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 
 namespace SuperLinq;
@@ -271,7 +270,8 @@ public static partial class SuperEnumerable
 						break;
 
 					default:
-						throw new UnreachableException();
+						ThrowHelper.ThrowUnreachableException();
+						return;
 				}
 			}
 		}
@@ -341,7 +341,8 @@ public static partial class SuperEnumerable
 						break;
 
 					default:
-						throw new UnreachableException();
+						ThrowHelper.ThrowUnreachableException();
+						return default!;
 				}
 			}
 		}

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -381,8 +381,15 @@ public static partial class SuperEnumerable
 		}
 
 		private ICollection<T>? _source;
-		private ICollection<T> Source =>
-			_source ?? ThrowHelper.ThrowObjectDisposedException<ICollection<T>>(nameof(IBuffer<T>));
+		private ICollection<T> Source
+		{
+			get
+			{
+				if (_source == null)
+					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+				return _source;
+			}
+		}
 
 		public void Reset()
 		{

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -79,7 +79,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				_buffer = new();
 				_initialized = false;
@@ -101,7 +101,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -143,7 +143,7 @@ public static partial class SuperEnumerable
 				lock (_lock)
 				{
 					if (_disposed)
-						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 					if (!_initialized
 						|| buffer != _buffer)
 					{
@@ -268,7 +268,7 @@ public static partial class SuperEnumerable
 					}
 
 					case State.Disposed:
-						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 						break;
 
 					default:
@@ -335,7 +335,7 @@ public static partial class SuperEnumerable
 						return h.Buffer;
 
 					case State.Disposed:
-						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 						break;
 
 					case State.Error:
@@ -354,7 +354,7 @@ public static partial class SuperEnumerable
 			foreach (var i in buffer)
 			{
 				if (_state.State == State.Disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				if (_state.State != State.Initialized
 					|| _state.Buffer != buffer)
@@ -390,7 +390,7 @@ public static partial class SuperEnumerable
 			get
 			{
 				if (_source == null)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 				return _source;
 			}
 		}
@@ -398,7 +398,7 @@ public static partial class SuperEnumerable
 		public void Reset()
 		{
 			if (_source == null)
-				ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+				ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 		}
 
 		public int Count => Source.Count;

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 
 namespace SuperLinq;
@@ -194,6 +195,7 @@ public static partial class SuperEnumerable
 			}
 		}
 
+		[ExcludeFromCodeCoverage]
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 		public void Dispose()
@@ -364,6 +366,7 @@ public static partial class SuperEnumerable
 			}
 		}
 
+		[ExcludeFromCodeCoverage]
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 		public void Dispose()
@@ -401,6 +404,8 @@ public static partial class SuperEnumerable
 		public int Count => Source.Count;
 
 		public IEnumerator<T> GetEnumerator() => Source.GetEnumerator();
+
+		[ExcludeFromCodeCoverage]
 		IEnumerator IEnumerable.GetEnumerator() => Source.GetEnumerator();
 
 		public void Dispose() => _source = null;

--- a/Source/SuperLinq/Move.cs
+++ b/Source/SuperLinq/Move.cs
@@ -30,9 +30,9 @@ public static partial class SuperEnumerable
 	public static IEnumerable<T> Move<T>(this IEnumerable<T> source, int fromIndex, int count, int toIndex)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(fromIndex, 0);
-		Guard.IsGreaterThanOrEqualTo(count, 0);
-		Guard.IsGreaterThanOrEqualTo(toIndex, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(fromIndex);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
+		ArgumentOutOfRangeException.ThrowIfNegative(toIndex);
 
 		return
 			toIndex == fromIndex || count == 0

--- a/Source/SuperLinq/Move.cs
+++ b/Source/SuperLinq/Move.cs
@@ -29,7 +29,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<T> Move<T>(this IEnumerable<T> source, int fromIndex, int count, int toIndex)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(fromIndex, 0);
 		Guard.IsGreaterThanOrEqualTo(count, 0);
 		Guard.IsGreaterThanOrEqualTo(toIndex, 0);

--- a/Source/SuperLinq/OnErrorResumeNext.cs
+++ b/Source/SuperLinq/OnErrorResumeNext.cs
@@ -13,8 +13,8 @@ public static partial class SuperEnumerable
 	/// langword="null"/>.</exception>
 	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		return OnErrorResumeNext(new[] { first, second, });
 	}
@@ -29,7 +29,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(params IEnumerable<TSource>[] sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return sources.AsEnumerable().OnErrorResumeNext();
 	}
@@ -44,7 +44,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> OnErrorResumeNext<TSource>(this IEnumerable<IEnumerable<TSource>> sources)
 	{
-		Guard.IsNotNull(sources);
+		ArgumentNullException.ThrowIfNull(sources);
 
 		return Core(sources);
 
@@ -52,7 +52,7 @@ public static partial class SuperEnumerable
 		{
 			foreach (var source in sources)
 			{
-				Guard.IsNotNull(source);
+				ArgumentNullException.ThrowIfNull(source);
 				using var e = source.GetEnumerator();
 
 				while (true)

--- a/Source/SuperLinq/OrderBy.cs
+++ b/Source/SuperLinq/OrderBy.cs
@@ -30,8 +30,8 @@ public static partial class SuperEnumerable
 
 	public static IOrderedEnumerable<T> OrderBy<T, TKey>(this IEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey>? comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 				   ? source.OrderBy(keySelector, comparer)
 				   : source.OrderByDescending(keySelector, comparer);
@@ -65,8 +65,8 @@ public static partial class SuperEnumerable
 
 	public static IOrderedEnumerable<T> ThenBy<T, TKey>(this IOrderedEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey>? comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 		return direction == OrderByDirection.Ascending
 				   ? source.ThenBy(keySelector, comparer)
 				   : source.ThenByDescending(keySelector, comparer);

--- a/Source/SuperLinq/OrderedMerge.cs
+++ b/Source/SuperLinq/OrderedMerge.cs
@@ -87,7 +87,7 @@ public static partial class SuperEnumerable
 		IEnumerable<T> second,
 		Func<T, TKey> keySelector)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return OrderedMerge(first, second, keySelector, Identity, Identity, static (a, _) => a);
 	}
@@ -123,7 +123,7 @@ public static partial class SuperEnumerable
 		Func<T, TKey> keySelector,
 		IComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return OrderedMerge(first, second, keySelector, Identity, Identity, static (a, _) => a, comparer);
 	}
@@ -165,12 +165,12 @@ public static partial class SuperEnumerable
 		Func<T, TResult> secondSelector,
 		Func<T, T, TResult> bothSelector)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
-		Guard.IsNotNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
 
 		return MergeJoin(
 			first, second,
@@ -220,12 +220,12 @@ public static partial class SuperEnumerable
 		Func<T, T, TResult> bothSelector,
 		IComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
-		Guard.IsNotNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
 
 		return MergeJoin(
 				first, second,
@@ -278,13 +278,13 @@ public static partial class SuperEnumerable
 		Func<TSecond, TResult> secondSelector,
 		Func<TFirst, TSecond, TResult> bothSelector)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
-		Guard.IsNotNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
 
 		return MergeJoin(
 			first, second,
@@ -340,13 +340,13 @@ public static partial class SuperEnumerable
 		Func<TFirst, TSecond, TResult> bothSelector,
 		IComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(firstSelector);
-		Guard.IsNotNull(bothSelector);
-		Guard.IsNotNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(firstSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
 
 		return MergeJoin(
 				first, second,

--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -89,8 +89,8 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="width"/> is less than 0.</exception>
 	public static IEnumerable<TSource> Pad<TSource>(this IEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(paddingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
 		if (source is IList<TSource> list)
@@ -142,7 +142,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			var cnt = _source.CopyTo(array, arrayIndex);
@@ -180,7 +180,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -91,7 +91,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(paddingSelector);
-		Guard.IsGreaterThanOrEqualTo(width, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(width);
 
 		if (source is IList<TSource> list)
 			return new PadListIterator<TSource>(list, width, paddingSelector);
@@ -143,7 +143,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			var cnt = _source.CopyTo(array, arrayIndex);
 
@@ -181,7 +182,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 
@@ -191,7 +193,9 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return index < _source.Count
 				? _source[index]
 				: _paddingSelector(index);

--- a/Source/SuperLinq/PadStart.cs
+++ b/Source/SuperLinq/PadStart.cs
@@ -90,8 +90,8 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException"><paramref name="width"/> is less than 0.</exception>
 	public static IEnumerable<TSource> PadStart<TSource>(this IEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(paddingSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(paddingSelector);
 		Guard.IsGreaterThanOrEqualTo(width, 0);
 
 		if (source is IList<TSource> list)
@@ -164,7 +164,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			var offset = Math.Max(_width - _source.GetCollectionCount(), 0);
@@ -201,7 +201,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			var offset = Math.Max(_width - _source.Count, 0);

--- a/Source/SuperLinq/PadStart.cs
+++ b/Source/SuperLinq/PadStart.cs
@@ -92,7 +92,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(paddingSelector);
-		Guard.IsGreaterThanOrEqualTo(width, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(width);
 
 		if (source is IList<TSource> list)
 			return new PadStartListIterator<TSource>(list, width, paddingSelector);
@@ -165,7 +165,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			var offset = Math.Max(_width - _source.GetCollectionCount(), 0);
 			for (var i = 0; i < offset; i++)
@@ -202,7 +203,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			var offset = Math.Max(_width - _source.Count, 0);
 			for (var i = 0; i < offset; i++)
@@ -213,7 +215,8 @@ public static partial class SuperEnumerable
 
 		protected override T ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			var offset = Math.Max(_width - _source.Count, 0);
 			return index < offset

--- a/Source/SuperLinq/PartialSort.cs
+++ b/Source/SuperLinq/PartialSort.cs
@@ -109,7 +109,7 @@ public static partial class SuperEnumerable
 		IComparer<T>? comparer, OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		comparer ??= Comparer<T>.Default;
 		if (direction == OrderByDirection.Descending)
@@ -271,7 +271,7 @@ public static partial class SuperEnumerable
 		OrderByDirection direction)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;

--- a/Source/SuperLinq/PartialSort.cs
+++ b/Source/SuperLinq/PartialSort.cs
@@ -108,7 +108,7 @@ public static partial class SuperEnumerable
 		this IEnumerable<T> source, int count,
 		IComparer<T>? comparer, OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
 
 		comparer ??= Comparer<T>.Default;
@@ -270,9 +270,9 @@ public static partial class SuperEnumerable
 		IComparer<TKey>? comparer,
 		OrderByDirection direction)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		comparer ??= Comparer<TKey>.Default;
 		if (direction == OrderByDirection.Descending)

--- a/Source/SuperLinq/Partition.cs
+++ b/Source/SuperLinq/Partition.cs
@@ -62,9 +62,9 @@ public static partial class SuperEnumerable
 		Func<T, bool> predicate,
 		Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		var lookup = source.ToLookup(predicate);
 		return resultSelector(lookup[true], lookup[false]);
@@ -91,8 +91,8 @@ public static partial class SuperEnumerable
 		this IEnumerable<IGrouping<bool, T>> source,
 		Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Partition(
 			key1: true, key2: false,
@@ -121,8 +121,8 @@ public static partial class SuperEnumerable
 		this IEnumerable<IGrouping<bool?, T>> source,
 		Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return source.Partition(
 			key1: true, key2: false, key3: null,
@@ -186,8 +186,8 @@ public static partial class SuperEnumerable
 		TKey key, IEqualityComparer<TKey>? comparer,
 		Func<IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(
 			source, 1, key, key2: default, key3: default, comparer,
@@ -255,8 +255,8 @@ public static partial class SuperEnumerable
 		TKey key1, TKey key2, IEqualityComparer<TKey>? comparer,
 		Func<IEnumerable<TElement>, IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(
 			source, 2, key1, key2, key3: default, comparer,
@@ -326,8 +326,8 @@ public static partial class SuperEnumerable
 		TKey key1, TKey key2, TKey key3, IEqualityComparer<TKey>? comparer,
 		Func<IEnumerable<TElement>, IEnumerable<TElement>, IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return PartitionImpl(source, 3, key1, key2, key3, comparer, resultSelector);
 	}

--- a/Source/SuperLinq/Permutations.cs
+++ b/Source/SuperLinq/Permutations.cs
@@ -60,7 +60,7 @@ public static partial class SuperEnumerable
 		{
 			_valueSet = sequence.ToArray();
 			if (_valueSet.Length > 21)
-				throw new ArgumentException("Input set is too large to permute properly.", nameof(sequence));
+				ThrowHelper.ThrowArgumentException(nameof(sequence), "Input set is too large to permute properly.");
 
 			_permutation = new int[_valueSet.Length];
 

--- a/Source/SuperLinq/Permutations.cs
+++ b/Source/SuperLinq/Permutations.cs
@@ -196,7 +196,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentException"><paramref name="sequence"/> has too many elements to permute properly.</exception>
 	public static IEnumerable<IList<T>> Permutations<T>(this IEnumerable<T> sequence)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 
 		return Core(sequence);
 

--- a/Source/SuperLinq/Pipe.cs
+++ b/Source/SuperLinq/Pipe.cs
@@ -11,8 +11,8 @@ public static partial class SuperEnumerable
 	/// <returns>Sequence exhibiting the specified side-effects upon enumeration.</returns>
 	public static IEnumerable<TSource> Pipe<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(action);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(action);
 
 		return Do(source, action);
 	}

--- a/Source/SuperLinq/PreScan.cs
+++ b/Source/SuperLinq/PreScan.cs
@@ -42,8 +42,8 @@ public static partial class SuperEnumerable
 		Func<TSource, TSource, TSource> transformation,
 		TSource identity)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, transformation, identity);
 

--- a/Source/SuperLinq/Publish.cs
+++ b/Source/SuperLinq/Publish.cs
@@ -33,7 +33,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IBuffer<TSource> Publish<TSource>(this IEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return new PublishBuffer<TSource>(source);
 	}

--- a/Source/SuperLinq/Publish.cs
+++ b/Source/SuperLinq/Publish.cs
@@ -66,7 +66,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				_initialized = false;
 				_version++;
@@ -91,7 +91,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -134,7 +134,7 @@ public static partial class SuperEnumerable
 					lock (_lock)
 					{
 						if (_disposed)
-							ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+							ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 						if (!_initialized
 							|| version != _version)
 						{

--- a/Source/SuperLinq/Random.cs
+++ b/Source/SuperLinq/Random.cs
@@ -67,7 +67,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<int> Random(int maxValue)
 	{
-		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(maxValue);
 
 		return Random(s_randomInstance, maxValue);
 	}
@@ -84,7 +84,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<int> Random(Random rand, int maxValue)
 	{
 		ArgumentNullException.ThrowIfNull(rand);
-		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(maxValue);
 
 		return RandomImpl(rand, r => r.Next(maxValue));
 	}
@@ -130,7 +130,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<int> Random(Random rand, int minValue, int maxValue)
 	{
 		ArgumentNullException.ThrowIfNull(rand);
-		Guard.IsLessThanOrEqualTo(minValue, maxValue);
+		ArgumentOutOfRangeException.ThrowIfLessThan(maxValue, minValue);
 
 		return RandomImpl(rand, r => r.Next(minValue, maxValue));
 	}

--- a/Source/SuperLinq/Random.cs
+++ b/Source/SuperLinq/Random.cs
@@ -229,7 +229,7 @@ public static partial class SuperEnumerable
 			// randomizing operator from the outer class then they will
 			// need to be overriden.
 
-			throw new NotSupportedException("Should never reach this code.");
+			return ThrowHelper.ThrowNotSupportedException<double>();
 		}
 	}
 #endif

--- a/Source/SuperLinq/Random.cs
+++ b/Source/SuperLinq/Random.cs
@@ -38,7 +38,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<int> Random(Random rand)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 
 		return RandomImpl(rand, r => r.Next());
 	}
@@ -83,7 +83,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<int> Random(Random rand, int maxValue)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 		Guard.IsGreaterThanOrEqualTo(maxValue, 0);
 
 		return RandomImpl(rand, r => r.Next(maxValue));
@@ -129,7 +129,7 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="minValue"/> is greater than <paramref name="maxValue"/>.</exception>
 	public static IEnumerable<int> Random(Random rand, int minValue, int maxValue)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 		Guard.IsLessThanOrEqualTo(minValue, maxValue);
 
 		return RandomImpl(rand, r => r.Next(minValue, maxValue));
@@ -170,7 +170,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<double> RandomDouble(Random rand)
 	{
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(rand);
 
 		return RandomImpl(rand, r => r.NextDouble());
 	}

--- a/Source/SuperLinq/RandomSubset.cs
+++ b/Source/SuperLinq/RandomSubset.cs
@@ -36,8 +36,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<T> RandomSubset<T>(this IEnumerable<T> source, int subsetSize, Random rand)
 	{
-		Guard.IsNotNull(rand);
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(rand);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
 
 		return RandomSubsetImpl(source, rand, seq => (seq.ToArray(), subsetSize));

--- a/Source/SuperLinq/RandomSubset.cs
+++ b/Source/SuperLinq/RandomSubset.cs
@@ -38,7 +38,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(rand);
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(subsetSize);
 
 		return RandomSubsetImpl(source, rand, seq => (seq.ToArray(), subsetSize));
 	}

--- a/Source/SuperLinq/Rank.cs
+++ b/Source/SuperLinq/Rank.cs
@@ -49,8 +49,8 @@ public static partial class SuperEnumerable
 	public static IEnumerable<(TSource item, int rank)> DenseRankBy<TSource, TKey>(
 		this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByCore(source, keySelector, comparer: null, isDense: true);
 	}
@@ -74,8 +74,8 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IComparer<TKey> comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByCore(source, keySelector, comparer, isDense: true);
 	}
@@ -127,8 +127,8 @@ public static partial class SuperEnumerable
 	public static IEnumerable<(TSource item, int rank)> RankBy<TSource, TKey>(
 		this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByCore(source, keySelector, comparer: null, isDense: false);
 	}
@@ -152,8 +152,8 @@ public static partial class SuperEnumerable
 		Func<TSource, TKey> keySelector,
 		IComparer<TKey> comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RankByCore(source, keySelector, comparer, isDense: false);
 	}

--- a/Source/SuperLinq/Repeat.cs
+++ b/Source/SuperLinq/Repeat.cs
@@ -52,7 +52,7 @@ public partial class SuperEnumerable
 	public static IEnumerable<TSource> Repeat<TSource>(this IEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		return Core(source, count);
 

--- a/Source/SuperLinq/Repeat.cs
+++ b/Source/SuperLinq/Repeat.cs
@@ -23,7 +23,7 @@ public partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> Repeat<TSource>(this IEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(source);
 
@@ -51,7 +51,7 @@ public partial class SuperEnumerable
 	/// <c>0</c>.</exception>
 	public static IEnumerable<TSource> Repeat<TSource>(this IEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 
 		return Core(source, count);

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -22,7 +22,7 @@ public static partial class SuperEnumerable
 		int index,
 		TSource value)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (source is IList<TSource> list)
 			return new ReplaceIterator<TSource>(list, value, index);
@@ -60,7 +60,7 @@ public static partial class SuperEnumerable
 		Index index,
 		TSource value)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		if (source is IList<TSource> list)
 			return new ReplaceIterator<TSource>(list, value, index);
@@ -135,7 +135,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(TSource[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -136,7 +136,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(TSource[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			_source.CopyTo(array, arrayIndex);
 
@@ -147,7 +148,8 @@ public static partial class SuperEnumerable
 
 		protected override TSource ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			return index == _index.GetOffset(_source.Count)
 				? _value

--- a/Source/SuperLinq/Retry.cs
+++ b/Source/SuperLinq/Retry.cs
@@ -52,7 +52,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<TSource> Retry<TSource>(this IEnumerable<TSource> source, int count)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThan(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
 		return Enumerable.Repeat(source, count).Catch();
 	}

--- a/Source/SuperLinq/Retry.cs
+++ b/Source/SuperLinq/Retry.cs
@@ -21,7 +21,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Retry<TSource>(this IEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Repeat<IEnumerable<TSource>>(source).Catch();
 	}
@@ -51,7 +51,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Retry<TSource>(this IEnumerable<TSource> source, int count)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThan(count, 0);
 
 		return Enumerable.Repeat(source, count).Catch();

--- a/Source/SuperLinq/RightJoin.cs
+++ b/Source/SuperLinq/RightJoin.cs
@@ -45,7 +45,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TResult> secondSelector,
 		Func<TSource, TSource, TResult> bothSelector)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RightJoin(
 			first, second,
@@ -101,7 +101,7 @@ public static partial class SuperEnumerable
 		Func<TSource, TSource, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(keySelector);
+		ArgumentNullException.ThrowIfNull(keySelector);
 
 		return RightJoin(
 			first, second,
@@ -157,12 +157,12 @@ public static partial class SuperEnumerable
 		Func<TSecond, TResult> secondSelector,
 		Func<TFirst, TSecond, TResult> bothSelector)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(secondSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 			second, first,
@@ -225,12 +225,12 @@ public static partial class SuperEnumerable
 		Func<TFirst, TSecond, TResult> bothSelector,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
-		Guard.IsNotNull(firstKeySelector);
-		Guard.IsNotNull(secondKeySelector);
-		Guard.IsNotNull(secondSelector);
-		Guard.IsNotNull(bothSelector);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
+		ArgumentNullException.ThrowIfNull(firstKeySelector);
+		ArgumentNullException.ThrowIfNull(secondKeySelector);
+		ArgumentNullException.ThrowIfNull(secondSelector);
+		ArgumentNullException.ThrowIfNull(bothSelector);
 
 		return HashJoin(
 				second, first,

--- a/Source/SuperLinq/RunLengthEncode.cs
+++ b/Source/SuperLinq/RunLengthEncode.cs
@@ -27,7 +27,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<(T value, int count)> RunLengthEncode<T>(this IEnumerable<T> sequence, IEqualityComparer<T>? comparer)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 
 		return Core(sequence, comparer ?? EqualityComparer<T>.Default);
 

--- a/Source/SuperLinq/Scan.cs
+++ b/Source/SuperLinq/Scan.cs
@@ -20,8 +20,8 @@ public static partial class SuperEnumerable
 		this IEnumerable<TSource> source,
 		Func<TSource, TSource, TSource> transformation)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, transformation);
 
@@ -86,15 +86,15 @@ public static partial class SuperEnumerable
 		TState seed,
 		Func<TState, TSource, TState> transformation)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(transformation);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(transformation);
 
 		return Core(source, seed, transformation);
 
 		static IEnumerable<TState> Core(
-			IEnumerable<TSource> source,
-			TState state,
-			Func<TState, TSource, TState> transformation)
+		IEnumerable<TSource> source,
+		TState state,
+		Func<TState, TSource, TState> transformation)
 		{
 			yield return state;
 

--- a/Source/SuperLinq/ScanBy.cs
+++ b/Source/SuperLinq/ScanBy.cs
@@ -66,10 +66,10 @@ public static partial class SuperEnumerable
 		Func<TState, TKey, TSource, TState> accumulator,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(seedSelector);
-		Guard.IsNotNull(accumulator);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(seedSelector);
+		ArgumentNullException.ThrowIfNull(accumulator);
 
 		comparer ??= EqualityComparer<TKey>.Default;
 

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -30,8 +30,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> ScanRight<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		if (source is ICollection<TSource> coll)
 			return new ScanRightIterator<TSource>(coll, func);
@@ -79,7 +79,7 @@ public static partial class SuperEnumerable
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
-			Guard.IsNotNull(array);
+			ArgumentNullException.ThrowIfNull(array);
 			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
 
 			var (sList, b, cnt) = _source is IList<T> s
@@ -125,8 +125,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(func);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(func);
 
 		return Core(source, seed, func);
 

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -80,7 +80,8 @@ public static partial class SuperEnumerable
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
 			ArgumentNullException.ThrowIfNull(array);
-			Guard.IsBetweenOrEqualTo(arrayIndex, 0, array.Length - Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
 			var (sList, b, cnt) = _source is IList<T> s
 				? (s, 0, s.Count)

--- a/Source/SuperLinq/Segment.cs
+++ b/Source/SuperLinq/Segment.cs
@@ -15,7 +15,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => newSegmentPredicate(curr));
 	}
@@ -33,7 +33,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, int, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Segment(source, (curr, prev, index) => newSegmentPredicate(curr, index));
 	}
@@ -51,8 +51,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(newSegmentPredicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(newSegmentPredicate);
 
 		return Core(source, newSegmentPredicate);
 

--- a/Source/SuperLinq/Sequence.cs
+++ b/Source/SuperLinq/Sequence.cs
@@ -16,10 +16,11 @@ public static partial class SuperEnumerable
 	/// </exception>
 	public static IEnumerable<int> Range(int start, int count, int step)
 	{
-		Guard.IsGreaterThanOrEqualTo(count, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
 
 		var max = start + ((count - 1) * (long)step);
-		Guard.IsBetweenOrEqualTo(max, int.MinValue, int.MaxValue, name: nameof(count));
+		ArgumentOutOfRangeException.ThrowIfLessThan(max, int.MinValue, nameof(count));
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(max, int.MaxValue, nameof(count));
 
 		return new SequenceIterator(start, step, count);
 	}
@@ -105,7 +106,9 @@ public static partial class SuperEnumerable
 
 		protected override int ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _start + (_step * index);
 		}
 	}

--- a/Source/SuperLinq/Share.cs
+++ b/Source/SuperLinq/Share.cs
@@ -30,7 +30,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IBuffer<TSource> Share<TSource>(this IEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return new SharedBuffer<TSource>(source);
 	}

--- a/Source/SuperLinq/Share.cs
+++ b/Source/SuperLinq/Share.cs
@@ -61,7 +61,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				_initialized = false;
 				_version++;
@@ -83,7 +83,7 @@ public static partial class SuperEnumerable
 			lock (_lock)
 			{
 				if (_disposed)
-					ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+					ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 
 				Assert.NotNull(_source);
 
@@ -114,7 +114,7 @@ public static partial class SuperEnumerable
 				lock (_lock)
 				{
 					if (_disposed)
-						ThrowHelper.ThrowObjectDisposedException(nameof(IBuffer<T>));
+						ThrowHelper.ThrowObjectDisposedException<IBuffer<T>>();
 					if (!_initialized
 						|| version != _version)
 					{

--- a/Source/SuperLinq/Shuffle.cs
+++ b/Source/SuperLinq/Shuffle.cs
@@ -46,8 +46,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, Random rand)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(rand);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(rand);
 
 		return RandomSubsetImpl(source, rand, seq =>
 		{

--- a/Source/SuperLinq/SkipUntil.cs
+++ b/Source/SuperLinq/SkipUntil.cs
@@ -34,8 +34,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<TSource> SkipUntil<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return Core(source, predicate);
 

--- a/Source/SuperLinq/SortedMerge.cs
+++ b/Source/SuperLinq/SortedMerge.cs
@@ -333,9 +333,9 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="otherSequences"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> SortedMergeBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, OrderByDirection direction, IComparer<TKey>? comparer, params IEnumerable<TSource>[] otherSequences)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(keySelector);
-		Guard.IsNotNull(otherSequences);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(keySelector);
+		ArgumentNullException.ThrowIfNull(otherSequences);
 
 		if (otherSequences.Length == 0)
 			return source; // optimization for when otherSequences is empty

--- a/Source/SuperLinq/Split.cs
+++ b/Source/SuperLinq/Split.cs
@@ -174,7 +174,7 @@ public static partial class SuperEnumerable
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		comparer ??= EqualityComparer<TSource>.Default;
@@ -271,7 +271,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(separatorFunc);
-		Guard.IsGreaterThanOrEqualTo(count, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, separatorFunc, count, resultSelector);

--- a/Source/SuperLinq/Split.cs
+++ b/Source/SuperLinq/Split.cs
@@ -173,9 +173,9 @@ public static partial class SuperEnumerable
 		TSource separator, IEqualityComparer<TSource>? comparer, int count,
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		comparer ??= EqualityComparer<TSource>.Default;
 		return Split(source, item => comparer.Equals(item, separator), count, resultSelector);
@@ -269,10 +269,10 @@ public static partial class SuperEnumerable
 		Func<TSource, bool> separatorFunc, int count,
 		Func<IEnumerable<TSource>, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(separatorFunc);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(separatorFunc);
 		Guard.IsGreaterThanOrEqualTo(count, 1);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(source, separatorFunc, count, resultSelector);
 

--- a/Source/SuperLinq/StartsWith.cs
+++ b/Source/SuperLinq/StartsWith.cs
@@ -49,8 +49,8 @@ public static partial class SuperEnumerable
 
 	public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer)
 	{
-		Guard.IsNotNull(first);
-		Guard.IsNotNull(second);
+		ArgumentNullException.ThrowIfNull(first);
+		ArgumentNullException.ThrowIfNull(second);
 
 		if (first.TryGetCollectionCount() is int firstCount &&
 			second.TryGetCollectionCount() is int secondCount &&

--- a/Source/SuperLinq/Subsets.cs
+++ b/Source/SuperLinq/Subsets.cs
@@ -74,7 +74,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence, int subsetSize)
 	{
 		ArgumentNullException.ThrowIfNull(sequence);
-		Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(subsetSize);
 
 		// NOTE: There's an interesting trade-off that we have to make in this operator.
 		// Ideally, we would throw an exception here if the {subsetSize} parameter is
@@ -194,9 +194,9 @@ public static partial class SuperEnumerable
 			ArgumentNullException.ThrowIfNull(sequence);
 			_sequence = sequence;
 
-			Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
+			ArgumentOutOfRangeException.ThrowIfNegative(subsetSize);
 			if (sequence.TryGetCollectionCount() is int cnt)
-				Guard.IsLessThanOrEqualTo(subsetSize, cnt - 1);
+				ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(subsetSize, cnt);
 
 			_subsetSize = subsetSize;
 		}

--- a/Source/SuperLinq/Subsets.cs
+++ b/Source/SuperLinq/Subsets.cs
@@ -24,7 +24,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 
 		return Core(sequence);
 
@@ -73,7 +73,7 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence, int subsetSize)
 	{
-		Guard.IsNotNull(sequence);
+		ArgumentNullException.ThrowIfNull(sequence);
 		Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
 
 		// NOTE: There's an interesting trade-off that we have to make in this operator.
@@ -191,7 +191,7 @@ public static partial class SuperEnumerable
 
 		public SubsetGenerator(IEnumerable<T> sequence, int subsetSize)
 		{
-			Guard.IsNotNull(sequence);
+			ArgumentNullException.ThrowIfNull(sequence);
 			_sequence = sequence;
 
 			Guard.IsGreaterThanOrEqualTo(subsetSize, 0);

--- a/Source/SuperLinq/SuperEnumerable.cs
+++ b/Source/SuperLinq/SuperEnumerable.cs
@@ -9,34 +9,40 @@ namespace SuperLinq;
 public static partial class SuperEnumerable
 {
 	[ExcludeFromCodeCoverage]
-	internal static int? TryGetCollectionCount<T>(this IEnumerable<T> source) =>
+	internal static int? TryGetCollectionCount<T>(this IEnumerable<T> source)
+	{
+		ArgumentNullException.ThrowIfNull(source);
+
 #if NET6_0_OR_GREATER
-		source.TryGetNonEnumeratedCount(out var count) ? count : default(int?);
+		return source.TryGetNonEnumeratedCount(out var count) ? count : default(int?);
 #else
-		source switch
+		return source switch
 		{
-			null => ThrowHelper.ThrowArgumentNullException<int?>(nameof(source)),
 			ICollection<T> collection => collection.Count,
 			System.Collections.ICollection collection => collection.Count,
 			_ => null,
 		};
 #endif
+	}
 
 	[ExcludeFromCodeCoverage]
-	internal static int GetCollectionCount<T>(this IEnumerable<T> source) =>
+	internal static int GetCollectionCount<T>(this IEnumerable<T> source)
+	{
+		ArgumentNullException.ThrowIfNull(source);
+
 #if NET6_0_OR_GREATER
-		source.TryGetNonEnumeratedCount(out var count)
-			? count
-			: ThrowHelper.ThrowInvalidOperationException<int>("Expected valid non-enumerated count.");
+		if (!source.TryGetNonEnumeratedCount(out var count))
+			ThrowHelper.ThrowInvalidOperationException("Expected valid non-enumerated count.");
+		return count;
 #else
-		source switch
+		return source switch
 		{
-			null => ThrowHelper.ThrowArgumentNullException<int>(nameof(source)),
 			ICollection<T> collection => collection.Count,
 			System.Collections.ICollection collection => collection.Count,
 			_ => ThrowHelper.ThrowInvalidOperationException<int>("Expected valid non-enumerated count."),
 		};
 #endif
+	}
 
 	private static int Max(int val1, int val2) => Math.Max(val1, val2);
 	private static int Max(int val1, int val2, int val3) => Math.Max(val1, Math.Max(val2, val3));

--- a/Source/SuperLinq/SuperLinq.csproj
+++ b/Source/SuperLinq/SuperLinq.csproj
@@ -148,12 +148,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Using Include="CommunityToolkit.Diagnostics" />
 		<Using Include="System.Runtime.CompilerServices" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />

--- a/Source/SuperLinq/SuperLinq.csproj
+++ b/Source/SuperLinq/SuperLinq.csproj
@@ -148,7 +148,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Using Include="System.Runtime.CompilerServices" />
+		<Using Include="SuperLinq.Exceptions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/SuperLinq/TagFirstLast.cs
+++ b/Source/SuperLinq/TagFirstLast.cs
@@ -126,7 +126,9 @@ public static partial class SuperEnumerable
 
 		protected override TResult ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, _source.Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
 			return _resultSelector(_source[index], index == 0, index == _source.Count - 1);
 		}
 	}

--- a/Source/SuperLinq/TagFirstLast.cs
+++ b/Source/SuperLinq/TagFirstLast.cs
@@ -63,8 +63,8 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IEnumerable<TResult> TagFirstLast<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		if (source is IList<TSource> list)
 			return new TagFirstLastIterator<TSource, TResult>(list, resultSelector);

--- a/Source/SuperLinq/Take.cs
+++ b/Source/SuperLinq/Take.cs
@@ -18,7 +18,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, Range range)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		var start = range.Start;
 		var end = range.End;

--- a/Source/SuperLinq/TakeEvery.cs
+++ b/Source/SuperLinq/TakeEvery.cs
@@ -25,7 +25,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IEnumerable<TSource> TakeEvery<TSource>(this IEnumerable<TSource> source, int step)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(step, 1);
 		return source.Where((e, i) => i % step == 0);
 	}

--- a/Source/SuperLinq/TakeEvery.cs
+++ b/Source/SuperLinq/TakeEvery.cs
@@ -26,7 +26,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<TSource> TakeEvery<TSource>(this IEnumerable<TSource> source, int step)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(step, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(step);
 		return source.Where((e, i) => i % step == 0);
 	}
 }

--- a/Source/SuperLinq/TakeUntil.cs
+++ b/Source/SuperLinq/TakeUntil.cs
@@ -34,8 +34,8 @@ public static partial class SuperEnumerable
 
 	public static IEnumerable<TSource> TakeUntil<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 
 		return Core(source, predicate);
 

--- a/Source/SuperLinq/Throw.cs
+++ b/Source/SuperLinq/Throw.cs
@@ -20,7 +20,7 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> Throw<TSource>(Exception exception)
 	{
-		Guard.IsNotNull(exception);
+		ArgumentNullException.ThrowIfNull(exception);
 
 		return Core(exception);
 

--- a/Source/SuperLinq/ThrowHelper.cs
+++ b/Source/SuperLinq/ThrowHelper.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
+
+internal static class ThrowHelper
+{
+	[DoesNotReturn]
+	public static void ThrowArgumentException(string param, string message) =>
+		throw new ArgumentException(param, message);
+
+	[DoesNotReturn]
+	public static T ThrowArgumentException<T>(string param, string message) =>
+		throw new ArgumentException(param, message);
+
+	[DoesNotReturn]
+	public static void ThrowArgumentOutOfRangeException(string param) =>
+		throw new System.ArgumentOutOfRangeException(param);
+
+	[DoesNotReturn]
+	public static T ThrowArgumentOutOfRangeException<T>(string param) =>
+		throw new System.ArgumentOutOfRangeException(param);
+
+	[DoesNotReturn]
+	public static void ThrowArgumentOutOfRangeException(string param, string message) =>
+		throw new System.ArgumentOutOfRangeException(param, message);
+
+	[DoesNotReturn]
+	public static T ThrowArgumentOutOfRangeException<T>(string param, string message) =>
+		throw new System.ArgumentOutOfRangeException(param, message);
+
+	[DoesNotReturn]
+	public static void ThrowInvalidOperationException(string message) =>
+		throw new InvalidOperationException(message);
+
+	[DoesNotReturn]
+	public static T ThrowInvalidOperationException<T>(string message) =>
+		throw new InvalidOperationException(message);
+
+	[DoesNotReturn]
+	public static void ThrowObjectDisposedException(string type) =>
+		throw new ObjectDisposedException(type);
+}

--- a/Source/SuperLinq/ThrowHelper.cs
+++ b/Source/SuperLinq/ThrowHelper.cs
@@ -37,6 +37,14 @@ internal static class ThrowHelper
 		throw new InvalidOperationException(message);
 
 	[DoesNotReturn]
+	public static void ThrowNotSupportedException() =>
+		throw new NotSupportedException();
+
+	[DoesNotReturn]
+	public static T ThrowNotSupportedException<T>() =>
+		throw new NotSupportedException();
+
+	[DoesNotReturn]
 	public static void ThrowObjectDisposedException(string type) =>
 		throw new ObjectDisposedException(type);
 }

--- a/Source/SuperLinq/ToArrayByIndex.cs
+++ b/Source/SuperLinq/ToArrayByIndex.cs
@@ -60,7 +60,7 @@ public static partial class SuperEnumerable
 		Func<T, int> indexSelector,
 		Func<T, TResult> resultSelector)
 	{
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		return source.ToArrayByIndex(indexSelector, (e, _) => resultSelector(e));
 	}
 
@@ -94,9 +94,9 @@ public static partial class SuperEnumerable
 		Func<T, int> indexSelector,
 		Func<T, int, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(indexSelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(indexSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		var lastIndex = -1;
 		var indexed = new List<(int, T)>();
@@ -184,7 +184,7 @@ public static partial class SuperEnumerable
 		Func<T, int> indexSelector,
 		Func<T, TResult> resultSelector)
 	{
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 		return source.ToArrayByIndex(length, indexSelector, (e, _) => resultSelector(e));
 	}
 
@@ -221,10 +221,10 @@ public static partial class SuperEnumerable
 		Func<T, int> indexSelector,
 		Func<T, int, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(length, 0);
-		Guard.IsNotNull(indexSelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(indexSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		var array = new TResult?[length];
 		foreach (var e in source)

--- a/Source/SuperLinq/ToArrayByIndex.cs
+++ b/Source/SuperLinq/ToArrayByIndex.cs
@@ -104,7 +104,8 @@ public static partial class SuperEnumerable
 		foreach (var e in source)
 		{
 			var i = indexSelector(e);
-			Guard.IsGreaterThanOrEqualTo(i, 0, "indexSelector(e)");
+			ArgumentOutOfRangeException.ThrowIfNegative(i, "indexSelector(e)");
+
 			lastIndex = Math.Max(i, lastIndex);
 			indexed.Add((i, e));
 		}
@@ -222,7 +223,7 @@ public static partial class SuperEnumerable
 		Func<T, int, TResult> resultSelector)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(length, 0);
+		ArgumentOutOfRangeException.ThrowIfNegative(length);
 		ArgumentNullException.ThrowIfNull(indexSelector);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 
@@ -230,7 +231,9 @@ public static partial class SuperEnumerable
 		foreach (var e in source)
 		{
 			var i = indexSelector(e);
-			Guard.IsBetween(i, -1, array.Length, "indexSelector(e)");
+			ArgumentOutOfRangeException.ThrowIfNegative(i, "indexSelector(e)");
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(i, array.Length, "indexSelector(e)");
+
 			array[i] = resultSelector(e, i);
 		}
 		return array;

--- a/Source/SuperLinq/ToDataTable.cs
+++ b/Source/SuperLinq/ToDataTable.cs
@@ -112,44 +112,35 @@ public static partial class SuperEnumerable
 		//
 		// If no lambda expressions supplied then reflect them off the source element type.
 		//
-
 		if (expressions.Count == 0)
 		{
-			return from m in typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance)
-				   where m.MemberType == MemberTypes.Field
-					  || (m is PropertyInfo { CanRead: true } p && p.GetIndexParameters().Length == 0)
-				   select m;
+			return typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance)
+				.Where(m => m.MemberType == MemberTypes.Field
+					  || (m is PropertyInfo { CanRead: true } p && p.GetIndexParameters().Length == 0));
 		}
-
-		//
-		// Ensure none of the expressions is <see langword="null"/>.
-		//
-
-		if (expressions.Any(e => e == null))
-			throw new ArgumentException("One of the supplied expressions was null.", nameof(expressions));
-		try
+		else
 		{
-			return expressions.Select(GetAccessedMember);
-		}
-		catch (ArgumentException e)
-		{
-			throw new ArgumentException("One of the supplied expressions is not allowed.", nameof(expressions), e);
-		}
+			return expressions
+				.Select(static lambda =>
+				{
+					var body = lambda.Body;
 
-		static MemberInfo GetAccessedMember(LambdaExpression lambda)
-		{
-			var body = lambda.Body;
+					// If it's a field access, boxing was used, we need the field
+					if (body.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked)
+					{
+						body = ((UnaryExpression)body).Operand;
+					}
 
-			// If it's a field access, boxing was used, we need the field
-			if (body.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked)
-				body = ((UnaryExpression)body).Operand;
+					// Check if the member expression is valid and is a "first level"
+					// member access e.g. not a.b.c
+					if (body is not MemberExpression me
+						|| me.Expression?.NodeType != ExpressionType.Parameter)
+					{
+						return ThrowHelper.ThrowArgumentException<MemberInfo>(nameof(lambda), $"Illegal expression: {lambda}");
+					}
 
-			// Check if the member expression is valid and is a "first level"
-			// member access e.g. not a.b.c
-			return body is MemberExpression memberExpression
-				   && memberExpression.Expression?.NodeType == ExpressionType.Parameter
-				 ? memberExpression.Member
-				 : ThrowHelper.ThrowArgumentException<MemberInfo>(nameof(lambda), $"Illegal expression: {lambda}");
+					return me.Member;
+				});
 		}
 	}
 

--- a/Source/SuperLinq/ToDataTable.cs
+++ b/Source/SuperLinq/ToDataTable.cs
@@ -149,7 +149,7 @@ public static partial class SuperEnumerable
 			return body is MemberExpression memberExpression
 				   && memberExpression.Expression?.NodeType == ExpressionType.Parameter
 				 ? memberExpression.Member
-				 : throw new ArgumentException($"Illegal expression: {lambda}", nameof(lambda));
+				 : ThrowHelper.ThrowArgumentException<MemberInfo>(nameof(lambda), $"Illegal expression: {lambda}");
 		}
 	}
 

--- a/Source/SuperLinq/ToDataTable.cs
+++ b/Source/SuperLinq/ToDataTable.cs
@@ -75,9 +75,9 @@ public static partial class SuperEnumerable
 	public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
 		where TTable : DataTable
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(table);
-		Guard.IsNotNull(expressions);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(table);
+		ArgumentNullException.ThrowIfNull(expressions);
 
 		var members = PrepareMemberInfos(expressions).ToArray();
 		members = BuildOrBindSchema(table, members);

--- a/Source/SuperLinq/ToDelimitedString.cs
+++ b/Source/SuperLinq/ToDelimitedString.cs
@@ -26,8 +26,8 @@ public static partial class SuperEnumerable
 
 	public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, string delimiter)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(delimiter);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(delimiter);
 		return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
 	}
 

--- a/Source/SuperLinq/ToDictionary.cs
+++ b/Source/SuperLinq/ToDictionary.cs
@@ -51,7 +51,7 @@ public static partial class SuperEnumerable
 #endif
 		where TKey : notnull
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return source.ToDictionary(e => e.Key, e => e.Value, comparer);
 	}
 
@@ -105,7 +105,7 @@ public static partial class SuperEnumerable
 #endif
 		where TKey : notnull
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return source.ToDictionary(e => e.Key, e => e.Value, comparer);
 	}
 }

--- a/Source/SuperLinq/ToLookup.cs
+++ b/Source/SuperLinq/ToLookup.cs
@@ -34,7 +34,7 @@ public static partial class SuperEnumerable
 	public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return source.ToLookup(e => e.Key, e => e.Value, comparer);
 	}
 
@@ -71,7 +71,7 @@ public static partial class SuperEnumerable
 	public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source,
 		IEqualityComparer<TKey>? comparer)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		return source.ToLookup(e => e.Key, e => e.Value, comparer);
 	}
 }

--- a/Source/SuperLinq/Transpose.cs
+++ b/Source/SuperLinq/Transpose.cs
@@ -33,7 +33,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IEnumerable<IEnumerable<T>> Transpose<T>(this IEnumerable<IEnumerable<T>> source)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(source);
 

--- a/Source/SuperLinq/Traverse.cs
+++ b/Source/SuperLinq/Traverse.cs
@@ -25,7 +25,7 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> TraverseBreadthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
 	{
-		Guard.IsNotNull(childrenSelector);
+		ArgumentNullException.ThrowIfNull(childrenSelector);
 
 		return Core(root, childrenSelector);
 
@@ -67,7 +67,7 @@ public partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<T> TraverseDepthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
 	{
-		Guard.IsNotNull(childrenSelector);
+		ArgumentNullException.ThrowIfNull(childrenSelector);
 
 		return Core(root, childrenSelector);
 

--- a/Source/SuperLinq/TrySingle.cs
+++ b/Source/SuperLinq/TrySingle.cs
@@ -82,8 +82,8 @@ public static partial class SuperEnumerable
 		TCardinality zero, TCardinality one, TCardinality many,
 		Func<TCardinality, T?, TResult> resultSelector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		if (source.TryGetCollectionCount() is int n)
 		{

--- a/Source/SuperLinq/Unfold.cs
+++ b/Source/SuperLinq/Unfold.cs
@@ -36,10 +36,10 @@ public static partial class SuperEnumerable
 		Func<T, TState> stateSelector,
 		Func<T, TResult> resultSelector)
 	{
-		Guard.IsNotNull(generator);
-		Guard.IsNotNull(predicate);
-		Guard.IsNotNull(stateSelector);
-		Guard.IsNotNull(resultSelector);
+		ArgumentNullException.ThrowIfNull(generator);
+		ArgumentNullException.ThrowIfNull(predicate);
+		ArgumentNullException.ThrowIfNull(stateSelector);
+		ArgumentNullException.ThrowIfNull(resultSelector);
 
 		return Core(state, generator, predicate, stateSelector, resultSelector);
 

--- a/Source/SuperLinq/Using.cs
+++ b/Source/SuperLinq/Using.cs
@@ -30,8 +30,8 @@ public static partial class SuperEnumerable
 		Func<TResource, IEnumerable<TSource>> enumerableFactory)
 		where TResource : IDisposable
 	{
-		Guard.IsNotNull(resourceFactory);
-		Guard.IsNotNull(enumerableFactory);
+		ArgumentNullException.ThrowIfNull(resourceFactory);
+		ArgumentNullException.ThrowIfNull(enumerableFactory);
 
 		return Core(resourceFactory, enumerableFactory);
 

--- a/Source/SuperLinq/Where.cs
+++ b/Source/SuperLinq/Where.cs
@@ -16,8 +16,8 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="filter"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, IEnumerable<bool> filter)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(filter);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(filter);
 
 		return Core(source, filter);
 

--- a/Source/SuperLinq/WhereLag.cs
+++ b/Source/SuperLinq/WhereLag.cs
@@ -54,7 +54,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLagValue, predicate);
 

--- a/Source/SuperLinq/WhereLag.cs
+++ b/Source/SuperLinq/WhereLag.cs
@@ -52,8 +52,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> WhereLag<TSource>(this IEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLagValue, predicate);

--- a/Source/SuperLinq/WhereLead.cs
+++ b/Source/SuperLinq/WhereLead.cs
@@ -54,7 +54,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(predicate);
-		Guard.IsGreaterThanOrEqualTo(offset, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(offset);
 
 		return Core(source, offset, defaultLeadValue, predicate);
 

--- a/Source/SuperLinq/WhereLead.cs
+++ b/Source/SuperLinq/WhereLead.cs
@@ -52,8 +52,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> WhereLead<TSource>(this IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, bool> predicate)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(predicate);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(predicate);
 		Guard.IsGreaterThanOrEqualTo(offset, 1);
 
 		return Core(source, offset, defaultLeadValue, predicate);

--- a/Source/SuperLinq/While.cs
+++ b/Source/SuperLinq/While.cs
@@ -23,8 +23,8 @@ public static partial class SuperEnumerable
 	/// </remarks>
 	public static IEnumerable<TSource> While<TSource>(Func<bool> condition, IEnumerable<TSource> source)
 	{
-		Guard.IsNotNull(condition);
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(condition);
+		ArgumentNullException.ThrowIfNull(source);
 
 		return Core(condition, source);
 

--- a/Source/SuperLinq/Window.Buffered.cs
+++ b/Source/SuperLinq/Window.Buffered.cs
@@ -27,8 +27,8 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Normal, selector);
@@ -61,9 +61,9 @@ public static partial class SuperEnumerable
 		TSource[] array,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return WindowImpl(source, array, array.Length, WindowType.Normal, selector);
 	}
@@ -99,9 +99,9 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Normal, selector);

--- a/Source/SuperLinq/Window.Buffered.cs
+++ b/Source/SuperLinq/Window.Buffered.cs
@@ -29,7 +29,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Normal, selector);
 	}
@@ -102,7 +102,8 @@ public static partial class SuperEnumerable
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(array);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(size, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Normal, selector);
 	}

--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -15,7 +15,7 @@ public static partial class SuperEnumerable
 	/// <returns>A series of sequences representing each sliding window subsequence</returns>
 	public static IEnumerable<IList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -16,7 +16,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		if (source is IList<TSource> list)
 			return new WindowIterator<TSource>(list, size);
@@ -92,7 +92,8 @@ public static partial class SuperEnumerable
 
 		protected override IList<T> ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			var arr = new T[_size];
 			var max = (uint)(index + _size);

--- a/Source/SuperLinq/WindowLeft.Buffered.cs
+++ b/Source/SuperLinq/WindowLeft.Buffered.cs
@@ -49,8 +49,8 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Left, selector);
@@ -102,9 +102,9 @@ public static partial class SuperEnumerable
 		TSource[] array,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return WindowImpl(source, array, array.Length, WindowType.Left, selector);
 	}
@@ -160,9 +160,9 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Left, selector);

--- a/Source/SuperLinq/WindowLeft.Buffered.cs
+++ b/Source/SuperLinq/WindowLeft.Buffered.cs
@@ -51,7 +51,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Left, selector);
 	}
@@ -163,7 +163,8 @@ public static partial class SuperEnumerable
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(array);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(size, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Left, selector);
 	}

--- a/Source/SuperLinq/WindowLeft.cs
+++ b/Source/SuperLinq/WindowLeft.cs
@@ -38,7 +38,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IEnumerable<IList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/WindowLeft.cs
+++ b/Source/SuperLinq/WindowLeft.cs
@@ -39,7 +39,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		if (source is IList<TSource> list)
 			return new WindowLeftIterator<TSource>(list, size);
@@ -147,7 +147,8 @@ skipLoop:
 
 		protected override IList<T> ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			if (index < _source.Count - _size)
 			{

--- a/Source/SuperLinq/WindowRight.Buffered.cs
+++ b/Source/SuperLinq/WindowRight.Buffered.cs
@@ -51,7 +51,7 @@ public static partial class SuperEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Right, selector);
 	}
@@ -163,7 +163,8 @@ public static partial class SuperEnumerable
 		ArgumentNullException.ThrowIfNull(source);
 		ArgumentNullException.ThrowIfNull(array);
 		ArgumentNullException.ThrowIfNull(selector);
-		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(size, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Right, selector);
 	}

--- a/Source/SuperLinq/WindowRight.Buffered.cs
+++ b/Source/SuperLinq/WindowRight.Buffered.cs
@@ -49,8 +49,8 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		return WindowImpl(source, new TSource[size], size, WindowType.Right, selector);
@@ -102,9 +102,9 @@ public static partial class SuperEnumerable
 		TSource[] array,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		return WindowImpl(source, array, array.Length, WindowType.Right, selector);
 	}
@@ -160,9 +160,9 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(array);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(array);
+		ArgumentNullException.ThrowIfNull(selector);
 		Guard.IsBetweenOrEqualTo(size, 1, array.Length);
 
 		return WindowImpl(source, array, size, WindowType.Right, selector);

--- a/Source/SuperLinq/WindowRight.cs
+++ b/Source/SuperLinq/WindowRight.cs
@@ -39,7 +39,7 @@ public static partial class SuperEnumerable
 	public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
 	{
 		ArgumentNullException.ThrowIfNull(source);
-		Guard.IsGreaterThanOrEqualTo(size, 1);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
 
 		if (source is IList<TSource> list)
 			return new WindowRightIterator<TSource>(list, size);
@@ -132,7 +132,8 @@ public static partial class SuperEnumerable
 
 		protected override IList<T> ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			if (index < _size)
 			{

--- a/Source/SuperLinq/WindowRight.cs
+++ b/Source/SuperLinq/WindowRight.cs
@@ -38,7 +38,7 @@ public static partial class SuperEnumerable
 	/// </example>
 	public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
 	{
-		Guard.IsNotNull(source);
+		ArgumentNullException.ThrowIfNull(source);
 		Guard.IsGreaterThanOrEqualTo(size, 1);
 
 		if (source is IList<TSource> list)

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -60,7 +60,8 @@ public static partial class SuperEnumerable
 
 		protected override (TSource, TResult) ElementAt(int index)
 		{
-			Guard.IsBetweenOrEqualTo(index, 0, Count - 1);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
 			var el = _source[index];
 			return (el, _selector(el));

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -19,8 +19,8 @@ public static partial class SuperEnumerable
 	/// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
 	public static IEnumerable<(TSource item, TResult result)> ZipMap<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
 	{
-		Guard.IsNotNull(source);
-		Guard.IsNotNull(selector);
+		ArgumentNullException.ThrowIfNull(source);
+		ArgumentNullException.ThrowIfNull(selector);
 
 		if (source is IList<TSource> list)
 			return new ZipMapIterator<TSource, TResult>(list, selector);

--- a/Tests/SuperLinq.Async.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Async.Test/AssertCountTest.cs
@@ -26,7 +26,7 @@ public class AssertCountTest
 	public async Task AssertCountShortSequence()
 	{
 		await using var data = TestingSequence.Of("foo", "bar", "baz");
-		_ = await Assert.ThrowsAsync<ArgumentException>("source.Count()", async () =>
+		_ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>("source.Count()", async () =>
 			await data.AssertCount(4).Consume());
 	}
 
@@ -34,7 +34,7 @@ public class AssertCountTest
 	public async Task AssertCountLongSequence()
 	{
 		await using var data = TestingSequence.Of("foo", "bar", "baz");
-		_ = await Assert.ThrowsAsync<ArgumentException>("source.Count()", async () =>
+		_ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>("source.Count()", async () =>
 			await data.AssertCount(2).Consume());
 	}
 }

--- a/Tests/SuperLinq.Async.Test/FoldTest.cs
+++ b/Tests/SuperLinq.Async.Test/FoldTest.cs
@@ -5,21 +5,21 @@ public class FoldTest
 	[Fact]
 	public async Task FoldWithTooFewItems()
 	{
-		_ = await Assert.ThrowsAsync<ArgumentException>(async () =>
+		_ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
 			await AsyncEnumerable.Range(1, 3).Fold(AsyncBreakingFunc.Of<int, int, int, int, int>()));
 	}
 
 	[Fact]
 	public async Task FoldWithEmptySequence()
 	{
-		_ = await Assert.ThrowsAsync<ArgumentException>(async () =>
+		_ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
 			await AsyncEnumerable.Empty<int>().Fold(AsyncBreakingFunc.Of<int, int>()));
 	}
 
 	[Fact]
 	public async Task FoldWithTooManyItems()
 	{
-		_ = await Assert.ThrowsAsync<ArgumentException>(async () =>
+		_ = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
 			await AsyncEnumerable.Range(1, 3).Fold(AsyncBreakingFunc.Of<int, int, int>()));
 	}
 

--- a/Tests/SuperLinq.Async.Test/SuperLinq.Async.Test.csproj
+++ b/Tests/SuperLinq.Async.Test/SuperLinq.Async.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="../../TargetFrameworks.props" />
 
@@ -34,6 +34,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
 		<PackageReference Include="xunit" Version="2.6.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="All" />
 		<PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="All" />

--- a/Tests/SuperLinq.Test/AssertCountTest.cs
+++ b/Tests/SuperLinq.Test/AssertCountTest.cs
@@ -27,7 +27,7 @@ public class AssertCountTest
 		using (seq)
 		{
 			var result = seq.AssertCount(11);
-			_ = Assert.Throws<ArgumentException>("source.Count()",
+			_ = Assert.Throws<ArgumentOutOfRangeException>("source.Count()",
 				() => result.Consume());
 		}
 	}
@@ -52,7 +52,7 @@ public class AssertCountTest
 		using (seq)
 		{
 			var result = seq.AssertCount(9);
-			_ = Assert.Throws<ArgumentException>("source.Count()",
+			_ = Assert.Throws<ArgumentOutOfRangeException>("source.Count()",
 				() => result.Consume());
 		}
 	}
@@ -86,7 +86,7 @@ public class AssertCountTest
 	{
 		var stack = new Stack<int>(Enumerable.Range(1, 3));
 		var result = stack.AssertCount(4);
-		_ = Assert.Throws<ArgumentException>("source.Count()",
+		_ = Assert.Throws<ArgumentOutOfRangeException>("source.Count()",
 			() => result.Consume());
 		stack.Push(4);
 		result.Consume();

--- a/Tests/SuperLinq.Test/FoldTest.cs
+++ b/Tests/SuperLinq.Test/FoldTest.cs
@@ -5,21 +5,21 @@ public class FoldTest
 	[Fact]
 	public void FoldWithTooFewItems()
 	{
-		_ = Assert.Throws<ArgumentException>(() =>
+		_ = Assert.Throws<ArgumentOutOfRangeException>(() =>
 			Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int, int, int>()));
 	}
 
 	[Fact]
 	public void FoldWithEmptySequence()
 	{
-		_ = Assert.Throws<ArgumentException>(() =>
+		_ = Assert.Throws<ArgumentOutOfRangeException>(() =>
 			Enumerable.Empty<int>().Fold(BreakingFunc.Of<int, int>()));
 	}
 
 	[Fact]
 	public void FoldWithTooManyItems()
 	{
-		_ = Assert.Throws<ArgumentException>(() =>
+		_ = Assert.Throws<ArgumentOutOfRangeException>(() =>
 			Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int>()));
 	}
 

--- a/Tests/SuperLinq.Test/SuperLinq.Test.csproj
+++ b/Tests/SuperLinq.Test/SuperLinq.Test.csproj
@@ -24,6 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
 		<PackageReference Include="xunit" Version="2.6.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="All" />
 		<PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="All" />


### PR DESCRIPTION
This PR removes `CommunityToolkit.Diagnostics` package from the SuperLinq libraries. net8 bcl includes new methods that replicate most of the core functionality SuperLinq relies on; this functionality is conditionally added to SuperLinq directly in net7-, etc.