### PR TITLE
Fix bugs in `Batch`

### DIFF
--- a/Source/SuperLinq/Batch.Buffered.cs
+++ b/Source/SuperLinq/Batch.Buffered.cs
@@ -155,7 +155,7 @@ public static partial class SuperEnumerable
 		ArgumentNullException.ThrowIfNull(array);
 		ArgumentNullException.ThrowIfNull(resultSelector);
 		ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
-		ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(size, array.Length);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(size, array.Length);
 
 		return BatchImpl(source, array, size, resultSelector);
 	}

--- a/Source/SuperLinq/Batch.Buffered.cs
+++ b/Source/SuperLinq/Batch.Buffered.cs
@@ -166,12 +166,17 @@ public static partial class SuperEnumerable
 		int size,
 		Func<IReadOnlyList<TSource>, TResult> resultSelector)
 	{
-		if (source is ICollection<TSource> coll
-			&& coll.Count <= size)
+		if (source is ICollection<TSource> coll)
 		{
-			coll.CopyTo(array, 0);
-			yield return resultSelector(new ArraySegment<TSource>(array, 0, coll.Count));
-			yield break;
+			if (coll.Count == 0)
+				yield break;
+
+			if (coll.Count <= size)
+			{
+				coll.CopyTo(array, 0);
+				yield return resultSelector(new ArraySegment<TSource>(array, 0, coll.Count));
+				yield break;
+			}
 		}
 
 		var n = 0;

--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -101,7 +101,7 @@ public static partial class SuperEnumerable
 			_size = size;
 		}
 
-		public override int Count => ((_source.Count - 1) / _size) + 1;
+		public override int Count => _source.Count == 0 ? 0 : ((_source.Count - 1) / _size) + 1;
 
 		protected override IEnumerable<IList<T>> GetEnumerable()
 		{

--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -65,10 +65,6 @@ public static partial class SuperEnumerable
 					yield break;
 				}
 			}
-			else if (source.TryGetCollectionCount() == 0)
-			{
-				yield break;
-			}
 
 			var n = 0;
 			foreach (var item in source)

--- a/Tests/SuperLinq.Test/BatchTest.cs
+++ b/Tests/SuperLinq.Test/BatchTest.cs
@@ -185,9 +185,8 @@ public class BatchTest
 		}
 	}
 
-	public static IEnumerable<object[]> GetBreakingCollections()
+	public static IEnumerable<object[]> GetBreakingCollections(IEnumerable<int> source)
 	{
-		var source = Enumerable.Range(1, 9);
 		yield return new object[] { source.AsBreakingCollection(), BatchMethod.Traditional, };
 		yield return new object[] { source.AsBreakingCollection(), BatchMethod.BufferSize, };
 		yield return new object[] { source.AsBreakingCollection(), BatchMethod.BufferArray, };
@@ -195,7 +194,18 @@ public class BatchTest
 	}
 
 	[Theory]
-	[MemberData(nameof(GetBreakingCollections))]
+	[MemberData(nameof(GetBreakingCollections), new int[] { })]
+	public void BatchWithEmptyCollection(IDisposableEnumerable<int> seq, BatchMethod bm)
+	{
+		using (seq)
+		{
+			var result = GetBatches(seq, bm, 10);
+			result.AssertSequenceEqual();
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetBreakingCollections), new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 })]
 	public void BatchWithCollectionSmallerThanBatchSize(IDisposableEnumerable<int> seq, BatchMethod bm)
 	{
 		using (seq)


### PR DESCRIPTION
This PR fixes three bugs in the `Batch` operator and adds tests to verify the fixes.

Bugs:
* The `size` parameter of the buffered implementation should be allowed to be equal to `array.Length`.
* `BatchListIterator` should return the right `Count` when supplied an empty sequence.
* The buffered implementation returned the wrong value for an empty source sequence.