### PR TITLE
Downgrade DocFX to 2.70.2

### DIFF
--- a/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
+++ b/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DocFx.App" Version="2.73.2" />
+		<PackageReference Include="DocFx.App" Version="2.70.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR downgrades DocFX to 2.70.2 to fix the broken docfx. DocFX version will be locked until future upgrade from SingulinkFX