### PR TITLE
Restore `Slice` to supported operator

### DIFF
--- a/Source/SuperLinq/Slice.cs
+++ b/Source/SuperLinq/Slice.cs
@@ -28,7 +28,6 @@ public static partial class SuperEnumerable
 	///     return all elements up to that point. There is no guarantee that the resulting sequence will contain the
 	///     number of elements requested - it may have anywhere from 0 to <paramref name="count"/>.
 	/// </remarks>
-	[Obsolete("Slice has been replaced by Take(Range).")]
 	public static IEnumerable<T> Slice<T>(this IEnumerable<T> source, int startIndex, int count)
 	{
 		return source.Take(startIndex..(startIndex + count));

--- a/Tests/SuperLinq.Test/SliceTest.cs
+++ b/Tests/SuperLinq.Test/SliceTest.cs
@@ -16,7 +16,7 @@ public class SliceTests
 
 	public static IEnumerable<object[]> GetSequences() =>
 		Enumerable.Range(1, 5)
-			.GetAllSequences()
+			.GetCollectionSequences()
 			.Select(x => new object[] { x });
 
 	[Theory]

--- a/Tests/SuperLinq.Test/SliceTest.cs
+++ b/Tests/SuperLinq.Test/SliceTest.cs
@@ -1,0 +1,76 @@
+﻿namespace Test;
+
+/// <summary>
+/// Verify the behavior of the Slice operator
+/// </summary>
+public class SliceTests
+{
+	/// <summary>
+	/// Verify that Slice evaluates in a lazy manner.
+	/// </summary>
+	[Fact]
+	public void TestSliceIsLazy()
+	{
+		_ = new BreakingSequence<int>().Slice(10, 10);
+	}
+
+	public static IEnumerable<object[]> GetSequences() =>
+		Enumerable.Range(1, 5)
+			.GetAllSequences()
+			.Select(x => new object[] { x });
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void TestSliceIdentity(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Slice(0, 5);
+			result.AssertSequenceEqual(1, 2, 3, 4, 5);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void TestSliceFirstItem(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Slice(0, 1);
+			result.AssertSequenceEqual(1);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void TestSliceLastItem(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Slice(4, 1);
+			result.AssertSequenceEqual(5);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void TestSliceSmallerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Slice(1, 2);
+			result.AssertSequenceEqual(2, 3);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSequences))]
+	public void TestSliceLongerThanSequence(IDisposableEnumerable<int> seq)
+	{
+		using (seq)
+		{
+			var result = seq.Slice(3, 5);
+			result.AssertSequenceEqual(4, 5);
+		}
+	}
+}


### PR DESCRIPTION
This PR restores `Slice` to be a fully supported operator, with unit tests to confirm operator behavior.

Fixes #575 