### PR TITLE
Update docs with examples from linqpad scripts

### DIFF
--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Aggregate.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Aggregate.md
@@ -1,0 +1,98 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Aggregate``10(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6},``7,System.Func{``7,``0,``7},``8,System.Func{``8,``0,``8},System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``9})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%602" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``4(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},System.Func{``1,``2,``3})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``4(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%603" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``5(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},System.Func{``1,``2,``3,``4})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``5(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%604" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``6(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},System.Func{``1,``2,``3,``4,``5})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``6(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%605" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``7(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},System.Func{``1,``2,``3,``4,``5,``6})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``7(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%606" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``8(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6},System.Func{``1,``2,``3,``4,``5,``6,``7})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``8(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6},``7,System.Func{``7,``0,``7})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%607" data-throw-if-not-resolved="false"></xref>
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``9(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6},``7,System.Func{``7,``0,``7},System.Func{``1,``2,``3,``4,``5,``6,``7,``8})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},System.Func{``1,``2})>.
+
+This operator uses multiple seeds and aggregates and passes the final values to <code class="paramref">resultSelector</code>.
+---
+uid: SuperLinq.SuperEnumerable.Aggregate``9(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1},``2,System.Func{``2,``0,``2},``3,System.Func{``3,``0,``3},``4,System.Func{``4,``0,``4},``5,System.Func{``5,``0,``5},``6,System.Func{``6,``0,``6},``7,System.Func{``7,``0,``7},``8,System.Func{``8,``0,``8})
+example: [*content]
+---
+For an example using a single seed and aggregate, please see <xref:System.Linq.Enumerable.Aggregate``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})>.
+
+This operator uses multiple seeds and aggregates and returns the final values in a <xref href="System.ValueTuple%608" data-throw-if-not-resolved="false"></xref>

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AggregateBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AggregateBy.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},``2,System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to aggregate values by key in a sequence, using `AggregateBy`.
+[!code-csharp[](SuperLinq/AggregateBy/AggregateBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,``2},System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to aggregate values by key in a sequence, using `AggregateBy`.
+[!code-csharp[](SuperLinq/AggregateBy/AggregateBy2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AggregateRight.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AggregateRight.md
@@ -1,0 +1,18 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.AggregateRight``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to collect numbers into a string using `AggregateRight`.
+[!code-csharp[](SuperLinq/AggregateRight/AggregateRight1.linq#L6-)]
+---
+uid: SuperLinq.SuperEnumerable.AggregateRight``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``0,``1,``1})
+example: [*content]
+---
+The following code example demonstrates how to collect numbers into a string using `AggregateRight`.
+[!code-csharp[](SuperLinq/AggregateRight/AggregateRight2.linq#L6-)]
+---
+uid: SuperLinq.SuperEnumerable.AggregateRight``3(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``0,``1,``1},System.Func{``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to collect numbers into a string using `AggregateRight`.
+[!code-csharp[](SuperLinq/AggregateRight/AggregateRight3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AssertCount.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AssertCount.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.AssertCount``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to validate the length of a sequence using `AssertCount`.
+[!code-csharp[](SuperLinq/AssertCount/AssertCount.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AtLeast.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AtLeast.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.AtLeast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence has a minimum size using `AtLeast`.
+[!code-csharp[](SuperLinq/AtLeast/AtLeast.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AtMost.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.AtMost.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.AtMost``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence has a maximum size using `AtMost`.
+[!code-csharp[](SuperLinq/AtMost/AtMost.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Backsert.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Backsert.md
@@ -1,0 +1,9 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Backsert``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+> [!NOTE]
+> `Backsert` has been deprecated in favor of `Insert`. Please see [here](xref:SuperLinq.SuperEnumerable.Insert``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Index)) for documentation on the equivalent method.
+
+The following code example demonstrates how to insert one sequence into another, using `Backsert`.
+[!code-csharp[](SuperLinq/Backsert/Backsert.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Batch.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Batch.md
@@ -1,0 +1,24 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Batch``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to break a sequence into chunks of a specific size, using `Batch`.
+[!code-csharp[](SuperLinq/Batch/Batch1.linq#L6-)]
+---
+uid: SuperLinq.SuperEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to break a sequence into chunks of a specific size, using `Batch`.
+[!code-csharp[](SuperLinq/Batch/Batch2.linq#L6-)]
+---
+uid: SuperLinq.SuperEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to break a sequence into chunks of a specific size, using `Batch`.
+[!code-csharp[](SuperLinq/Batch/Batch3.linq#L6-)]
+---
+uid: SuperLinq.SuperEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to break a sequence into chunks of a specific size, using `Batch`.
+[!code-csharp[](SuperLinq/Batch/Batch4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.BindByIndex.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.BindByIndex.md
@@ -1,0 +1,14 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.BindByIndex``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{System.Int32})
+example: [*content]
+---
+The following code example demonstrates how to select elements from a sequence by index, using `BindByIndex`.
+[!code-csharp[](SuperLinq/BindByIndex/BindByIndex1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.BindByIndex``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{System.Int32},System.Func{``0,System.Int32,``1},System.Func{System.Int32,``1})
+example: [*content]
+---
+The following code example demonstrates how to select elements from a sequence by index, using `BindByIndex`.
+[!code-csharp[](SuperLinq/BindByIndex/BindByIndex2.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Buffer.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Buffer.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Buffer``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to buffer a sequence using `Buffer`.
+[!code-csharp[](SuperLinq/Buffer/Buffer1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Buffer``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to buffer a sequence using `Buffer`.
+[!code-csharp[](SuperLinq/Buffer/Buffer2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Cartesian.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Cartesian.md
@@ -1,0 +1,98 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Cartesian``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Func{``0,``1,``2,``3})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``5(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``5(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Func{``0,``1,``2,``3,``4})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``6(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``6(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Func{``0,``1,``2,``3,``4,``5})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``7(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5},System.Collections.Generic.IEnumerable{``6})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``7(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5},System.Func{``0,``1,``2,``3,``4,``5,``6})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``8(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5},System.Collections.Generic.IEnumerable{``6},System.Collections.Generic.IEnumerable{``7})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``8(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5},System.Collections.Generic.IEnumerable{``6},System.Func{``0,``1,``2,``3,``4,``5,``6,``7})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Cartesian``9(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Collections.Generic.IEnumerable{``4},System.Collections.Generic.IEnumerable{``5},System.Collections.Generic.IEnumerable{``6},System.Collections.Generic.IEnumerable{``7},System.Func{``0,``1,``2,``3,``4,``5,``6,``7,``8})
+example: [*content]
+---
+The following code example demonstrates how to get the cartesian product of multiple sequences using `Cartesian`.
+[!code-csharp[](SuperLinq/Cartesian/Cartesian.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Case.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Case.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Case``2(System.Func{``0},System.Collections.Generic.IDictionary{``0,System.Collections.Generic.IEnumerable{``1}})
+example: [*content]
+---
+The following code example demonstrates how to select which sequence to return values from, using `Case`.
+[!code-csharp[](SuperLinq/Case/Case1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Case``2(System.Func{``0},System.Collections.Generic.IDictionary{``0,System.Collections.Generic.IEnumerable{``1}},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates how to select which sequence to return values from, using `Case`.
+[!code-csharp[](SuperLinq/Case/Case2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Catch.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Catch.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Catch``1(System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to use the `Catch` operator.
+[!code-csharp[](SuperLinq/Catch/Catch4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Catch``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to use the `Catch` operator.
+[!code-csharp[](SuperLinq/Catch/Catch2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Catch``1(System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to use the `Catch` operator.
+[!code-csharp[](SuperLinq/Catch/Catch3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Catch``2(System.Collections.Generic.IEnumerable{``0},System.Func{``1,System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to use the `Catch` operator.
+[!code-csharp[](SuperLinq/Catch/Catch1.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Choose.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Choose.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Choose``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.ValueTuple{System.Boolean,``1}})
+example: [*content]
+---
+The following code example demonstrates choose and project elements in a sequence using the `Choose` operator.
+[!code-csharp[](SuperLinq/Choose/Choose.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CollectionEqual.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CollectionEqual.md
@@ -1,0 +1,14 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CollectionEqual``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to compare two collections using the `CollectionEqual` operator.
+[!code-csharp[](SuperLinq/CollectionEqual/CollectionEqual1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CollectionEqual``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to compare two collections using the `CollectionEqual` operator.
+[!code-csharp[](SuperLinq/CollectionEqual/CollectionEqual2.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CompareCount.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CompareCount.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CompareCount``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates to compare the length of two sequences using `CompareCount`.
+[!code-csharp[](SuperLinq/CompareCount/CompareCount.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Consume.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Consume.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Consume``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates consume a sequence using the `Consume` operator.
+[!code-csharp[](SuperLinq/Consume/Consume.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CopyTo.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CopyTo.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CopyTo``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IList{``0})
+example: [*content]
+---
+The following code example demonstrates how to copy data to a list using the `CopyTo` operator.
+[!code-csharp[](SuperLinq/CopyTo/CopyTo1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CopyTo``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IList{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to copy data to a list using the `CopyTo` operator.
+[!code-csharp[](SuperLinq/CopyTo/CopyTo2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CopyTo``1(System.Collections.Generic.IEnumerable{``0},System.Span{``0})
+example: [*content]
+---
+The following code example demonstrates how to copy data to a span using the `CopyTo` operator.
+[!code-csharp[](SuperLinq/CopyTo/CopyTo3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CopyTo``1(System.Collections.Generic.IEnumerable{``0},``0[])
+example: [*content]
+---
+The following code example demonstrates how to copy data to an array using the `CopyTo` operator.
+[!code-csharp[](SuperLinq/CopyTo/CopyTo4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountBetween.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountBetween.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CountBetween``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence length is between two numbers using `CountBetween`
+[!code-csharp[](SuperLinq/CountBetween/CountBetween.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountBy.md
@@ -1,0 +1,14 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CountBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the count by key in a sequence, using the `CountBy` operator:
+[!code-csharp[](SuperLinq/CountBy/CountBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CountBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the count by key in a sequence, using the `CountBy` operator:
+[!code-csharp[](SuperLinq/CountBy/CountBy2.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountDown.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.CountDown.md
@@ -1,0 +1,14 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.CountDown``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get a count down timer for a sequence, using the `CountDown` operator:
+[!code-csharp[](SuperLinq/CountDown/CountDown1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.CountDown``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,System.Nullable{System.Int32},``1})
+example: [*content]
+---
+The following code example demonstrates how to get a count down timer for a sequence, using the `CountDown` operator:
+[!code-csharp[](SuperLinq/CountDown/CountDown2.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Defer.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Defer.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Defer``1(System.Func{System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to defer the execution of a method that returns an enumerable using `Defer`.
+[!code-csharp[](SuperLinq/Defer/Defer.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DensePartialSort.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DensePartialSort.md
@@ -1,0 +1,28 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.DensePartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSort/DensePartialSort1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSort/DensePartialSort2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Collections.Generic.IComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSort/DensePartialSort3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Collections.Generic.IComparer{``0},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSort/DensePartialSort4.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DensePartialSortBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DensePartialSortBy.md
@@ -1,0 +1,28 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.DensePartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSortBy/DensePartialSortBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSortBy/DensePartialSortBy2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSortBy/DensePartialSortBy3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DensePartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},System.Collections.Generic.IComparer{``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `DensePartialSort`.
+[!code-csharp[](SuperLinq/DensePartialSortBy/DensePartialSortBy4.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DistinctUntilChanged.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DistinctUntilChanged.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.DistinctUntilChanged``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to get distinct elements from a sequence using `DistinctUntilChanged`.
+[!code-csharp[](SuperLinq/DistinctUntilChanged/DistinctUntilChanged1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DistinctUntilChanged``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to get distinct elements from a sequence using `DistinctUntilChanged`.
+[!code-csharp[](SuperLinq/DistinctUntilChanged/DistinctUntilChanged2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DistinctUntilChanged``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get distinct elements from a sequence using `DistinctUntilChanged`.
+[!code-csharp[](SuperLinq/DistinctUntilChanged/DistinctUntilChanged3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DistinctUntilChanged``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get distinct elements from a sequence using `DistinctUntilChanged`.
+[!code-csharp[](SuperLinq/DistinctUntilChanged/DistinctUntilChanged4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Do.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Do.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Do``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})
+example: [*content]
+---
+The following code example demonstrates how to lazily invoke actions for each element using `Do`.
+[!code-csharp[](SuperLinq/Do/Do1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Do``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0},System.Action)
+example: [*content]
+---
+The following code example demonstrates how to lazily invoke actions for each element using `Do`.
+[!code-csharp[](SuperLinq/Do/Do2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Do``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0},System.Action{System.Exception})
+example: [*content]
+---
+The following code example demonstrates how to lazily invoke actions for each element using `Do`.
+[!code-csharp[](SuperLinq/Do/Do3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Do``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0},System.Action{System.Exception},System.Action)
+example: [*content]
+---
+The following code example demonstrates how to lazily invoke actions for each element using `Do`.
+[!code-csharp[](SuperLinq/Do/Do4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DoWhile.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.DoWhile.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.DoWhile``1(System.Collections.Generic.IEnumerable{``0},System.Func{System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to repeat a sequence as long as a condition is `true`, using `DoWhile`.
+[!code-csharp[](SuperLinq/DoWhile/DoWhile.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.EndsWith.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.EndsWith.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.EndsWith``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence ends with another sequence using `EndsWith`.
+[!code-csharp[](SuperLinq/EndsWith/EndsWith1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EndsWith``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence ends with another sequence using `EndsWith`.
+[!code-csharp[](SuperLinq/EndsWith/EndsWith2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.EquiZip.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.EquiZip.md
@@ -1,0 +1,42 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.EquiZip``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge two sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EquiZip``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge two sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EquiZip``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge three sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EquiZip``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge three sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EquiZip``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Func{``0,``1,``2,``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge four sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.EquiZip``5(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Func{``0,``1,``2,``3,``4})
+example: [*content]
+---
+The following code example demonstrates how to use the `EquiZip` to merge four sequences of exactly equal length. 
+[!code-csharp[](SuperLinq/EquiZip/EquiZip6.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Evaluate.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Evaluate.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Evaluate``1(System.Collections.Generic.IEnumerable{System.Func{``0}})
+example: [*content]
+---
+The following code example demonstrates how to project a sequence of functions into their return values using `Evaluate`.
+[!code-csharp[](SuperLinq/Evaluate/Evaluate.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Exactly.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Exactly.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Exactly``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to check that a sequence has as an exact length using `Exactly`.
+[!code-csharp[](SuperLinq/Exactly/Exactly.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ExceptBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ExceptBy.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ExceptBy``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to filter items from a sequence using a second sequence using `ExceptBy`.
+[!code-csharp[](SuperLinq/ExceptBy/ExceptBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ExceptBy``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to filter items from a sequence using a second sequence using `ExceptBy`.
+[!code-csharp[](SuperLinq/ExceptBy/ExceptBy2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Exclude.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Exclude.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Exclude``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to exclude a contiguous set of elements from a sequence using `Exclude`.
+[!code-csharp[](SuperLinq/Exclude/Exclude.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FallbackIfEmpty.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FallbackIfEmpty.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FallbackIfEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to use `FallbackIfEmpty` to use a fallback sequence if the primary sequence is empty.
+[!code-csharp[](SuperLinq/FallbackIfEmpty/FallbackIfEmpty2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FallbackIfEmpty``1(System.Collections.Generic.IEnumerable{``0},``0[])
+example: [*content]
+---
+The following code example demonstrates how to use `FallbackIfEmpty` to use a fallback sequence if the primary sequence is empty.
+[!code-csharp[](SuperLinq/FallbackIfEmpty/FallbackIfEmpty1.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FillBackward.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FillBackward.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FillBackward``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with following elements using `FillBackward`.
+[!code-csharp[](SuperLinq/FillBackward/FillBackward1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FillBackward``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with following elements using `FillBackward`.
+[!code-csharp[](SuperLinq/FillBackward/FillBackward2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FillBackward``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Func{``0,``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with following elements using `FillBackward`.
+[!code-csharp[](SuperLinq/FillBackward/FillBackward3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FillForward.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FillForward.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FillForward``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with previous elements using `FillForward`.
+[!code-csharp[](SuperLinq/FillForward/FillForward1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FillForward``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with previous elements using `FillForward`.
+[!code-csharp[](SuperLinq/FillForward/FillForward2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FillForward``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Func{``0,``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to fill in missing elements with previous elements using `FillForward`.
+[!code-csharp[](SuperLinq/FillForward/FillForward3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Finally.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Finally.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Finally``1(System.Collections.Generic.IEnumerable{``0},System.Action)
+example: [*content]
+---
+The following code example demonstrates how to execute an action when an enumeration completes, using `Finally`.
+[!code-csharp[](SuperLinq/Finally/Finally.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FindIndex.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FindIndex.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FindIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to find the index of the first element that satisfies a condition, using `FindIndex`.
+[!code-csharp[](SuperLinq/FindIndex/FindIndex1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FindIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Index)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the first element that satisfies a condition, using `FindIndex`.
+[!code-csharp[](SuperLinq/FindIndex/FindIndex2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FindIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Index,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the first element that satisfies a condition, using `FindIndex`.
+[!code-csharp[](SuperLinq/FindIndex/FindIndex3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FindLastIndex.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FindLastIndex.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FindLastIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last element that satisfies a condition, using `FindLastIndex`.
+[!code-csharp[](SuperLinq/FindLastIndex/FindLastIndex1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FindLastIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Index)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last element that satisfies a condition, using `FindLastIndex`.
+[!code-csharp[](SuperLinq/FindLastIndex/FindLastIndex2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FindLastIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Index,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last element that satisfies a condition, using `FindLastIndex`.
+[!code-csharp[](SuperLinq/FindLastIndex/FindLastIndex3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Flatten.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Flatten.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Flatten(System.Collections.IEnumerable)
+example: [*content]
+---
+The following code example demonstrates how to flatten hierarchical sequences into a flat sequences using `Flatten`.
+[!code-csharp[](SuperLinq/Flatten/Flatten1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Flatten(System.Collections.IEnumerable,System.Func{System.Collections.IEnumerable,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to flatten hierarchical sequences into a flat sequences using `Flatten`.
+[!code-csharp[](SuperLinq/Flatten/Flatten2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Flatten(System.Collections.IEnumerable,System.Func{System.Object,System.Collections.IEnumerable})
+example: [*content]
+---
+The following code example demonstrates how to flatten hierarchical sequences into a flat sequences using `Flatten`.
+[!code-csharp[](SuperLinq/Flatten/Flatten3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Fold.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Fold.md
@@ -1,0 +1,112 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 1 element using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 2 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 3 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 4 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 5 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 6 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold6.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 7 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold7.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 8 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold8.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 9 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold9.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 10 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold10.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 11 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold11.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 12 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold12.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 13 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold13.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 14 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold14.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 15 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold15.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Fold``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to apply a projection to a sequence of 16 elements using `Fold`.
+[!code-csharp[](SuperLinq/Fold/Fold16.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ForEach.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ForEach.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})
+example: [*content]
+---
+The following code example demonstrates how to immediately execute an action on every element of a sequence using `ForEach`.
+[!code-csharp[](SuperLinq/ForEach/ForEach1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0,System.Int32})
+example: [*content]
+---
+The following code example demonstrates how to immediately execute an action on every element of a sequence using `ForEach`.
+[!code-csharp[](SuperLinq/ForEach/ForEach2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.From.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.From.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.From``1(System.Func{``0})
+example: [*content]
+---
+The following code example demonstrates how to project a sequence of functions into their return values using `From`.
+[!code-csharp[](SuperLinq/From/From1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.From``1(System.Func{``0},System.Func{``0})
+example: [*content]
+---
+The following code example demonstrates how to project a sequence of functions into their return values using `From`.
+[!code-csharp[](SuperLinq/From/From2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.From``1(System.Func{``0},System.Func{``0},System.Func{``0})
+example: [*content]
+---
+The following code example demonstrates how to project a sequence of functions into their return values using `From`.
+[!code-csharp[](SuperLinq/From/From3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.From``1(System.Func{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to project a sequence of functions into their return values using `From`.
+[!code-csharp[](SuperLinq/From/From4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FullGroupJoin.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FullGroupJoin.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FullGroupJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to execute a full group join using `FullGroupJoin`
+[!code-csharp[](SuperLinq/FullGroupJoin/FullGroupJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullGroupJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute a full group join using `FullGroupJoin`
+[!code-csharp[](SuperLinq/FullGroupJoin/FullGroupJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullGroupJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``2,System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},``3})
+example: [*content]
+---
+The following code example demonstrates how to execute a full group join using `FullGroupJoin`
+[!code-csharp[](SuperLinq/FullGroupJoin/FullGroupJoin3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullGroupJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``2,System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute a full group join using `FullGroupJoin`
+[!code-csharp[](SuperLinq/FullGroupJoin/FullGroupJoin4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Generate.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Generate.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Generate``1(``0,System.Func{``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to generate a sequence from a generator function using `Generate`.
+[!code-csharp[](SuperLinq/Generate/Generate.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPath.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPath.md
@@ -1,0 +1,55 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},``0)
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.Dijkstra/GetShortestPath1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},``0,System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.Dijkstra/GetShortestPath2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.Dijkstra/GetShortestPath3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},System.Func{``0,System.Boolean},System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.Dijkstra/GetShortestPath4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},``0)
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.AStar/GetShortestPath1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},``0,System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.AStar/GetShortestPath2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.AStar/GetShortestPath3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPath``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},System.Func{``0,System.Boolean},System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path using `GetShortestPath`.
+[!code-csharp[](SuperLinq/GetShortestPath.AStar/GetShortestPath4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPathCost.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPathCost.md
@@ -1,0 +1,55 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},``0)
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.Dijkstra/GetShortestPathCost1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},``0,System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.Dijkstra/GetShortestPathCost2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.Dijkstra/GetShortestPathCost3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},System.Func{``0,System.Boolean},System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.Dijkstra/GetShortestPathCost4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},``0)
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.AStar/GetShortestPathCost1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},``0,System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.AStar/GetShortestPathCost2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.AStar/GetShortestPathCost3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPathCost``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1,``1}}},System.Func{``0,System.Boolean},System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use A* to find the shortest path to a destination using `GetShortestPathCost`.
+[!code-csharp[](SuperLinq/GetShortestPathCost.AStar/GetShortestPathCost4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPaths.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GetShortestPaths.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.GetShortestPaths``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to build a distance map using `GetShortestPaths`.
+[!code-csharp[](SuperLinq/GetShortestPaths/GetShortestPaths1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GetShortestPaths``2(``0,System.Func{``0,``1,System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}}},System.Collections.Generic.IEqualityComparer{``0},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to use Dijkstra's algorithm to build a distance map using `GetShortestPaths`.
+[!code-csharp[](SuperLinq/GetShortestPaths/GetShortestPaths2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GroupAdjacent.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.GroupAdjacent.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``0,``2})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``0,``2},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,System.Collections.Generic.IEnumerable{``0},``2})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.GroupAdjacent``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,System.Collections.Generic.IEnumerable{``0},``2},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example shows how to group adjacent items in a sequence using `GroupAdjacent`:
+[!code-csharp[](SuperLinq/GroupAdjacent/GroupAdjacent6.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.HasDuplicates.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.HasDuplicates.md
@@ -1,0 +1,28 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.HasDuplicates``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to check if a sequence has duplicate values using `HasDuplicates`.
+[!code-csharp[](SuperLinq/HasDuplicates/HasDuplicates1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.HasDuplicates``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to check if a sequence has duplicate values using `HasDuplicates`.
+[!code-csharp[](SuperLinq/HasDuplicates/HasDuplicates2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.HasDuplicates``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to check if a sequence has duplicate values using `HasDuplicates`.
+[!code-csharp[](SuperLinq/HasDuplicates/HasDuplicates3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.HasDuplicates``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to check if a sequence has duplicate values using `HasDuplicates`.
+[!code-csharp[](SuperLinq/HasDuplicates/HasDuplicates4.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.If.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.If.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.If``1(System.Func{System.Boolean},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to selectively enumerate a sequence using `If`.
+[!code-csharp[](SuperLinq/If/If1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.If``1(System.Func{System.Boolean},System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to selectively enumerate a sequence using `If`.
+[!code-csharp[](SuperLinq/If/If2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Index.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Index.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Index``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to return an index with each element of a sequence using `Index`.
+[!code-csharp[](SuperLinq/Index/Index1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Index``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to return an index with each element of a sequence using `Index`.
+[!code-csharp[](SuperLinq/Index/Index2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.IndexBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.IndexBy.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.IndexBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to return a sub-sequence index with each element using `IndexBy`.
+[!code-csharp[](SuperLinq/IndexBy/IndexBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.IndexBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to return a sub-sequence index with each element using `IndexBy`.
+[!code-csharp[](SuperLinq/IndexBy/IndexBy2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.IndexOf.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.IndexOf.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.IndexOf``1(System.Collections.Generic.IEnumerable{``0},``0)
+example: [*content]
+---
+The following code example demonstrates how to find the index of an element in a sequence using `IndexOf`.
+[!code-csharp[](SuperLinq/IndexOf/IndexOf1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.IndexOf``1(System.Collections.Generic.IEnumerable{``0},``0,System.Index)
+example: [*content]
+---
+The following code example demonstrates how to find the index of an element in a sequence using `IndexOf`.
+[!code-csharp[](SuperLinq/IndexOf/IndexOf2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.IndexOf``1(System.Collections.Generic.IEnumerable{``0},``0,System.Index,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to find the index of an element in a sequence using `IndexOf`.
+[!code-csharp[](SuperLinq/IndexOf/IndexOf3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Insert.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Insert.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Insert``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to insert one sequence into the middle of another sequence using `Insert`.
+[!code-csharp[](SuperLinq/Insert/Insert1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Insert``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Index)
+example: [*content]
+---
+The following code example demonstrates how to insert one sequence into the middle of another sequence using `Insert`.
+[!code-csharp[](SuperLinq/Insert/Insert2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Interleave.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Interleave.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Interleave``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to interleave the elements from multiple sequences into a single sequence using `Interleave`.
+[!code-csharp[](SuperLinq/Interleave/Interleave1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Interleave``1(System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to interleave the elements from multiple sequences into a single sequence using `Interleave`.
+[!code-csharp[](SuperLinq/Interleave/Interleave2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Lag.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Lag.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Lag``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a previous value using `Lag`.
+[!code-csharp[](SuperLinq/Lag/Lag1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Lag``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a previous value using `Lag`.
+[!code-csharp[](SuperLinq/Lag/Lag2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Lag``2(System.Collections.Generic.IEnumerable{``0},System.Int32,``0,System.Func{``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a previous value using `Lag`.
+[!code-csharp[](SuperLinq/Lag/Lag3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.LastIndexOf.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.LastIndexOf.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.LastIndexOf``1(System.Collections.Generic.IEnumerable{``0},``0)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last instance of an element in a sequence using `LastIndexOf`.
+[!code-csharp[](SuperLinq/LastIndexOf/LastIndexOf1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LastIndexOf``1(System.Collections.Generic.IEnumerable{``0},``0,System.LastIndex)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last instance of an element in a sequence using `LastIndexOf`.
+[!code-csharp[](SuperLinq/LastIndexOf/LastIndexOf2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LastIndexOf``1(System.Collections.Generic.IEnumerable{``0},``0,System.LastIndex,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to find the index of the last instance of an element in a sequence using `LastIndexOf`.
+[!code-csharp[](SuperLinq/LastIndexOf/LastIndexOf3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Lead.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Lead.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Lead``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a future value using `Lead`.
+[!code-csharp[](SuperLinq/Lead/Lead1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Lead``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a future value using `Lead`.
+[!code-csharp[](SuperLinq/Lead/Lead2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Lead``2(System.Collections.Generic.IEnumerable{``0},System.Int32,``0,System.Func{``0,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get elements along with a future value using `Lead`.
+[!code-csharp[](SuperLinq/Lead/Lead3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.MaxItems.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.MaxItems.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.MaxItems``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxItems`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MaxItems``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxItems`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MaxItemsBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxItemsBy`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MaxItemsBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxItemsBy`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MaxByWithTies``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxByWithTies`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MaxByWithTies``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the maximum items from a sequence using `MaxByWithTies`.
+[!code-csharp[](SuperLinq/MaxItems/MaxItems6.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Memoize.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Memoize.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Memoize``1(System.Collections.Generic.IEnumerable{``0},System.Boolean)
+example: [*content]
+---
+The following code example demonstrates how to cache a sequence for repeated use using `Memoize`.
+[!code-csharp[](SuperLinq/Memoize/Memoize.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.MinItems.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.MinItems.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.MinItems``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinItems`.
+[!code-csharp[](SuperLinq/MinItems/MinItems1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MinItems``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinItems`.
+[!code-csharp[](SuperLinq/MinItems/MinItems2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MinItemsBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinItemsBy`.
+[!code-csharp[](SuperLinq/MinItems/MinItems3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MinItemsBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinItemsBy`.
+[!code-csharp[](SuperLinq/MinItems/MinItems4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MinByWithTies``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinByWithTies`.
+[!code-csharp[](SuperLinq/MinItems/MinItems5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.MinByWithTies``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the minimum items from a sequence using `MinByWithTies`.
+[!code-csharp[](SuperLinq/MinItems/MinItems6.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Move.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Move.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Move``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to move a subsequence from one location to another using `Move`.
+[!code-csharp[](SuperLinq/Move/Move.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.OnErrorResumeNext.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.OnErrorResumeNext.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.OnErrorResumeNext``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to concatenate multiple sequences, regardless of any errors that may occur, using `OnErrorResumeNext`.
+[!code-csharp[](SuperLinq/OnErrorResumeNext/OnErrorResumeNext1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.OnErrorResumeNext``1(System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to concatenate multiple sequences, regardless of any errors that may occur, using `OnErrorResumeNext`.
+[!code-csharp[](SuperLinq/OnErrorResumeNext/OnErrorResumeNext2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.OnErrorResumeNext``1(System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to concatenate multiple sequences, regardless of any errors that may occur, using `OnErrorResumeNext`.
+[!code-csharp[](SuperLinq/OnErrorResumeNext/OnErrorResumeNext3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.OrderBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.OrderBy.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.OrderBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to sort a sequence using `OrderBy` and `ThenBy`.
+[!code-csharp[](SuperLinq/OrderBy/OrderBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ThenBy``2(System.Linq.IOrderedEnumerable{``0},System.Func{``0,``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to sort a sequence using `OrderBy` and `ThenBy`.
+[!code-csharp[](SuperLinq/OrderBy/OrderBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.OrderBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to sort a sequence using `OrderBy` and `ThenBy`.
+[!code-csharp[](SuperLinq/OrderBy/OrderBy2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ThenBy``2(System.Linq.IOrderedEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to sort a sequence using `OrderBy` and `ThenBy`.
+[!code-csharp[](SuperLinq/OrderBy/OrderBy2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Pad.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Pad.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Pad``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `Pad`.
+[!code-csharp[](SuperLinq/Pad/Pad1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Pad``1(System.Collections.Generic.IEnumerable{``0},System.Int32,``0)
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `Pad`.
+[!code-csharp[](SuperLinq/Pad/Pad2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Pad``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Int32,``0})
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `Pad`.
+[!code-csharp[](SuperLinq/Pad/Pad3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PadStart.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PadStart.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.PadStart``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `PadStart`.
+[!code-csharp[](SuperLinq/PadStart/PadStart1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PadStart``1(System.Collections.Generic.IEnumerable{``0},System.Int32,``0)
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `PadStart`.
+[!code-csharp[](SuperLinq/PadStart/PadStart2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PadStart``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Int32,``0})
+example: [*content]
+---
+The following code example demonstrates how to pad a sequence using `PadStart`.
+[!code-csharp[](SuperLinq/PadStart/PadStart3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PartialSort.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PartialSort.md
@@ -1,0 +1,28 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.PartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSort/PartialSort1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSort/PartialSort2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Collections.Generic.IComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSort/PartialSort3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSort``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Collections.Generic.IComparer{``0},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSort/PartialSort4.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PartialSortBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PartialSortBy.md
@@ -1,0 +1,28 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.PartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSortBy/PartialSortBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSortBy/PartialSortBy2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSortBy/PartialSortBy3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.PartialSortBy``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``1},System.Collections.Generic.IComparer{``1},SuperLinq.OrderByDirection)
+example: [*content]
+---
+The following code example demonstrates how to get the top N items of a sequence using `PartialSort`.
+[!code-csharp[](SuperLinq/PartialSortBy/PartialSortBy4.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Partition.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Partition.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Partition``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to partition a sequence using `Partition`.
+[!code-csharp[](SuperLinq/Partition/Partition1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Partition``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Func{System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to partition a sequence using `Partition`.
+[!code-csharp[](SuperLinq/Partition/Partition2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Permutations.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Permutations.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Permutations``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to enumerate the permutations of a sequence using `Permutations`.
+[!code-csharp[](SuperLinq/Permutations/Permutations.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Pipe.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Pipe.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Pipe``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})
+example: [*content]
+---
+The following code example demonstrates how to lazily invoke actions for each element using `Do`, which is a synonym for `Pipe`.
+[!code-csharp[](SuperLinq/Do/Do1.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PreScan.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.PreScan.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.PreScan``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0},``0)
+example: [*content]
+---
+The following code example demonstrates how to perform an exclusive pre-fix scan on a sequence using `PreScan`.
+[!code-csharp[](SuperLinq/PreScan/PreScan.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Publish.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Publish.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Publish``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to publish multiple views of the same enumerator using `Publish`.
+[!code-csharp[](SuperLinq/Publish/Publish1.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RandomSubset.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RandomSubset.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.RandomSubset``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to get a random subset of a sequence using `RandomSubset`.
+[!code-csharp[](SuperLinq/RandomSubset/RandomSubset1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.RandomSubset``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Random)
+example: [*content]
+---
+The following code example demonstrates how to get a random subset of a sequence using `RandomSubset`.
+[!code-csharp[](SuperLinq/RandomSubset/RandomSubset2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Rank.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Rank.md
@@ -1,0 +1,55 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.DenseRank``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to rank the items in a sequence using `DenseRank`.
+[!code-csharp[](SuperLinq/DenseRank/DenseRank1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DenseRank``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to rank the items in a sequence using `DenseRank`.
+[!code-csharp[](SuperLinq/DenseRank/DenseRank3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DenseRankBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to rank the items in a sequence according to a key using `DenseRankBy`.
+[!code-csharp[](SuperLinq/DenseRankBy/DenseRankBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.DenseRankBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to rank the items in a sequence according to a key using `DenseRankBy`.
+[!code-csharp[](SuperLinq/DenseRankBy/DenseRankBy3.linq#L6-)]
+
+----
+uid: SuperLinq.SuperEnumerable.Rank``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+----
+The following code example demonstrates how to rank the items in a sequence using `Rank`.
+[!code-csharp[](SuperLinq/Rank/Rank1.linq#L6-)]
+
+----
+uid: SuperLinq.SuperEnumerable.Rank``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IComparer{``0})
+example: [*content]
+----
+The following code example demonstrates how to rank the items in a sequence using `Rank`.
+[!code-csharp[](SuperLinq/Rank/Rank3.linq#L6-)]
+
+----
+uid: SuperLinq.SuperEnumerable.RankBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+----
+The following code example demonstrates how to rank the items in a sequence according to a key using `RankBy`.
+[!code-csharp[](SuperLinq/RankBy/RankBy1.linq#L6-)]
+
+----
+uid: SuperLinq.SuperEnumerable.RankBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})
+example: [*content]
+----
+The following code example demonstrates how to rank the items in a sequence according to a key using `RankBy`.
+[!code-csharp[](SuperLinq/RankBy/RankBy3.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Repeat.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Repeat.md
@@ -1,0 +1,21 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Repeat``1(``0)
+example: [*content]
+---
+The following code example demonstrates how to repeat a value using `Repeat`.
+[!code-csharp[](SuperLinq/Repeat/Repeat1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Repeat``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to repeat a value using `Repeat`.
+[!code-csharp[](SuperLinq/Repeat/Repeat2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Repeat``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to repeat a value using `Repeat`.
+[!code-csharp[](SuperLinq/Repeat/Repeat3.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Replace.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Replace.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Replace``1(System.Collections.Generic.IEnumerable{``0},System.Int32,``0)
+example: [*content]
+---
+The following code example demonstrates how to replace a value using `Replace`.
+[!code-csharp[](SuperLinq/Replace/Replace1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Replace``1(System.Collections.Generic.IEnumerable{``0},System.Index,``0)
+example: [*content]
+---
+The following code example demonstrates how to replace a value using `Replace`.
+[!code-csharp[](SuperLinq/Replace/Replace2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Retry.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Retry.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Retry``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to retry sequences on failure using `Retry`.
+[!code-csharp[](SuperLinq/Retry/Retry1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Retry``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to retry sequences on failure using `Retry`.
+[!code-csharp[](SuperLinq/Retry/Retry2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Return.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Return.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Return``1(``0)
+example: [*content]
+---
+The following code example demonstrates how to return a single element as a sequence using `Return`.
+[!code-csharp[](SuperLinq/Return/Return.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RunLengthEncode.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RunLengthEncode.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.RunLengthEncode``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to return the run-length-encoding of a sequence using `RunLengthEncode`.
+[!code-csharp[](SuperLinq/RunLengthEncode/RunLengthEncode1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.RunLengthEncode``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to return the run-length-encoding of a sequence using `RunLengthEncode`.
+[!code-csharp[](SuperLinq/RunLengthEncode/RunLengthEncode2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Scan.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Scan.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Scan``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to execute a post-fix scan on a sequence using `Scan`.
+[!code-csharp[](SuperLinq/Scan/Scan1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Scan``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``1,``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to execute a post-fix scan on a sequence using `Scan`.
+[!code-csharp[](SuperLinq/Scan/Scan2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ScanBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ScanBy.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ScanBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,``2},System.Func{``2,``1,``0,``2})
+example: [*content]
+---
+The following code example demonstrates how to execute a post-fix scan by key on a sequence using `ScanBy`.
+[!code-csharp[](SuperLinq/ScanBy/ScanBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ScanBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,``2},System.Func{``2,``1,``0,``2},System.Collections.Generic.IEqualityComparer{``1})
+example: [*content]
+---
+The following code example demonstrates how to execute a post-fix scan by key on a sequence using `ScanBy`.
+[!code-csharp[](SuperLinq/ScanBy/ScanBy2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ScanRight.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ScanRight.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ScanRight``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,``0})
+example: [*content]
+---
+The following code example demonstrates how to execute a right-associative post-fix scan on a sequence using `ScanRight`.
+[!code-csharp[](SuperLinq/ScanRight/ScanRight1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ScanRight``2(System.Collections.Generic.IEnumerable{``0},``1,System.Func{``0,``1,``1})
+example: [*content]
+---
+The following code example demonstrates how to execute a right-associative post-fix scan on a sequence using `ScanRight`.
+[!code-csharp[](SuperLinq/ScanRight/ScanRight2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Segment.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Segment.md
@@ -1,0 +1,21 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Segment``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a segment detector using `Segment`.
+[!code-csharp[](SuperLinq/Segment/Segment1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Segment``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Int32,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a segment detector using `Segment`.
+[!code-csharp[](SuperLinq/Segment/Segment2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Segment``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``0,System.Int32,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a segment detector using `Segment`.
+[!code-csharp[](SuperLinq/Segment/Segment3.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Sequence.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Sequence.md
@@ -1,0 +1,20 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Range(System.Int32,System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sequence of values using `Range`.
+[!code-csharp[](SuperLinq/Range/Range.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Sequence(System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sequence of values using `Sequence`.
+[!code-csharp[](SuperLinq/Sequence/Sequence1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Sequence(System.Int32,System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sequence of values using `Sequence`.
+[!code-csharp[](SuperLinq/Sequence/Sequence2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Share.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Share.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Share``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to share a single view of an enumerator across multiple consumers using `Share`.
+[!code-csharp[](SuperLinq/Share/Share.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Shuffle.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Shuffle.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Shuffle``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to shuffle a sequence using `Shuffle`.
+[!code-csharp[](SuperLinq/Shuffle/Shuffle1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Shuffle``1(System.Collections.Generic.IEnumerable{``0},System.Random)
+example: [*content]
+---
+The following code example demonstrates how to shuffle a sequence using `Shuffle`.
+[!code-csharp[](SuperLinq/Shuffle/Shuffle2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SkipUntil.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SkipUntil.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.SkipUntil``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to bypass elements in a sequence until a condition is true using `SkipUntil`.
+[!code-csharp[](SuperLinq/SkipUntil/SkipUntil.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Slice.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Slice.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Slice``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to take a range of elements from a sequence using `Slice`.
+[!code-csharp[](SuperLinq/Slice/Slice.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SortedMerge.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SortedMerge.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.SortedMerge``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMerge`.
+[!code-csharp[](SuperLinq/SortedMerge/SortedMerge1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMerge``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IComparer{``0},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMerge`.
+[!code-csharp[](SuperLinq/SortedMerge/SortedMerge2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMerge``1(System.Collections.Generic.IEnumerable{``0},SuperLinq.OrderByDirection,System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMerge`.
+[!code-csharp[](SuperLinq/SortedMerge/SortedMerge3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMerge``1(System.Collections.Generic.IEnumerable{``0},SuperLinq.OrderByDirection,System.Collections.Generic.IComparer{``0},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMerge`.
+[!code-csharp[](SuperLinq/SortedMerge/SortedMerge4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SortedMergeBy.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.SortedMergeBy.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.SortedMergeBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMergeBy`.
+[!code-csharp[](SuperLinq/SortedMergeBy/SortedMergeBy1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMergeBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMergeBy`.
+[!code-csharp[](SuperLinq/SortedMergeBy/SortedMergeBy2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMergeBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},SuperLinq.OrderByDirection,System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMergeBy`.
+[!code-csharp[](SuperLinq/SortedMergeBy/SortedMergeBy3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.SortedMergeBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},SuperLinq.OrderByDirection,System.Collections.Generic.IComparer{``1},System.Collections.Generic.IEnumerable{``0}[])
+example: [*content]
+---
+The following code example demonstrates how to merge two or more sequences that are in a common order into a single sequence that preserves that order using `SortedMergeBy`.
+[!code-csharp[](SuperLinq/SortedMergeBy/SortedMergeBy4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Split.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Split.md
@@ -1,0 +1,83 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},``0)
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},``0,System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},``0,System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},``0,System.Collections.Generic.IEqualityComparer{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},``0,System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},``0,System.Collections.Generic.IEqualityComparer{``0},System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split6.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},``0,System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split7.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},``0,System.Collections.Generic.IEqualityComparer{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a value using `Split`.
+[!code-csharp[](SuperLinq/Split/Split8.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a condition using `Split`.
+[!code-csharp[](SuperLinq/Split/Split9.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a condition using `Split`.
+[!code-csharp[](SuperLinq/Split/Split10.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a condition using `Split`.
+[!code-csharp[](SuperLinq/Split/Split11.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Split``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to split a sequence based on a condition using `Split`.
+[!code-csharp[](SuperLinq/Split/Split12.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.StartsWith.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.StartsWith.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.StartsWith``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to check that one sequence starts with the same elements as another sequence using `StartsWith`.
+[!code-csharp[](SuperLinq/StartsWith/StartsWith1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.StartsWith``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})
+example: [*content]
+---
+The following code example demonstrates how to check that one sequence starts with the same elements as another sequence using `StartsWith`.
+[!code-csharp[](SuperLinq/StartsWith/StartsWith2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Subsets.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Subsets.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Subsets``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to get all subsets of a sequence using `Subsets`.
+[!code-csharp[](SuperLinq/Subsets/Subsets1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Subsets``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how get all subsets of a particular length using `Subsets`.
+[!code-csharp[](SuperLinq/Subsets/Subsets2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TagFirstLast.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TagFirstLast.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.TagFirstLast``1(System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how tag elements of a sequence with information on whether it is the first or last element of the sequence using `TagFirstLast`.
+[!code-csharp[](SuperLinq/TagFirstLast/TagFirstLast1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.TagFirstLast``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean,System.Boolean,``1})
+example: [*content]
+---
+The following code example demonstrates how tag elements of a sequence with information on whether it is the first or last element of the sequence using `TagFirstLast`.
+[!code-csharp[](SuperLinq/TagFirstLast/TagFirstLast2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TakeEvery.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TakeEvery.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.TakeEvery``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to take every n-th element of a sequence using `TakeEvery`.
+[!code-csharp[](SuperLinq/TakeEvery/TakeEvery.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TakeUntil.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TakeUntil.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.TakeUntil``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to take elements in a sequence until a condition is true using `TakeUntil`.
+[!code-csharp[](SuperLinq/TakeUntil/TakeUntil.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Throw.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Throw.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Throw``1(System.Exception)
+example: [*content]
+---
+The following code example demonstrates how to create a sequence that throws on enumeration using `Throw`.
+[!code-csharp[](SuperLinq/Catch/Catch1.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ToArrayByIndex.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ToArrayByIndex.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Int32})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,System.Int32})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Int32},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Int32},System.Func{``0,System.Int32,``1})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,System.Int32},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex6.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ToArrayByIndex``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,System.Int32},System.Func{``0,System.Int32,``1})
+example: [*content]
+---
+The following code example demonstrates how to transform a sequence into an array using indices using `ToArrayByIndex`.
+[!code-csharp[](SuperLinq/ToArrayByIndex/ToArrayByIndex5.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Transpose.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Transpose.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Transpose``1(System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to transpose a jagged 2d sequence using `Transpose`.
+[!code-csharp[](SuperLinq/Transpose/Transpose.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Traverse.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Traverse.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.TraverseBreadthFirst``1(``0,System.Func{``0,System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to traverse a tree breadth-first using `TraverseBreadthFirst`.
+[!code-csharp[](SuperLinq/TraverseBreadthFirst/TraverseBreadthFirst.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.TraverseDepthFirst``1(``0,System.Func{``0,System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to traverse a tree depth-first using `TraverseDepthFirst`.
+[!code-csharp[](SuperLinq/TraverseDepthFirst/TraverseDepthFirst.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TrySingle.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.TrySingle.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.TrySingle``2(System.Collections.Generic.IEnumerable{``0},``1,``1,``1)
+example: [*content]
+---
+The following code example demonstrates how to evaluate the cardinality of a sequence using `TrySingle`.
+[!code-csharp[](SuperLinq/TrySingle/TrySingle1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.TrySingle``3(System.Collections.Generic.IEnumerable{``0},``1,``1,``1,System.Func{``1,``0,``2})
+example: [*content]
+---
+The following code example demonstrates how to evaluate the cardinality of a sequence using `TrySingle`.
+[!code-csharp[](SuperLinq/TrySingle/TrySingle2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Using.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Using.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Using``2(System.Func{``1},System.Func{``1,System.Collections.Generic.IEnumerable{``0}})
+example: [*content]
+---
+The following code example demonstrates how to create a sequence that throws on enumeration using `Using`.
+[!code-csharp[](SuperLinq/Using/Using.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Where.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Where.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Where``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to create filter a sequence with matching `bool` values using `Where`.
+[!code-csharp[](SuperLinq/Where/Where.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WhereLag.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WhereLag.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.WhereLag``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to filter a sequence based on a lagging value in the sequence using `WhereLag`.
+[!code-csharp[](SuperLinq/WhereLag/WhereLag1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WhereLag``1(System.Collections.Generic.IEnumerable{``0},System.Int32,``0,System.Func{``0,``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to filter a sequence based on a lagging value in the sequence using `WhereLag`.
+[!code-csharp[](SuperLinq/WhereLag/WhereLag2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WhereLead.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WhereLead.md
@@ -1,0 +1,13 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.WhereLead``1(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{``0,``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to filter a sequence based on a leading value in the sequence using `WhereLead`.
+[!code-csharp[](SuperLinq/WhereLead/WhereLead1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WhereLead``1(System.Collections.Generic.IEnumerable{``0},System.Int32,``0,System.Func{``0,``0,System.Boolean})
+example: [*content]
+---
+The following code example demonstrates how to filter a sequence based on a leading value in the sequence using `WhereLead`.
+[!code-csharp[](SuperLinq/WhereLead/WhereLead2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.While.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.While.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.While``1(System.Func{System.Boolean},System.Collections.Generic.IEnumerable{``0})
+example: [*content]
+---
+The following code example demonstrates how to repeat a sequence while a condition is true using `While`.
+[!code-csharp[](SuperLinq/While/While.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Window.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.Window.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.Window``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `Window`.
+[!code-csharp[](SuperLinq/Window/Window1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Window``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `Window`.
+[!code-csharp[](SuperLinq/Window/Window2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Window``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `Window`.
+[!code-csharp[](SuperLinq/Window/Window3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.Window``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `Window`.
+[!code-csharp[](SuperLinq/Window/Window4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WindowLeft.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WindowLeft.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.WindowLeft``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowLeft`.
+[!code-csharp[](SuperLinq/WindowLeft/WindowLeft1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowLeft``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowLeft`.
+[!code-csharp[](SuperLinq/WindowLeft/WindowLeft2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowLeft``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowLeft`.
+[!code-csharp[](SuperLinq/WindowLeft/WindowLeft3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowLeft``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowLeft`.
+[!code-csharp[](SuperLinq/WindowLeft/WindowLeft4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WindowRight.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.WindowRight.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.WindowRight``1(System.Collections.Generic.IEnumerable{``0},System.Int32)
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowRight`.
+[!code-csharp[](SuperLinq/WindowRight/WindowRight1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowRight``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowRight`.
+[!code-csharp[](SuperLinq/WindowRight/WindowRight2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowRight``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowRight`.
+[!code-csharp[](SuperLinq/WindowRight/WindowRight3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.WindowRight``2(System.Collections.Generic.IEnumerable{``0},``0[],System.Int32,System.Func{System.Collections.Generic.IReadOnlyList{``0},``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sliding window over a sequence using `WindowRight`.
+[!code-csharp[](SuperLinq/WindowRight/WindowRight4.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipLongest.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipLongest.md
@@ -1,0 +1,42 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ZipLongest``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge two sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipLongest``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge two sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipLongest``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge three sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipLongest``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge three sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipLongest``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Func{``0,``1,``2,``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge four sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipLongest``5(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Func{``0,``1,``2,``3,``4})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipLongest` to merge four sequences. 
+[!code-csharp[](SuperLinq/ZipLongest/ZipLongest6.linq#L6-)]
+

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipMap.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipMap.md
@@ -1,0 +1,6 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ZipMap``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})
+example: [*content]
+---
+The following code example demonstrates how to generate a sequence of values and a projection of that value using `ZipMap`.
+[!code-csharp[](SuperLinq/ZipMap/ZipMap.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipShortest.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.ZipShortest.md
@@ -1,0 +1,42 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.ZipShortest``2(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge two sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipShortest``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge two sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest3.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipShortest``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``1,``2})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge three sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipShortest``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge three sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest5.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipShortest``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Func{``0,``1,``2,``3})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge four sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest4.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.ZipShortest``5(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Collections.Generic.IEnumerable{``2},System.Collections.Generic.IEnumerable{``3},System.Func{``0,``1,``2,``3,``4})
+example: [*content]
+---
+The following code example demonstrates how to use the `ZipShortest` to merge four sequences. 
+[!code-csharp[](SuperLinq/ZipShortest/ZipShortest6.linq#L6-)]
+


### PR DESCRIPTION
This PR updates the online documentation with examples pulled from the linqpad scripts. This helps to keep examples in sync between the linqpad and online documentation examples.