### PR TITLE
Fix bug in `Subset` argument check

### DIFF
--- a/Source/SuperLinq/Subsets.cs
+++ b/Source/SuperLinq/Subsets.cs
@@ -196,7 +196,7 @@ public static partial class SuperEnumerable
 
 			ArgumentOutOfRangeException.ThrowIfNegative(subsetSize);
 			if (sequence.TryGetCollectionCount() is int cnt)
-				ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(subsetSize, cnt);
+				ArgumentOutOfRangeException.ThrowIfGreaterThan(subsetSize, cnt);
 
 			_subsetSize = subsetSize;
 		}


### PR DESCRIPTION
This PR fixes a bug in the `Subset` argument validation for collections. `subsetSize` should be allowed if equal to `sequence.Count` but was failing validation.

Fixes #570 