### PR TITLE
Add primary constructors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -242,7 +242,7 @@ dotnet_diagnostic.RS0026.severity = none				# RS0026: Do not add multiple public
 dotnet_diagnostic.CA1861.severity = none				# CA1861: Avoid constant arrays as arguments
 
 # Primary Constructors
-dotnet_diagnostic.CS9107.severity = error				# CS9107: Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well. This warning indicates that your code may be allocated two copies of a primary constructor parameter. Because the parameter is passed to the base class, the base class likely uses it. Because the derived class accesses it, it may have a second copy of the same parameter. That extra storage may not be intended
-dotnet_diagnostic.CS9113.severity = error				# CS9113: Parameter is not being used
-dotnet_diagnostic.CS9124.severity = error				# CS9124: Use primary constructor
-dotnet_diagnostic.CS9179.severity = error				# CS9179: Use primary constructor
+dotnet_diagnostic.CS9107.severity = error				# CS9107: Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor
+dotnet_diagnostic.CS9113.severity = error				# CS9113: Your class never references the primary constructor
+dotnet_diagnostic.CS9124.severity = error				# CS9124: Parameter is captured into the state of the enclosing type and its value is also used to initialize a field, property, or event
+dotnet_diagnostic.CS9179.severity = error				# CS9179: Primary constructor parameter is shadowed by a member from base

--- a/.editorconfig
+++ b/.editorconfig
@@ -209,7 +209,6 @@ dotnet_analyzer_diagnostic.category-Style.severity = warning
 
 dotnet_diagnostic.IDE0011.severity = silent				# IDE0011: Add braces
 dotnet_diagnostic.IDE0046.severity = silent				# IDE0046: Convert to conditional expression
-dotnet_diagnostic.IDE0290.severity = none				# IDE0290: Use primary constructor
 dotnet_diagnostic.IDE0028.severity = none				# IDE0028: Simplify collection initialization
 dotnet_diagnostic.IDE0305.severity = none				# IDE0305: Simplify collection initialization
 
@@ -241,3 +240,9 @@ dotnet_diagnostic.RS0026.severity = none				# RS0026: Do not add multiple public
 
 # Bug in compiler
 dotnet_diagnostic.CA1861.severity = none				# CA1861: Avoid constant arrays as arguments
+
+# Primary Constructors
+dotnet_diagnostic.CS9107.severity = error				# CS9107: Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well. This warning indicates that your code may be allocated two copies of a primary constructor parameter. Because the parameter is passed to the base class, the base class likely uses it. Because the derived class accesses it, it may have a second copy of the same parameter. That extra storage may not be intended
+dotnet_diagnostic.CS9113.severity = error				# CS9113: Parameter is not being used
+dotnet_diagnostic.CS9124.severity = error				# CS9124: Use primary constructor
+dotnet_diagnostic.CS9179.severity = error				# CS9179: Use primary constructor

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
-		
+
 		<AnalysisLevel>latest-all</AnalysisLevel>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 

--- a/Source/SuperLinq.Async/GroupAdjacent.cs
+++ b/Source/SuperLinq.Async/GroupAdjacent.cs
@@ -297,17 +297,14 @@ public static partial class AsyncSuperEnumerable
 		new(key, members.AsReadOnly());
 
 	[Serializable]
-	private sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>
+	private sealed class Grouping<TKey, TElement>(
+		TKey key,
+		IEnumerable<TElement> members
+	) : IGrouping<TKey, TElement>
 	{
-		private readonly IEnumerable<TElement> _members;
+		private readonly IEnumerable<TElement> _members = members;
 
-		public Grouping(TKey key, IEnumerable<TElement> members)
-		{
-			Key = key;
-			_members = members;
-		}
-
-		public TKey Key { get; }
+		public TKey Key { get; } = key;
 
 		public IEnumerator<TElement> GetEnumerator() => _members.GetEnumerator();
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Source/SuperLinq.Async/Join.MergeJoin.cs
+++ b/Source/SuperLinq.Async/Join.MergeJoin.cs
@@ -717,15 +717,10 @@ public static partial class AsyncSuperEnumerable
 	}
 }
 
-file sealed class ComparerEqualityComparer<TKey> : IEqualityComparer<TKey>
+file sealed class ComparerEqualityComparer<TKey>(
+	IComparer<TKey> comparer
+) : IEqualityComparer<TKey>
 {
-	private readonly IComparer<TKey> _comparer;
-
-	public ComparerEqualityComparer(IComparer<TKey> comparer)
-	{
-		_comparer = comparer;
-	}
-
-	public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => _comparer.Compare(x, y) == 0;
+	public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => comparer.Compare(x, y) == 0;
 	public int GetHashCode([DisallowNull] TKey obj) => ThrowHelper.ThrowNotSupportedException<int>();
 }

--- a/Source/SuperLinq.Async/Memoize.cs
+++ b/Source/SuperLinq.Async/Memoize.cs
@@ -32,11 +32,13 @@ public static partial class AsyncSuperEnumerable
 		return new EnumerableMemoizedBuffer<TSource>(source);
 	}
 
-	private sealed class EnumerableMemoizedBuffer<T> : IAsyncBuffer<T>
+	private sealed class EnumerableMemoizedBuffer<T>(
+		IAsyncEnumerable<T> source
+	) : IAsyncBuffer<T>
 	{
 		private readonly SemaphoreSlim _lock = new(initialCount: 1);
 
-		private IAsyncEnumerable<T>? _source;
+		private IAsyncEnumerable<T>? _source = source;
 
 		private IAsyncEnumerator<T>? _enumerator;
 		private List<T> _buffer = new();
@@ -46,11 +48,6 @@ public static partial class AsyncSuperEnumerable
 		private int? _exceptionIndex;
 
 		private bool _disposed;
-
-		public EnumerableMemoizedBuffer(IAsyncEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => _buffer.Count;
 

--- a/Source/SuperLinq.Async/Publish.cs
+++ b/Source/SuperLinq.Async/Publish.cs
@@ -22,11 +22,13 @@ public static partial class AsyncSuperEnumerable
 		return new PublishBuffer<TSource>(source);
 	}
 
-	private sealed class PublishBuffer<T> : IAsyncBuffer<T>
+	private sealed class PublishBuffer<T>(
+		IAsyncEnumerable<T> source
+	) : IAsyncBuffer<T>
 	{
 		private readonly SemaphoreSlim _lock = new(initialCount: 1);
 
-		private IAsyncEnumerable<T>? _source;
+		private IAsyncEnumerable<T>? _source = source;
 
 		private IAsyncEnumerator<T>? _enumerator;
 		private List<Queue<T>>? _buffers;
@@ -37,11 +39,6 @@ public static partial class AsyncSuperEnumerable
 		private bool? _exceptionOnGetEnumerator;
 
 		private bool _disposed;
-
-		public PublishBuffer(IAsyncEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => _buffers?.Count > 0 ? _buffers.Max(x => x.Count) : 0;
 

--- a/Source/SuperLinq.Async/Share.cs
+++ b/Source/SuperLinq.Async/Share.cs
@@ -19,11 +19,13 @@ public static partial class AsyncSuperEnumerable
 		return new SharedBuffer<TSource>(source);
 	}
 
-	private sealed class SharedBuffer<T> : IAsyncBuffer<T>
+	private sealed class SharedBuffer<T>(
+		IAsyncEnumerable<T> source
+	) : IAsyncBuffer<T>
 	{
 		private readonly SemaphoreSlim _lock = new(initialCount: 1);
 
-		private IAsyncEnumerable<T>? _source;
+		private IAsyncEnumerable<T>? _source = source;
 
 		private IAsyncEnumerator<T>? _enumerator;
 		private bool _initialized;
@@ -32,11 +34,6 @@ public static partial class AsyncSuperEnumerable
 		private ExceptionDispatchInfo? _exception;
 
 		private bool _disposed;
-
-		public SharedBuffer(IAsyncEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => 0;
 

--- a/Source/SuperLinq/AssertCount.cs
+++ b/Source/SuperLinq/AssertCount.cs
@@ -57,31 +57,25 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class AssertCountCollectionIterator<T> : CollectionIterator<T>
+	private sealed class AssertCountCollectionIterator<T>(
+		IEnumerable<T> source,
+		int count
+	) : CollectionIterator<T>
 	{
-		private readonly IEnumerable<T> _source;
-		private readonly int _count;
-
-		public AssertCountCollectionIterator(IEnumerable<T> source, int count)
-		{
-			_source = source;
-			_count = count;
-		}
-
 		public override int Count
 		{
 			get
 			{
-				ArgumentOutOfRangeException.ThrowIfNotEqual(_source.GetCollectionCount(), _count, "source.Count()");
-				return _count;
+				ArgumentOutOfRangeException.ThrowIfNotEqual(source.GetCollectionCount(), count, "source.Count()");
+				return count;
 			}
 		}
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			ArgumentOutOfRangeException.ThrowIfNotEqual(_source.GetCollectionCount(), _count, "source.Count()");
+			ArgumentOutOfRangeException.ThrowIfNotEqual(source.GetCollectionCount(), count, "source.Count()");
 
-			foreach (var item in _source)
+			foreach (var item in source)
 				yield return item;
 		}
 
@@ -91,27 +85,21 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			_ = _source.CopyTo(array, arrayIndex);
+			_ = source.CopyTo(array, arrayIndex);
 		}
 	}
 
-	private sealed class AssertCountListIterator<T> : ListIterator<T>
+	private sealed class AssertCountListIterator<T>(
+		IList<T> source,
+		int count
+	) : ListIterator<T>
 	{
-		private readonly IList<T> _source;
-		private readonly int _count;
-
-		public AssertCountListIterator(IList<T> source, int count)
-		{
-			_source = source;
-			_count = count;
-		}
-
 		public override int Count
 		{
 			get
 			{
-				ArgumentOutOfRangeException.ThrowIfNotEqual(_source.Count, _count, "source.Count()");
-				return _count;
+				ArgumentOutOfRangeException.ThrowIfNotEqual(source.Count, count, "source.Count()");
+				return count;
 			}
 		}
 
@@ -120,7 +108,7 @@ public static partial class SuperEnumerable
 			var cnt = (uint)Count;
 			for (var i = 0; i < cnt; i++)
 			{
-				yield return _source[i];
+				yield return source[i];
 			}
 		}
 
@@ -130,7 +118,7 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			_source.CopyTo(array, arrayIndex);
+			source.CopyTo(array, arrayIndex);
 		}
 
 		protected override T ElementAt(int index)
@@ -138,7 +126,7 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _source[index];
+			return source[index];
 		}
 	}
 }

--- a/Source/SuperLinq/Batch.cs
+++ b/Source/SuperLinq/Batch.cs
@@ -86,28 +86,22 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class BatchIterator<T> : ListIterator<IList<T>>
+	private sealed class BatchIterator<T>(
+		IList<T> source,
+		int size
+	) : ListIterator<IList<T>>
 	{
-		private readonly IList<T> _source;
-		private readonly int _size;
-
-		public BatchIterator(IList<T> source, int size)
-		{
-			_source = source;
-			_size = size;
-		}
-
-		public override int Count => _source.Count == 0 ? 0 : ((_source.Count - 1) / _size) + 1;
+		public override int Count => source.Count == 0 ? 0 : ((source.Count - 1) / size) + 1;
 
 		protected override IEnumerable<IList<T>> GetEnumerable()
 		{
 			var sourceIndex = 0;
-			var count = (uint)_source.Count;
-			while (sourceIndex + _size - 1 < count)
+			var count = (uint)source.Count;
+			while (sourceIndex + size - 1 < count)
 			{
-				var window = new T[_size];
-				for (var i = 0; i < _size && sourceIndex < count; sourceIndex++, i++)
-					window[i] = _source[sourceIndex];
+				var window = new T[size];
+				for (var i = 0; i < size && sourceIndex < count; sourceIndex++, i++)
+					window[i] = source[sourceIndex];
 
 				yield return window;
 			}
@@ -116,7 +110,7 @@ public static partial class SuperEnumerable
 			{
 				var window = new T[count - sourceIndex];
 				for (var j = 0; sourceIndex < count; sourceIndex++, j++)
-					window[j] = _source[sourceIndex];
+					window[j] = source[sourceIndex];
 
 				yield return window;
 			}
@@ -127,11 +121,11 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var start = index * _size;
-			var max = (uint)Math.Min(_source.Count, start + _size);
-			var arr = new T[Math.Min(_size, max - start)];
-			for (int i = 0, j = start; i < _size && j < max; i++, j++)
-				arr[i] = _source[j];
+			var start = index * size;
+			var max = (uint)Math.Min(source.Count, start + size);
+			var arr = new T[Math.Min(size, max - start)];
+			for (int i = 0, j = start; i < size && j < max; i++, j++)
+				arr[i] = source[j];
 
 			return arr;
 		}

--- a/Source/SuperLinq/CountDown.cs
+++ b/Source/SuperLinq/CountDown.cs
@@ -19,7 +19,7 @@ public static partial class SuperEnumerable
 	/// <returns>
 	///	    A sequence of tuples containing the element and it's count from the end of the sequence, or <see
 	///     langword="null"/>.
-	/// </returns>  
+	/// </returns>
 	/// <exception cref="ArgumentNullException">
 	///	    <paramref name="source"/> is <see langword="null"/>.
 	/// </exception>
@@ -110,60 +110,46 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class CountDownCollectionIterator<TSource, TResult> : CollectionIterator<TResult>
+	private sealed class CountDownCollectionIterator<TSource, TResult>(
+		IEnumerable<TSource> source,
+		int count,
+		Func<TSource, int?, TResult> resultSelector
+	) : CollectionIterator<TResult>
 	{
-		private readonly IEnumerable<TSource> _source;
-		private readonly int _count;
-		private readonly Func<TSource, int?, TResult> _resultSelector;
-
-		public CountDownCollectionIterator(IEnumerable<TSource> source, int count, Func<TSource, int?, TResult> resultSelector)
-		{
-			_source = source;
-			_count = count;
-			_resultSelector = resultSelector;
-		}
-
-		public override int Count => _source.GetCollectionCount();
+		public override int Count => source.GetCollectionCount();
 
 		protected override IEnumerable<TResult> GetEnumerable()
 		{
 			var i = Count;
-			foreach (var item in _source)
-				yield return _resultSelector(item, i-- <= _count ? i : null);
+			foreach (var item in source)
+				yield return resultSelector(item, i-- <= count ? i : null);
 		}
 	}
 
-	private sealed class CountDownListIterator<TSource, TResult> : ListIterator<TResult>
+	private sealed class CountDownListIterator<TSource, TResult>(
+		IList<TSource> source,
+		int count,
+		Func<TSource, int?, TResult> resultSelector
+	) : ListIterator<TResult>
 	{
-		private readonly IList<TSource> _source;
-		private readonly int _count;
-		private readonly Func<TSource, int?, TResult> _resultSelector;
-
-		public CountDownListIterator(IList<TSource> source, int count, Func<TSource, int?, TResult> resultSelector)
-		{
-			_source = source;
-			_count = count;
-			_resultSelector = resultSelector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<TResult> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count - _count;
+			var cnt = (uint)source.Count - count;
 			var i = 0;
 			for (; i < cnt; i++)
 			{
-				yield return _resultSelector(
-					_source[i],
+				yield return resultSelector(
+					source[i],
 					null);
 			}
 
-			cnt = (uint)_source.Count;
+			cnt = (uint)source.Count;
 			for (; i < cnt; i++)
 			{
-				yield return _resultSelector(
-					_source[i],
+				yield return resultSelector(
+					source[i],
 					(int)cnt - i - 1);
 			}
 		}
@@ -173,9 +159,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _resultSelector(
-				_source[index],
-				_source.Count - index < _count ? _source.Count - index - 1 : null);
+			return resultSelector(
+				source[index],
+				source.Count - index < count ? source.Count - index - 1 : null);
 		}
 	}
 }

--- a/Source/SuperLinq/Exclude.cs
+++ b/Source/SuperLinq/Exclude.cs
@@ -46,54 +46,40 @@ public static partial class SuperEnumerable
 		};
 	}
 
-	private sealed class ExcludeCollectionIterator<T> : CollectionIterator<T>
+	private sealed class ExcludeCollectionIterator<T>(
+		ICollection<T> source,
+		int startIndex,
+		int count
+	) : CollectionIterator<T>
 	{
-		private readonly ICollection<T> _source;
-		private readonly int _startIndex;
-		private readonly int _count;
-
-		public ExcludeCollectionIterator(ICollection<T> source, int startIndex, int count)
-		{
-			_source = source;
-			_startIndex = startIndex;
-			_count = count;
-		}
-
 		public override int Count =>
-			_source.Count < _startIndex ? _source.Count :
-			_source.Count < _startIndex + _count ? _startIndex :
-			_source.Count - _count;
+			source.Count < startIndex ? source.Count :
+			source.Count < startIndex + count ? startIndex :
+			source.Count - count;
 
 		protected override IEnumerable<T> GetEnumerable() =>
-			ExcludeCore(_source, _startIndex, _count);
+			ExcludeCore(source, startIndex, count);
 	}
 
-	private sealed class ExcludeListIterator<T> : ListIterator<T>
+	private sealed class ExcludeListIterator<T>(
+		IList<T> source,
+		int startIndex,
+		int count
+	) : ListIterator<T>
 	{
-		private readonly IList<T> _source;
-		private readonly int _startIndex;
-		private readonly int _count;
-
-		public ExcludeListIterator(IList<T> source, int startIndex, int count)
-		{
-			_source = source;
-			_startIndex = startIndex;
-			_count = count;
-		}
-
 		public override int Count =>
-			_source.Count < _startIndex ? _source.Count :
-			_source.Count < _startIndex + _count ? _startIndex :
-			_source.Count - _count;
+			source.Count < startIndex ? source.Count :
+			source.Count < startIndex + count ? startIndex :
+			source.Count - count;
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count;
-			for (var i = 0; i < cnt && i < _startIndex; i++)
-				yield return _source[i];
+			var cnt = (uint)source.Count;
+			for (var i = 0; i < cnt && i < startIndex; i++)
+				yield return source[i];
 
-			for (var i = _startIndex + _count; i < cnt; i++)
-				yield return _source[i];
+			for (var i = startIndex + count; i < cnt; i++)
+				yield return source[i];
 		}
 
 		protected override T ElementAt(int index)
@@ -101,9 +87,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return index < _startIndex
-				? _source[index]
-				: _source[index + _count];
+			return index < startIndex
+				? source[index]
+				: source[index + count];
 		}
 	}
 

--- a/Source/SuperLinq/FallbackIfEmpty.cs
+++ b/Source/SuperLinq/FallbackIfEmpty.cs
@@ -92,27 +92,21 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class FallbackIfEmptyCollectionIterator<T> : CollectionIterator<T>
+	private sealed class FallbackIfEmptyCollectionIterator<T>(
+		IEnumerable<T> source,
+		IEnumerable<T> fallback
+	) : CollectionIterator<T>
 	{
-		private readonly IEnumerable<T> _source;
-		private readonly IEnumerable<T> _fallback;
-
-		public FallbackIfEmptyCollectionIterator(IEnumerable<T> source, IEnumerable<T> fallback)
-		{
-			_source = source;
-			_fallback = fallback;
-		}
-
 		public override int Count =>
-			_source.GetCollectionCount() == 0
-				? _fallback.Count()
-				: _source.GetCollectionCount();
+			source.GetCollectionCount() == 0
+				? fallback.Count()
+				: source.GetCollectionCount();
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			return _source.GetCollectionCount() == 0
-				? _fallback
-				: _source;
+			return source.GetCollectionCount() == 0
+				? fallback
+				: source;
 		}
 	}
 }

--- a/Source/SuperLinq/FillBackward.cs
+++ b/Source/SuperLinq/FillBackward.cs
@@ -138,24 +138,17 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class FillBackwardCollection<T> : CollectionIterator<T>
+	private sealed class FillBackwardCollection<T>(
+		ICollection<T> source,
+		Func<T, bool> predicate,
+		Func<T, T, T>? fillSelector
+	) : CollectionIterator<T>
 	{
-		private readonly ICollection<T> _source;
-		private readonly Func<T, bool> _predicate;
-		private readonly Func<T, T, T>? _fillSelector;
-
-		public FillBackwardCollection(ICollection<T> source, Func<T, bool> predicate, Func<T, T, T>? fillSelector)
-		{
-			_source = source;
-			_predicate = predicate;
-			_fillSelector = fillSelector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<T> GetEnumerable() =>
-			FillBackwardCore(_source, _predicate, _fillSelector);
+			FillBackwardCore(source, predicate, fillSelector);
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
@@ -163,10 +156,10 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, Count);
 
-			_source.CopyTo(array, arrayIndex);
+			source.CopyTo(array, arrayIndex);
 
-			var i = arrayIndex + _source.Count - 1;
-			for (; i >= arrayIndex && _predicate(array[i]); i--)
+			var i = arrayIndex + source.Count - 1;
+			for (; i >= arrayIndex && predicate(array[i]); i--)
 				;
 
 			if (i < arrayIndex)
@@ -175,10 +168,10 @@ public static partial class SuperEnumerable
 			var last = array[i--];
 			for (; i >= arrayIndex; i--)
 			{
-				if (_predicate(array[i]))
+				if (predicate(array[i]))
 				{
-					array[i] = _fillSelector != null
-						? _fillSelector(array[i], last)
+					array[i] = fillSelector != null
+						? fillSelector(array[i], last)
 						: last;
 				}
 				else

--- a/Source/SuperLinq/GroupAdjacent.cs
+++ b/Source/SuperLinq/GroupAdjacent.cs
@@ -328,17 +328,14 @@ public static partial class SuperEnumerable
 		new(key, members.AsReadOnly());
 
 	[Serializable]
-	private sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>
+	private sealed class Grouping<TKey, TElement>(
+		TKey key,
+		IEnumerable<TElement> members
+	) : IGrouping<TKey, TElement>
 	{
-		private readonly IEnumerable<TElement> _members;
+		private readonly IEnumerable<TElement> _members = members;
 
-		public Grouping(TKey key, IEnumerable<TElement> members)
-		{
-			Key = key;
-			_members = members;
-		}
-
-		public TKey Key { get; }
+		public TKey Key { get; } = key;
 
 		public IEnumerator<TElement> GetEnumerator() => _members.GetEnumerator();
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Source/SuperLinq/Index.cs
+++ b/Source/SuperLinq/Index.cs
@@ -67,46 +67,34 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class IndexCollectionIterator<T> : CollectionIterator<(int index, T item)>
+	private sealed class IndexCollectionIterator<T>(
+		IEnumerable<T> source,
+		int startIndex
+	) : CollectionIterator<(int index, T item)>
 	{
-		private readonly IEnumerable<T> _source;
-		private readonly int _startIndex;
-
-		public IndexCollectionIterator(IEnumerable<T> source, int startIndex)
-		{
-			_source = source;
-			_startIndex = startIndex;
-		}
-
-		public override int Count => _source.GetCollectionCount();
+		public override int Count => source.GetCollectionCount();
 
 		protected override IEnumerable<(int index, T item)> GetEnumerable()
 		{
-			var index = _startIndex;
-			foreach (var item in _source)
+			var index = startIndex;
+			foreach (var item in source)
 				yield return (index++, item);
 		}
 	}
 
-	private sealed class IndexListIterator<T> : ListIterator<(int index, T item)>
+	private sealed class IndexListIterator<T>(
+		IList<T> source,
+		int startIndex
+	) : ListIterator<(int index, T item)>
 	{
-		private readonly IList<T> _source;
-		private readonly int _startIndex;
-
-		public IndexListIterator(IList<T> source, int startIndex)
-		{
-			_source = source;
-			_startIndex = startIndex;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<(int index, T item)> GetEnumerable()
 		{
 			var cnt = (uint)Count;
 			for (var i = 0; i < cnt; i++)
 			{
-				yield return (_startIndex + i, _source[i]);
+				yield return (startIndex + i, source[i]);
 			}
 		}
 
@@ -115,7 +103,7 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return (_startIndex + index, _source[index]);
+			return (startIndex + index, source[index]);
 		}
 	}
 }

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -198,11 +198,13 @@ public static partial class SuperEnumerable
 		Index index
 	) : ListIterator<T>
 	{
+		private readonly Index _index = index;
+
 		public override int Count
 		{
 			get
 			{
-				var idx = index.GetOffset(first.Count);
+				var idx = _index.GetOffset(first.Count);
 				ArgumentOutOfRangeException.ThrowIfNegative(idx);
 				ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
 
@@ -212,7 +214,7 @@ public static partial class SuperEnumerable
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var idx = index.GetOffset(first.Count);
+			var idx = _index.GetOffset(first.Count);
 			ArgumentOutOfRangeException.ThrowIfNegative(idx);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
 
@@ -238,24 +240,24 @@ public static partial class SuperEnumerable
 
 			var span = array.AsSpan()[arrayIndex..];
 			var cnt = first.Count;
-			var idx = index.GetOffset(cnt);
+			var idx = _index.GetOffset(cnt);
 			span[idx..cnt].CopyTo(span[(idx + second.Count)..]);
 
 			second.CopyTo(array, arrayIndex + idx);
 		}
 
-		protected override T ElementAt(int index1)
+		protected override T ElementAt(int index)
 		{
-			ArgumentOutOfRangeException.ThrowIfNegative(index1);
-			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index1, Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var idx = index.GetOffset(first.Count);
+			var idx = _index.GetOffset(first.Count);
 			ArgumentOutOfRangeException.ThrowIfNegative(idx);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
 
-			return index1 < idx ? first[index1] :
-				index1 < idx + second.Count ? second[index1 - idx] :
-				first[index1 - second.Count];
+			return index < idx ? first[index] :
+				index < idx + second.Count ? second[index - idx] :
+				first[index - second.Count];
 		}
 	}
 }

--- a/Source/SuperLinq/Insert.cs
+++ b/Source/SuperLinq/Insert.cs
@@ -198,36 +198,38 @@ public static partial class SuperEnumerable
 		Index index
 	) : ListIterator<T>
 	{
+		private readonly IList<T> _first = first;
+		private readonly IList<T> _second = second;
 		private readonly Index _index = index;
 
 		public override int Count
 		{
 			get
 			{
-				var idx = _index.GetOffset(first.Count);
+				var idx = _index.GetOffset(_first.Count);
 				ArgumentOutOfRangeException.ThrowIfNegative(idx);
-				ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
+				ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
 
-				return first.Count + second.Count;
+				return _first.Count + _second.Count;
 			}
 		}
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var idx = _index.GetOffset(first.Count);
+			var idx = _index.GetOffset(_first.Count);
 			ArgumentOutOfRangeException.ThrowIfNegative(idx);
-			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
 
 			for (var i = 0; i < (uint)idx; i++)
-				yield return first[i];
+				yield return _first[i];
 
-			var cnt = (uint)second.Count;
+			var cnt = (uint)_second.Count;
 			for (var j = 0; j < cnt; j++)
-				yield return second[j];
+				yield return _second[j];
 
-			cnt = (uint)first.Count;
+			cnt = (uint)_first.Count;
 			for (var i = idx; i < cnt; i++)
-				yield return first[i];
+				yield return _first[i];
 		}
 
 		public override void CopyTo(T[] array, int arrayIndex)
@@ -236,14 +238,14 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			first.CopyTo(array, arrayIndex);
+			_first.CopyTo(array, arrayIndex);
 
 			var span = array.AsSpan()[arrayIndex..];
-			var cnt = first.Count;
+			var cnt = _first.Count;
 			var idx = _index.GetOffset(cnt);
-			span[idx..cnt].CopyTo(span[(idx + second.Count)..]);
+			span[idx..cnt].CopyTo(span[(idx + _second.Count)..]);
 
-			second.CopyTo(array, arrayIndex + idx);
+			_second.CopyTo(array, arrayIndex + idx);
 		}
 
 		protected override T ElementAt(int index)
@@ -251,13 +253,13 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var idx = _index.GetOffset(first.Count);
+			var idx = _index.GetOffset(_first.Count);
 			ArgumentOutOfRangeException.ThrowIfNegative(idx);
-			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, first.Count);
+			ArgumentOutOfRangeException.ThrowIfGreaterThan(idx, _first.Count);
 
-			return index < idx ? first[index] :
-				index < idx + second.Count ? second[index - idx] :
-				first[index - second.Count];
+			return index < idx ? _first[index] :
+				index < idx + _second.Count ? _second[index - idx] :
+				_first[index - _second.Count];
 		}
 	}
 }

--- a/Source/SuperLinq/Interleave.cs
+++ b/Source/SuperLinq/Interleave.cs
@@ -87,19 +87,14 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class InterleaveIterator<T> : CollectionIterator<T>
+	private sealed class InterleaveIterator<T>(
+		IEnumerable<ICollection<T>> sources
+	) : CollectionIterator<T>
 	{
-		private readonly IEnumerable<ICollection<T>> _sources;
-
-		public InterleaveIterator(IEnumerable<ICollection<T>> sources)
-		{
-			_sources = sources;
-		}
-
-		public override int Count => _sources.Sum(static s => s.Count);
+		public override int Count => sources.Sum(static s => s.Count);
 
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<T> GetEnumerable() =>
-			InterleaveCore(_sources);
+			InterleaveCore(sources);
 	}
 }

--- a/Source/SuperLinq/Join.MergeJoin.cs
+++ b/Source/SuperLinq/Join.MergeJoin.cs
@@ -720,15 +720,10 @@ public static partial class SuperEnumerable
 	}
 }
 
-file sealed class ComparerEqualityComparer<TKey> : IEqualityComparer<TKey>
+file sealed class ComparerEqualityComparer<TKey>(
+	IComparer<TKey> comparer
+) : IEqualityComparer<TKey>
 {
-	private readonly IComparer<TKey> _comparer;
-
-	public ComparerEqualityComparer(IComparer<TKey> comparer)
-	{
-		_comparer = comparer;
-	}
-
-	public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => _comparer.Compare(x, y) == 0;
+	public bool Equals([AllowNull] TKey x, [AllowNull] TKey y) => comparer.Compare(x, y) == 0;
 	public int GetHashCode([DisallowNull] TKey obj) => ThrowHelper.ThrowNotSupportedException<int>();
 }

--- a/Source/SuperLinq/KeyValuePairEqualityComparer.cs
+++ b/Source/SuperLinq/KeyValuePairEqualityComparer.cs
@@ -35,18 +35,13 @@ internal static class KeyValuePairEqualityComparer
 			keyComparer,
 			valueComparer);
 
-	private sealed class ItemEqualityComparer<TKey, TValue> : IEqualityComparer<KeyValuePair<TKey, TValue>>
+	private sealed class ItemEqualityComparer<TKey, TValue>(
+		IEqualityComparer<TKey>? keyComparer,
+		IEqualityComparer<TValue>? valueComparer
+	) : IEqualityComparer<KeyValuePair<TKey, TValue>>
 	{
-		private readonly IEqualityComparer<TKey> _keyComparer;
-		private readonly IEqualityComparer<TValue> _valueComparer;
-
-		public ItemEqualityComparer(
-			IEqualityComparer<TKey>? keyComparer,
-			IEqualityComparer<TValue>? valueComparer)
-		{
-			_keyComparer = keyComparer ?? EqualityComparer<TKey>.Default;
-			_valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
-		}
+		private readonly IEqualityComparer<TKey> _keyComparer = keyComparer ?? EqualityComparer<TKey>.Default;
+		private readonly IEqualityComparer<TValue> _valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
 
 		public bool Equals(KeyValuePair<TKey, TValue> x, KeyValuePair<TKey, TValue> y)
 			=> _keyComparer.Equals(x.Key, y.Key)

--- a/Source/SuperLinq/Lag.cs
+++ b/Source/SuperLinq/Lag.cs
@@ -140,30 +140,22 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class LagIterator<TSource, TResult> : ListIterator<TResult>
+	private sealed class LagIterator<TSource, TResult>(
+		IList<TSource> source,
+		int offset,
+		TSource defaultLagValue,
+		Func<TSource, TSource, TResult> resultSelector
+	) : ListIterator<TResult>
 	{
-		private readonly IList<TSource> _source;
-		private readonly int _offset;
-		private readonly TSource _defaultLagValue;
-		private readonly Func<TSource, TSource, TResult> _resultSelector;
-
-		public LagIterator(IList<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
-		{
-			_source = source;
-			_offset = offset;
-			_defaultLagValue = defaultLagValue;
-			_resultSelector = resultSelector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<TResult> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count;
+			var cnt = (uint)source.Count;
 			for (var i = 0; i < cnt; i++)
-				yield return _resultSelector(
-					_source[i],
-					i < _offset ? _defaultLagValue : _source[i - _offset]);
+				yield return resultSelector(
+					source[i],
+					i < offset ? defaultLagValue : source[i - offset]);
 		}
 
 		protected override TResult ElementAt(int index)
@@ -171,9 +163,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _resultSelector(
-				_source[index],
-				index < _offset ? _defaultLagValue : _source[index - _offset]);
+			return resultSelector(
+				source[index],
+				index < offset ? defaultLagValue : source[index - offset]);
 		}
 	}
 }

--- a/Source/SuperLinq/Lead.cs
+++ b/Source/SuperLinq/Lead.cs
@@ -145,31 +145,23 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class LeadIterator<TSource, TResult> : ListIterator<TResult>
+	private sealed class LeadIterator<TSource, TResult>(
+		IList<TSource> source,
+		int offset,
+		TSource defaultLeadValue,
+		Func<TSource, TSource, TResult> resultSelector
+	) : ListIterator<TResult>
 	{
-		private readonly IList<TSource> _source;
-		private readonly int _offset;
-		private readonly TSource _defaultLeadValue;
-		private readonly Func<TSource, TSource, TResult> _resultSelector;
-
-		public LeadIterator(IList<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
-		{
-			_source = source;
-			_offset = offset;
-			_defaultLeadValue = defaultLeadValue;
-			_resultSelector = resultSelector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<TResult> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count;
-			var maxOffset = Math.Max(_source.Count - _offset, 0);
+			var cnt = (uint)source.Count;
+			var maxOffset = Math.Max(source.Count - offset, 0);
 			for (var i = 0; i < cnt; i++)
-				yield return _resultSelector(
-					_source[i],
-					i < maxOffset ? _source[i + _offset] : _defaultLeadValue);
+				yield return resultSelector(
+					source[i],
+					i < maxOffset ? source[i + offset] : defaultLeadValue);
 		}
 
 		protected override TResult ElementAt(int index)
@@ -177,11 +169,11 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _resultSelector(
-				_source[index],
-				index < Math.Max(_source.Count - _offset, 0)
-					? _source[index + _offset]
-					: _defaultLeadValue);
+			return resultSelector(
+				source[index],
+				index < Math.Max(source.Count - offset, 0)
+					? source[index + offset]
+					: defaultLeadValue);
 		}
 	}
 }

--- a/Source/SuperLinq/Memoize.cs
+++ b/Source/SuperLinq/Memoize.cs
@@ -56,11 +56,13 @@ public static partial class SuperEnumerable
 		};
 	}
 
-	private sealed class EnumerableMemoizedBuffer<T> : IBuffer<T>
+	private sealed class EnumerableMemoizedBuffer<T>(
+		IEnumerable<T> source
+	) : IBuffer<T>
 	{
 		private readonly object _lock = new();
 
-		private IEnumerable<T>? _source;
+		private IEnumerable<T>? _source = source;
 
 		private IEnumerator<T>? _enumerator;
 		private List<T> _buffer = new();
@@ -70,11 +72,6 @@ public static partial class SuperEnumerable
 		private int? _exceptionIndex;
 
 		private bool _disposed;
-
-		public EnumerableMemoizedBuffer(IEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => _buffer.Count;
 
@@ -215,7 +212,9 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class CollectionMemoizedBuffer<T> : IBuffer<T>
+	private sealed class CollectionMemoizedBuffer<T>(
+		ICollection<T> source
+	) : IBuffer<T>
 	{
 		private enum State
 		{
@@ -228,15 +227,9 @@ public static partial class SuperEnumerable
 
 		private sealed record CmbHelper(State State, T[]? Buffer = null, ExceptionDispatchInfo? Exception = null);
 
-		private ICollection<T>? _source;
+		private ICollection<T>? _source = source;
 
-		private volatile CmbHelper _state;
-
-		public CollectionMemoizedBuffer(ICollection<T> source)
-		{
-			_source = source;
-			_state = new(State.Uninitialized, null);
-		}
+		private volatile CmbHelper _state = new(State.Uninitialized, null);
 
 		public int Count
 		{
@@ -381,14 +374,11 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class CollectionProxyBuffer<T> : IBuffer<T>
+	private sealed class CollectionProxyBuffer<T>(
+		ICollection<T> source
+	) : IBuffer<T>
 	{
-		public CollectionProxyBuffer(ICollection<T> source)
-		{
-			_source = source;
-		}
-
-		private ICollection<T>? _source;
+		private ICollection<T>? _source = source;
 		private ICollection<T> Source
 		{
 			get

--- a/Source/SuperLinq/Pad.cs
+++ b/Source/SuperLinq/Pad.cs
@@ -127,25 +127,16 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class PadCollectionIterator<T> : CollectionIterator<T>
+	private sealed class PadCollectionIterator<T>(
+		IEnumerable<T> source,
+		int width,
+		Func<int, T> paddingSelector
+	) : CollectionIterator<T>
 	{
-		private readonly IEnumerable<T> _source;
-		private readonly int _width;
-		private readonly Func<int, T> _paddingSelector;
-
-		public PadCollectionIterator(
-			IEnumerable<T> source, int width,
-			Func<int, T> paddingSelector)
-		{
-			_source = source;
-			_width = width;
-			_paddingSelector = paddingSelector;
-		}
-
-		public override int Count => Math.Max(_source.GetCollectionCount(), _width);
+		public override int Count => Math.Max(source.GetCollectionCount(), width);
 
 		protected override IEnumerable<T> GetEnumerable() =>
-			PadCore(_source, _width, _paddingSelector);
+			PadCore(source, width, paddingSelector);
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
@@ -153,37 +144,29 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			var cnt = _source.CopyTo(array, arrayIndex);
+			var cnt = source.CopyTo(array, arrayIndex);
 
-			for (var i = cnt; i < _width; i++)
-				array[arrayIndex + i] = _paddingSelector(i);
+			for (var i = cnt; i < width; i++)
+				array[arrayIndex + i] = paddingSelector(i);
 		}
 	}
 
-	private sealed class PadListIterator<T> : ListIterator<T>
+	private sealed class PadListIterator<T>(
+		IList<T> source,
+		int width, Func<int, T> paddingSelector
+	) : ListIterator<T>
 	{
-		private readonly IList<T> _source;
-		private readonly int _width;
-		private readonly Func<int, T> _paddingSelector;
-
-		public PadListIterator(IList<T> source, int width, Func<int, T> paddingSelector)
-		{
-			_source = source;
-			_width = width;
-			_paddingSelector = paddingSelector;
-		}
-
-		public override int Count => Math.Max(_source.Count, _width);
+		public override int Count => Math.Max(source.Count, width);
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var src = _source;
+			var src = source;
 			var cnt = (uint)src.Count;
 			for (var i = 0; i < cnt; i++)
 				yield return src[i];
 
-			for (var i = (int)cnt; i < _width; i++)
-				yield return _paddingSelector(i);
+			for (var i = (int)cnt; i < width; i++)
+				yield return paddingSelector(i);
 		}
 
 		public override void CopyTo(T[] array, int arrayIndex)
@@ -192,10 +175,10 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			_source.CopyTo(array, arrayIndex);
+			source.CopyTo(array, arrayIndex);
 
-			for (var i = _source.Count; i < _width; i++)
-				array[arrayIndex + i] = _paddingSelector(i);
+			for (var i = source.Count; i < width; i++)
+				array[arrayIndex + i] = paddingSelector(i);
 		}
 
 		protected override T ElementAt(int index)
@@ -203,9 +186,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return index < _source.Count
-				? _source[index]
-				: _paddingSelector(index);
+			return index < source.Count
+				? source[index]
+				: paddingSelector(index);
 		}
 	}
 }

--- a/Source/SuperLinq/PadStart.cs
+++ b/Source/SuperLinq/PadStart.cs
@@ -144,29 +144,20 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class PadStartCollectionIterator<T> : CollectionIterator<T>
+	private sealed class PadStartCollectionIterator<T>(
+		IEnumerable<T> source,
+		int width,
+		Func<int, T> paddingSelector
+	) : CollectionIterator<T>
 	{
-		private readonly IEnumerable<T> _source;
-		private readonly int _width;
-		private readonly Func<int, T> _paddingSelector;
-
-		public PadStartCollectionIterator(
-			IEnumerable<T> source, int width,
-			Func<int, T> paddingSelector)
-		{
-			_source = source;
-			_width = width;
-			_paddingSelector = paddingSelector;
-		}
-
-		public override int Count => Math.Max(_source.GetCollectionCount(), _width);
+		public override int Count => Math.Max(source.GetCollectionCount(), width);
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var cnt = _width - _source.GetCollectionCount();
+			var cnt = width - source.GetCollectionCount();
 			for (var i = 0; i < cnt; i++)
-				yield return _paddingSelector(i);
-			foreach (var item in _source)
+				yield return paddingSelector(i);
+			foreach (var item in source)
 				yield return item;
 		}
 
@@ -176,36 +167,29 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			var offset = Math.Max(_width - _source.GetCollectionCount(), 0);
+			var offset = Math.Max(width - source.GetCollectionCount(), 0);
 			for (var i = 0; i < offset; i++)
-				array[arrayIndex + i] = _paddingSelector(i);
+				array[arrayIndex + i] = paddingSelector(i);
 
-			_ = _source.CopyTo(array, arrayIndex + offset);
+			_ = source.CopyTo(array, arrayIndex + offset);
 		}
 	}
 
-	private sealed class PadStartListIterator<T> : ListIterator<T>
+	private sealed class PadStartListIterator<T>(
+		IList<T> source,
+		int width,
+		Func<int, T> paddingSelector
+	) : ListIterator<T>
 	{
-		private readonly IList<T> _source;
-		private readonly int _width;
-		private readonly Func<int, T> _paddingSelector;
-
-		public PadStartListIterator(IList<T> source, int width, Func<int, T> paddingSelector)
-		{
-			_source = source;
-			_width = width;
-			_paddingSelector = paddingSelector;
-		}
-
-		public override int Count => Math.Max(_source.Count, _width);
+		public override int Count => Math.Max(source.Count, width);
 
 		protected override IEnumerable<T> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count;
-			for (var i = 0; i < _width - cnt; i++)
-				yield return _paddingSelector(i);
+			var cnt = (uint)source.Count;
+			for (var i = 0; i < width - cnt; i++)
+				yield return paddingSelector(i);
 			for (var i = 0; i < cnt; i++)
-				yield return _source[i];
+				yield return source[i];
 		}
 
 		public override void CopyTo(T[] array, int arrayIndex)
@@ -214,11 +198,11 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			var offset = Math.Max(_width - _source.Count, 0);
+			var offset = Math.Max(width - source.Count, 0);
 			for (var i = 0; i < offset; i++)
-				array[arrayIndex + i] = _paddingSelector(i);
+				array[arrayIndex + i] = paddingSelector(i);
 
-			_source.CopyTo(array, arrayIndex + offset);
+			source.CopyTo(array, arrayIndex + offset);
 		}
 
 		protected override T ElementAt(int index)
@@ -226,10 +210,10 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var offset = Math.Max(_width - _source.Count, 0);
+			var offset = Math.Max(width - source.Count, 0);
 			return index < offset
-				? _paddingSelector(index)
-				: _source[index - offset];
+				? paddingSelector(index)
+				: source[index - offset];
 		}
 	}
 }

--- a/Source/SuperLinq/Publish.cs
+++ b/Source/SuperLinq/Publish.cs
@@ -27,7 +27,7 @@ public static partial class SuperEnumerable
 	///	    A separate buffer will be maintained for each <see cref="IEnumerator{T}"/> created from the returned <see
 	///	    cref="IEnumerable{T}"/>. This buffer will be maintained until the enumerator is disposed, and will contain
 	///	    all elements returned by <paramref name="source"/> from the time that the <see cref="IEnumerator{T}"/> is
-	///	    created.  
+	///	    created.
 	/// </para>
 	/// <para>
 	///	    This operator uses deferred execution and streams its result.
@@ -40,11 +40,13 @@ public static partial class SuperEnumerable
 		return new PublishBuffer<TSource>(source);
 	}
 
-	private sealed class PublishBuffer<T> : IBuffer<T>
+	private sealed class PublishBuffer<T>(
+		IEnumerable<T> source
+	) : IBuffer<T>
 	{
 		private readonly object _lock = new();
 
-		private IEnumerable<T>? _source;
+		private IEnumerable<T>? _source = source;
 
 		private IEnumerator<T>? _enumerator;
 		private List<Queue<T>>? _buffers;
@@ -55,11 +57,6 @@ public static partial class SuperEnumerable
 		private bool? _exceptionOnGetEnumerator;
 
 		private bool _disposed;
-
-		public PublishBuffer(IEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => _buffers?.Count > 0 ? _buffers.Max(x => x.Count) : 0;
 

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -1,4 +1,6 @@
-﻿namespace SuperLinq;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {
@@ -135,17 +137,19 @@ public static partial class SuperEnumerable
 		Index index
 	) : ListIterator<TSource>
 	{
+		private readonly IList<TSource> _source = source;
+		private readonly TSource _value = value;
 		private readonly Index _index = index;
 
-		public override int Count => source.Count;
+		public override int Count => _source.Count;
 
 		protected override IEnumerable<TSource> GetEnumerable()
 		{
-			var cnt = (uint)source.Count;
-			var idx = _index.GetOffset(source.Count);
+			var cnt = (uint)_source.Count;
+			var idx = _index.GetOffset(_source.Count);
 
 			for (var i = 0; i < cnt; i++)
-				yield return i == idx ? value : source[i];
+				yield return i == idx ? _value : _source[i];
 		}
 
 		public override void CopyTo(TSource[] array, int arrayIndex)
@@ -154,11 +158,11 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			source.CopyTo(array, arrayIndex);
+			_source.CopyTo(array, arrayIndex);
 
-			var idx = _index.GetOffset(source.Count);
-			if (idx >= 0 && idx < source.Count)
-				array[arrayIndex + idx] = value;
+			var idx = _index.GetOffset(_source.Count);
+			if (idx >= 0 && idx < _source.Count)
+				array[arrayIndex + idx] = _value;
 		}
 
 		protected override TSource ElementAt(int index)
@@ -166,9 +170,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return index == _index.GetOffset(source.Count)
-				? value
-				: source[index];
+			return index == _index.GetOffset(_source.Count)
+				? _value
+				: _source[index];
 		}
 	}
 }

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -135,12 +135,14 @@ public static partial class SuperEnumerable
 		Index index
 	) : ListIterator<TSource>
 	{
+		private readonly Index _index = index;
+
 		public override int Count => source.Count;
 
 		protected override IEnumerable<TSource> GetEnumerable()
 		{
 			var cnt = (uint)source.Count;
-			var idx = index.GetOffset(source.Count);
+			var idx = _index.GetOffset(source.Count);
 
 			for (var i = 0; i < cnt; i++)
 				yield return i == idx ? value : source[i];
@@ -154,19 +156,19 @@ public static partial class SuperEnumerable
 
 			source.CopyTo(array, arrayIndex);
 
-			var idx = index.GetOffset(source.Count);
+			var idx = _index.GetOffset(source.Count);
 			if (idx >= 0 && idx < source.Count)
 				array[arrayIndex + idx] = value;
 		}
 
-		protected override TSource ElementAt(int index1)
+		protected override TSource ElementAt(int index)
 		{
-			ArgumentOutOfRangeException.ThrowIfNegative(index1);
-			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index1, Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(index);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return index1 == index.GetOffset(source.Count)
+			return index == _index.GetOffset(source.Count)
 				? value
-				: source[index1];
+				: source[index];
 		}
 	}
 }

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace SuperLinq;
+﻿namespace SuperLinq;
 
 public static partial class SuperEnumerable
 {

--- a/Source/SuperLinq/Replace.cs
+++ b/Source/SuperLinq/Replace.cs
@@ -129,28 +129,21 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class ReplaceIterator<TSource> : ListIterator<TSource>
+	private sealed class ReplaceIterator<TSource>(
+		IList<TSource> source,
+		TSource value,
+		Index index
+	) : ListIterator<TSource>
 	{
-		private readonly IList<TSource> _source;
-		private readonly TSource _value;
-		private readonly Index _index;
-
-		public ReplaceIterator(IList<TSource> source, TSource value, Index index)
-		{
-			_source = source;
-			_value = value;
-			_index = index;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<TSource> GetEnumerable()
 		{
-			var cnt = (uint)_source.Count;
-			var idx = _index.GetOffset(_source.Count);
+			var cnt = (uint)source.Count;
+			var idx = index.GetOffset(source.Count);
 
 			for (var i = 0; i < cnt; i++)
-				yield return i == idx ? _value : _source[i];
+				yield return i == idx ? value : source[i];
 		}
 
 		public override void CopyTo(TSource[] array, int arrayIndex)
@@ -159,21 +152,21 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			_source.CopyTo(array, arrayIndex);
+			source.CopyTo(array, arrayIndex);
 
-			var idx = _index.GetOffset(_source.Count);
-			if (idx >= 0 && idx < _source.Count)
-				array[arrayIndex + idx] = _value;
+			var idx = index.GetOffset(source.Count);
+			if (idx >= 0 && idx < source.Count)
+				array[arrayIndex + idx] = value;
 		}
 
-		protected override TSource ElementAt(int index)
+		protected override TSource ElementAt(int index1)
 		{
-			ArgumentOutOfRangeException.ThrowIfNegative(index);
-			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+			ArgumentOutOfRangeException.ThrowIfNegative(index1);
+			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index1, Count);
 
-			return index == _index.GetOffset(_source.Count)
-				? _value
-				: _source[index];
+			return index1 == index.GetOffset(source.Count)
+				? value
+				: source[index1];
 		}
 	}
 }

--- a/Source/SuperLinq/Return.cs
+++ b/Source/SuperLinq/Return.cs
@@ -19,28 +19,26 @@ public partial class SuperEnumerable
 	public static IEnumerable<T> Return<T>(T item) =>
 		new SingleElementList<T>(item);
 
-	private sealed class SingleElementList<T> : IList<T>, IReadOnlyList<T>
+	private sealed class SingleElementList<T>(
+		T item
+	) : IList<T>, IReadOnlyList<T>
 	{
-		private readonly T _item;
-
-		public SingleElementList(T item) => _item = item;
-
 		public int Count => 1;
 		public bool IsReadOnly => true;
 
 		public T this[int index]
 		{
-			get => index == 0 ? _item : ThrowHelper.ThrowArgumentOutOfRangeException<T>(nameof(index));
+			get => index == 0 ? item : ThrowHelper.ThrowArgumentOutOfRangeException<T>(nameof(index));
 			set => throw ReadOnlyException();
 		}
 
-		public IEnumerator<T> GetEnumerator() { yield return _item; }
+		public IEnumerator<T> GetEnumerator() { yield return item; }
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 		public int IndexOf(T item) => Contains(item) ? 0 : -1;
-		public bool Contains(T item) => EqualityComparer<T>.Default.Equals(_item, item);
+		public bool Contains(T item1) => EqualityComparer<T>.Default.Equals(item, item1);
 
-		public void CopyTo(T[] array, int arrayIndex) => array[arrayIndex] = _item;
+		public void CopyTo(T[] array, int arrayIndex) => array[arrayIndex] = item;
 
 		// Following methods are unsupported as this is a read-only list.
 

--- a/Source/SuperLinq/ReverseComparer.cs
+++ b/Source/SuperLinq/ReverseComparer.cs
@@ -1,12 +1,9 @@
 ﻿namespace SuperLinq;
 
-internal sealed class ReverseComparer<T> : IComparer<T>
+internal sealed class ReverseComparer<T>(
+	IComparer<T> underlying
+) : IComparer<T>
 {
-	private readonly IComparer<T> _underlying;
-
-	public ReverseComparer(IComparer<T> underlying) =>
-		_underlying = underlying;
-
 	public int Compare(T? x, T? y) =>
-		-_underlying.Compare(x, y);
+		-underlying.Compare(x, y);
 }

--- a/Source/SuperLinq/ScanRight.cs
+++ b/Source/SuperLinq/ScanRight.cs
@@ -28,7 +28,7 @@ public static partial class SuperEnumerable
 	/// <remarks>
 	/// <para>
 	///	    This method is implemented by using deferred execution. However, <paramref name="source"/> will be consumed
-	///     in it's entirety immediately when first element of the returned sequence is consumed. 
+	///     in it's entirety immediately when first element of the returned sequence is consumed.
 	/// </para>
 	/// </remarks>
 	public static IEnumerable<TSource> ScanRight<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
@@ -63,22 +63,16 @@ public static partial class SuperEnumerable
 			yield return item;
 	}
 
-	private sealed class ScanRightIterator<T> : CollectionIterator<T>
+	private sealed class ScanRightIterator<T>(
+		ICollection<T> source,
+		Func<T, T, T> func
+	) : CollectionIterator<T>
 	{
-		private readonly ICollection<T> _source;
-		private readonly Func<T, T, T> _func;
-
-		public ScanRightIterator(ICollection<T> source, Func<T, T, T> func)
-		{
-			_source = source;
-			_func = func;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		[ExcludeFromCodeCoverage]
 		protected override IEnumerable<T> GetEnumerable() =>
-			ScanRightCore(_source, _func);
+			ScanRightCore(source, func);
 
 		public override void CopyTo(T[] array, int arrayIndex)
 		{
@@ -86,9 +80,9 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 			ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
-			var (sList, b, cnt) = _source is IList<T> s
+			var (sList, b, cnt) = source is IList<T> s
 				? (s, 0, s.Count)
-				: (array, arrayIndex, SuperEnumerable.CopyTo(_source, array, arrayIndex));
+				: (array, arrayIndex, SuperEnumerable.CopyTo(source, array, arrayIndex));
 
 			var i = cnt - 1;
 			var state = sList[b + i];
@@ -96,7 +90,7 @@ public static partial class SuperEnumerable
 
 			for (i--; i >= 0; i--)
 			{
-				state = _func(sList[b + i], state);
+				state = func(sList[b + i], state);
 				array[arrayIndex + i] = state;
 			}
 		}
@@ -132,7 +126,7 @@ public static partial class SuperEnumerable
 	/// <remarks>
 	/// <para>
 	///	    This method is implemented by using deferred execution. However, <paramref name="source"/> will be consumed
-	///     in it's entirety immediately when first element of the returned sequence is consumed. 
+	///     in it's entirety immediately when first element of the returned sequence is consumed.
 	/// </para>
 	/// </remarks>
 	public static IEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)

--- a/Source/SuperLinq/Sequence.cs
+++ b/Source/SuperLinq/Sequence.cs
@@ -96,28 +96,21 @@ public static partial class SuperEnumerable
 		return new SequenceIterator(start, step, (((long)stop - start) / step) + 1);
 	}
 
-	private sealed class SequenceIterator : ListIterator<int>
+	private sealed class SequenceIterator(
+		int start,
+		int step,
+		long count
+	) : ListIterator<int>
 	{
-		private readonly int _start;
-		private readonly int _step;
-		private readonly long _count;
-
-		public SequenceIterator(int start, int step, long count)
-		{
-			_start = start;
-			_step = step;
-			_count = count;
-		}
-
-		public override int Count => _count <= int.MaxValue ? (int)_count : int.MaxValue;
+		public override int Count => count <= int.MaxValue ? (int)count : int.MaxValue;
 
 		protected override IEnumerable<int> GetEnumerable()
 		{
-			var value = _start;
+			var value = start;
 			for (var i = 0; i < Count; i++)
 			{
 				yield return value;
-				value += _step;
+				value += step;
 			}
 		}
 
@@ -126,7 +119,7 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _start + (_step * index);
+			return start + (step * index);
 		}
 	}
 }

--- a/Source/SuperLinq/Share.cs
+++ b/Source/SuperLinq/Share.cs
@@ -33,11 +33,13 @@ public static partial class SuperEnumerable
 		return new SharedBuffer<TSource>(source);
 	}
 
-	private sealed class SharedBuffer<T> : IBuffer<T>
+	private sealed class SharedBuffer<T>(
+		IEnumerable<T> source
+	) : IBuffer<T>
 	{
 		private readonly object _lock = new();
 
-		private IEnumerable<T>? _source;
+		private IEnumerable<T>? _source = source;
 
 		private IEnumerator<T>? _enumerator;
 		private bool _initialized;
@@ -46,11 +48,6 @@ public static partial class SuperEnumerable
 		private ExceptionDispatchInfo? _exception;
 
 		private bool _disposed;
-
-		public SharedBuffer(IEnumerable<T> source)
-		{
-			_source = source;
-		}
 
 		public int Count => 0;
 

--- a/Source/SuperLinq/TagFirstLast.cs
+++ b/Source/SuperLinq/TagFirstLast.cs
@@ -86,36 +86,30 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private class TagFirstLastIterator<TSource, TResult> : ListIterator<TResult>
+	private class TagFirstLastIterator<TSource, TResult>(
+		IList<TSource> source,
+		Func<TSource, bool, bool, TResult> resultSelector
+	) : ListIterator<TResult>
 	{
-		private readonly IList<TSource> _source;
-		private readonly Func<TSource, bool, bool, TResult> _resultSelector;
-
-		public TagFirstLastIterator(IList<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
-		{
-			_source = source;
-			_resultSelector = resultSelector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<TResult> GetEnumerable()
 		{
-			if (_source.Count <= 1)
+			if (source.Count <= 1)
 			{
-				if (_source.Count == 1)
-					yield return _resultSelector(_source[0], true, true);
+				if (source.Count == 1)
+					yield return resultSelector(source[0], true, true);
 				yield break;
 			}
 
-			yield return _resultSelector(_source[0], true, false);
+			yield return resultSelector(source[0], true, false);
 
-			var cnt = (uint)_source.Count - 1;
+			var cnt = (uint)source.Count - 1;
 
 			for (var i = 1; i < cnt; i++)
-				yield return _resultSelector(_source[i], false, false);
+				yield return resultSelector(source[i], false, false);
 
-			yield return _resultSelector(_source[^1], false, true);
+			yield return resultSelector(source[^1], false, true);
 		}
 
 		protected override TResult ElementAt(int index)
@@ -123,7 +117,7 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			return _resultSelector(_source[index], index == 0, index == _source.Count - 1);
+			return resultSelector(source[index], index == 0, index == source.Count - 1);
 		}
 	}
 }

--- a/Source/SuperLinq/ValueTupleComparer.cs
+++ b/Source/SuperLinq/ValueTupleComparer.cs
@@ -37,18 +37,13 @@ internal static class ValueTupleComparer
 			comparer1,
 			comparer2);
 
-	private sealed class Comparer<T1, T2> : IComparer<(T1, T2)>
+	private sealed class Comparer<T1, T2>(
+		IComparer<T1>? comparer1,
+		IComparer<T2>? comparer2
+	) : IComparer<(T1, T2)>
 	{
-		private readonly IComparer<T1> _comparer1;
-		private readonly IComparer<T2> _comparer2;
-
-		public Comparer(
-			IComparer<T1>? comparer1,
-			IComparer<T2>? comparer2)
-		{
-			_comparer1 = comparer1 ?? Comparer<T1>.Default;
-			_comparer2 = comparer2 ?? Comparer<T2>.Default;
-		}
+		private readonly IComparer<T1> _comparer1 = comparer1 ?? Comparer<T1>.Default;
+		private readonly IComparer<T2> _comparer2 = comparer2 ?? Comparer<T2>.Default;
 
 		public int Compare([AllowNull] (T1, T2) x, [AllowNull] (T1, T2) y)
 		{

--- a/Source/SuperLinq/ValueTupleEqualityComparer.cs
+++ b/Source/SuperLinq/ValueTupleEqualityComparer.cs
@@ -27,15 +27,11 @@ internal static class ValueTupleEqualityComparer
 			? EqualityComparer<ValueTuple<T1>>.Default
 			: new ItemEqualityComparer<T1>(comparer1);
 
-	private sealed class ItemEqualityComparer<T1> : IEqualityComparer<ValueTuple<T1>>
+	private sealed class ItemEqualityComparer<T1>(
+		IEqualityComparer<T1>? comparer1
+	) : IEqualityComparer<ValueTuple<T1>>
 	{
-		private readonly IEqualityComparer<T1> _comparer1;
-
-		public ItemEqualityComparer(
-			IEqualityComparer<T1>? comparer1)
-		{
-			_comparer1 = comparer1 ?? EqualityComparer<T1>.Default;
-		}
+		private readonly IEqualityComparer<T1> _comparer1 = comparer1 ?? EqualityComparer<T1>.Default;
 
 		public bool Equals(ValueTuple<T1> x,
 						   ValueTuple<T1> y)
@@ -74,18 +70,13 @@ internal static class ValueTupleEqualityComparer
 			comparer1,
 			comparer2);
 
-	private sealed class ItemEqualityComparer<T1, T2> : IEqualityComparer<(T1, T2)>
+	private sealed class ItemEqualityComparer<T1, T2>(
+		IEqualityComparer<T1>? comparer1,
+		IEqualityComparer<T2>? comparer2
+	) : IEqualityComparer<(T1, T2)>
 	{
-		private readonly IEqualityComparer<T1> _comparer1;
-		private readonly IEqualityComparer<T2> _comparer2;
-
-		public ItemEqualityComparer(
-			IEqualityComparer<T1>? comparer1,
-			IEqualityComparer<T2>? comparer2)
-		{
-			_comparer1 = comparer1 ?? EqualityComparer<T1>.Default;
-			_comparer2 = comparer2 ?? EqualityComparer<T2>.Default;
-		}
+		private readonly IEqualityComparer<T1> _comparer1 = comparer1 ?? EqualityComparer<T1>.Default;
+		private readonly IEqualityComparer<T2> _comparer2 = comparer2 ?? EqualityComparer<T2>.Default;
 
 		public bool Equals((T1, T2) x,
 						   (T1, T2) y)

--- a/Source/SuperLinq/Window.cs
+++ b/Source/SuperLinq/Window.cs
@@ -67,35 +67,29 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class WindowIterator<T> : ListIterator<IList<T>>
+	private sealed class WindowIterator<T>(
+		IList<T> source,
+		int size
+	) : ListIterator<IList<T>>
 	{
-		private readonly IList<T> _source;
-		private readonly int _size;
-
-		public WindowIterator(IList<T> source, int size)
-		{
-			_source = source;
-			_size = size;
-		}
-
-		public override int Count => Math.Max(_source.Count - _size + 1, 0);
+		public override int Count => Math.Max(source.Count - size + 1, 0);
 
 		protected override IEnumerable<IList<T>> GetEnumerable()
 		{
-			if (Count < _size)
+			if (Count < size)
 				yield break;
 
-			var window = new T[_size];
+			var window = new T[size];
 
-			for (var i = 0; i < _size; i++)
-				window[i] = _source[i];
+			for (var i = 0; i < size; i++)
+				window[i] = source[i];
 
-			var count = (uint)_source.Count;
-			for (var i = _size; i < count; i++)
+			var count = (uint)source.Count;
+			for (var i = size; i < count; i++)
 			{
-				var newWindow = new T[_size];
+				var newWindow = new T[size];
 				window.AsSpan()[1..].CopyTo(newWindow);
-				newWindow[^1] = _source[i];
+				newWindow[^1] = source[i];
 
 				yield return window;
 				window = newWindow;
@@ -109,10 +103,10 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var arr = new T[_size];
-			var max = (uint)(index + _size);
-			for (int i = 0, j = index; i < _size && j < max; i++, j++)
-				arr[i] = _source[j];
+			var arr = new T[size];
+			var max = (uint)(index + size);
+			for (int i = 0, j = index; i < size && j < max; i++, j++)
+				arr[i] = source[j];
 
 			return arr;
 		}

--- a/Source/SuperLinq/WindowLeft.cs
+++ b/Source/SuperLinq/WindowLeft.cs
@@ -85,40 +85,34 @@ skipLoop:
 		}
 	}
 
-	private sealed class WindowLeftIterator<T> : ListIterator<IList<T>>
+	private sealed class WindowLeftIterator<T>(
+		IList<T> source,
+		int size
+	) : ListIterator<IList<T>>
 	{
-		private readonly IList<T> _source;
-		private readonly int _size;
-
-		public WindowLeftIterator(IList<T> source, int size)
-		{
-			_source = source;
-			_size = size;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<IList<T>> GetEnumerable()
 		{
 			T[] window;
 
-			if (_source.Count == 0)
+			if (source.Count == 0)
 			{
 				yield break;
 			}
-			else if (_source.Count > _size)
+			else if (source.Count > size)
 			{
-				window = new T[_size];
+				window = new T[size];
 
-				for (var i = 0; i < _size; i++)
-					window[i] = _source[i];
+				for (var i = 0; i < size; i++)
+					window[i] = source[i];
 
-				var count = (uint)_source.Count;
-				for (var i = _size; i < count; i++)
+				var count = (uint)source.Count;
+				for (var i = size; i < count; i++)
 				{
-					var newWindow = new T[_size];
+					var newWindow = new T[size];
 					window.AsSpan()[1..].CopyTo(newWindow);
-					newWindow[^1] = _source[i];
+					newWindow[^1] = source[i];
 
 					yield return window;
 					window = newWindow;
@@ -126,7 +120,7 @@ skipLoop:
 			}
 			else
 			{
-				window = _source.ToArray();
+				window = source.ToArray();
 			}
 
 			while (window.Length > 1)
@@ -146,21 +140,21 @@ skipLoop:
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			if (index < _source.Count - _size)
+			if (index < source.Count - size)
 			{
-				var arr = new T[_size];
-				var max = (uint)(index + _size);
-				for (int i = 0, j = index; i < _size && j < max; i++, j++)
-					arr[i] = _source[j];
+				var arr = new T[size];
+				var max = (uint)(index + size);
+				for (int i = 0, j = index; i < size && j < max; i++, j++)
+					arr[i] = source[j];
 
 				return arr;
 			}
 			else
 			{
-				var arr = new T[_source.Count - index];
-				var max = (uint)_source.Count;
+				var arr = new T[source.Count - index];
+				var max = (uint)source.Count;
 				for (int i = 0, j = index; i < arr.Length && j < max; i++, j++)
-					arr[i] = _source[j];
+					arr[i] = source[j];
 				return arr;
 			}
 		}

--- a/Source/SuperLinq/WindowRight.cs
+++ b/Source/SuperLinq/WindowRight.cs
@@ -80,44 +80,38 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class WindowRightIterator<T> : ListIterator<IList<T>>
+	private sealed class WindowRightIterator<T>(
+		IList<T> source,
+		int size
+	) : ListIterator<IList<T>>
 	{
-		private readonly IList<T> _source;
-		private readonly int _size;
-
-		public WindowRightIterator(IList<T> source, int size)
-		{
-			_source = source;
-			_size = size;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<IList<T>> GetEnumerable()
 		{
-			if (_source.Count == 0)
+			if (source.Count == 0)
 			{
 				yield break;
 			}
 
-			var window = new T[1] { _source[0], };
-			var max = (uint)Math.Min(_source.Count, _size);
+			var window = new T[1] { source[0], };
+			var max = (uint)Math.Min(source.Count, size);
 			for (var i = 1; i < max; i++)
 			{
 				var newWindow = new T[i + 1];
 				window.AsSpan()[..].CopyTo(newWindow);
-				newWindow[^1] = _source[i];
+				newWindow[^1] = source[i];
 
 				yield return window;
 				window = newWindow;
 			}
 
-			max = (uint)_source.Count;
+			max = (uint)source.Count;
 			for (var i = window.Length; i < max; i++)
 			{
-				var newWindow = new T[_size];
+				var newWindow = new T[size];
 				window.AsSpan()[1..].CopyTo(newWindow);
-				newWindow[^1] = _source[i];
+				newWindow[^1] = source[i];
 
 				yield return window;
 				window = newWindow;
@@ -131,21 +125,21 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			if (index < _size)
+			if (index < size)
 			{
 				var arr = new T[index];
 				var max = (uint)index;
 				for (var i = 0; i < max; i++)
-					arr[i] = _source[i];
+					arr[i] = source[i];
 
 				return arr;
 			}
 			else
 			{
-				var arr = new T[_size];
+				var arr = new T[size];
 				var max = (uint)index + 1;
-				for (int i = 0, j = index - _size + 1; i < arr.Length && j < max; i++, j++)
-					arr[i] = _source[j];
+				for (int i = 0, j = index - size + 1; i < arr.Length && j < max; i++, j++)
+					arr[i] = source[j];
 				return arr;
 			}
 		}

--- a/Source/SuperLinq/ZipMap.cs
+++ b/Source/SuperLinq/ZipMap.cs
@@ -47,27 +47,21 @@ public static partial class SuperEnumerable
 		}
 	}
 
-	private sealed class ZipMapIterator<TSource, TResult> : ListIterator<(TSource, TResult)>
+	private sealed class ZipMapIterator<TSource, TResult>(
+		IList<TSource> source,
+		Func<TSource, TResult> selector
+	) : ListIterator<(TSource, TResult)>
 	{
-		private readonly IList<TSource> _source;
-		private readonly Func<TSource, TResult> _selector;
-
-		public ZipMapIterator(IList<TSource> source, Func<TSource, TResult> selector)
-		{
-			_source = source;
-			_selector = selector;
-		}
-
-		public override int Count => _source.Count;
+		public override int Count => source.Count;
 
 		protected override IEnumerable<(TSource, TResult)> GetEnumerable()
 		{
-			var src = _source;
+			var src = source;
 			var cnt = (uint)src.Count;
 			for (var i = 0; i < cnt; i++)
 			{
 				var el = src[i];
-				yield return (el, _selector(el));
+				yield return (el, selector(el));
 			}
 		}
 
@@ -76,8 +70,8 @@ public static partial class SuperEnumerable
 			ArgumentOutOfRangeException.ThrowIfNegative(index);
 			ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-			var el = _source[index];
-			return (el, _selector(el));
+			var el = source[index];
+			return (el, selector(el));
 		}
 	}
 }

--- a/Tests/SuperLinq.Async.Test/TestingSequence.cs
+++ b/Tests/SuperLinq.Async.Test/TestingSequence.cs
@@ -56,10 +56,7 @@ internal static class TestingSequence
 	}
 }
 
-public class TestingSequenceException : Exception
-{
-	public TestingSequenceException(string message) : base(message) { }
-}
+public class TestingSequenceException(string message) : Exception(message);
 
 /// <summary>
 /// Sequence that asserts whether its iterator has been disposed

--- a/Tests/SuperLinq.Async.Test/TraverseTest.cs
+++ b/Tests/SuperLinq.Async.Test/TraverseTest.cs
@@ -33,16 +33,13 @@ public class TraverseTest
 		await res.AssertSequenceEqual(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	}
 
-	private class Tree<T>
+	private class Tree<T>(
+		T value,
+		IEnumerable<Tree<T>> children
+	)
 	{
-		public T Value { get; }
-		public IEnumerable<Tree<T>> Children { get; }
-
-		public Tree(T value, IEnumerable<Tree<T>> children)
-		{
-			Value = value;
-			Children = children;
-		}
+		public T Value { get; } = value;
+		public IEnumerable<Tree<T>> Children { get; } = children;
 	}
 
 	private static class Tree

--- a/Tests/SuperLinq.Test/EqualityComparer.cs
+++ b/Tests/SuperLinq.Test/EqualityComparer.cs
@@ -8,19 +8,16 @@ internal static class EqualityComparer
 	public static IEqualityComparer<T> Create<T>(Func<T, T, bool> comparer, Func<T, int> hasher) =>
 		new DelegatingComparer<T>(comparer, hasher);
 
-	private sealed class DelegatingComparer<T> : IEqualityComparer<T>
+	private sealed class DelegatingComparer<T>(
+		Func<T, T, bool> comparer,
+		Func<T, int> hasher
+	) : IEqualityComparer<T>
 	{
-		private readonly Func<T, T, bool> _comparer;
-		private readonly Func<T, int> _hasher;
+		private readonly Func<T, T, bool> _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+		private readonly Func<T, int> _hasher = hasher ?? throw new ArgumentNullException(nameof(hasher));
 
 		public DelegatingComparer(Func<T, T, bool> comparer)
 			: this(comparer, x => x == null ? 0 : x.GetHashCode()) { }
-
-		public DelegatingComparer(Func<T, T, bool> comparer, Func<T, int> hasher)
-		{
-			_comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-			_hasher = hasher ?? throw new ArgumentNullException(nameof(hasher));
-		}
 
 		public bool Equals(T? x, T? y) => _comparer(x!, y!);
 		public int GetHashCode(T obj) => _hasher(obj);

--- a/Tests/SuperLinq.Test/FlattenTest.cs
+++ b/Tests/SuperLinq.Test/FlattenTest.cs
@@ -343,18 +343,16 @@ public class FlattenTest
 		public int[] Values { get; init; } = [];
 	}
 
-	private class Tree<T>
+	private class Tree<T>(
+		Tree<T>? left,
+		T value,
+		Tree<T>? right
+	)
 	{
-		public readonly T Value;
-		public readonly Tree<T>? Left;
-		public readonly Tree<T>? Right;
+		public readonly T Value = value;
+		public readonly Tree<T>? Left = left;
+		public readonly Tree<T>? Right = right;
 
 		public Tree(T value) : this(null, value, null) { }
-		public Tree(Tree<T>? left, T value, Tree<T>? right)
-		{
-			Left = left;
-			Value = value;
-			Right = right;
-		}
 	}
 }

--- a/Tests/SuperLinq.Test/MemoizeTest.cs
+++ b/Tests/SuperLinq.Test/MemoizeTest.cs
@@ -443,20 +443,12 @@ public class MemoizeTest
 		Assert.Equal(42, memo.Count);
 	}
 
-	private class ProxyCollection : ICollection<int>
+	private class ProxyCollection(
+		Func<IEnumerator<int>> enumeratorFunc,
+		Func<int> countFunc
+	) : ICollection<int>
 	{
-		private readonly Func<IEnumerator<int>> _enumeratorFunc;
-		private readonly Func<int> _countFunc;
-
-		public ProxyCollection(
-			Func<IEnumerator<int>> enumeratorFunc,
-			Func<int> countFunc)
-		{
-			_enumeratorFunc = enumeratorFunc;
-			_countFunc = countFunc;
-		}
-
-		public int Count => _countFunc();
+		public int Count => countFunc();
 
 		public void Add(int item) => throw new TestException();
 		public void Clear() => throw new TestException();
@@ -466,8 +458,8 @@ public class MemoizeTest
 
 		public virtual void CopyTo(int[] array, int arrayIndex) => throw new TestException();
 
-		public IEnumerator<int> GetEnumerator() => _enumeratorFunc();
-		IEnumerator IEnumerable.GetEnumerator() => _enumeratorFunc();
+		public IEnumerator<int> GetEnumerator() => enumeratorFunc();
+		IEnumerator IEnumerable.GetEnumerator() => enumeratorFunc();
 	}
 
 #if false

--- a/Tests/SuperLinq.Test/ReadOnlyCollection.cs
+++ b/Tests/SuperLinq.Test/ReadOnlyCollection.cs
@@ -7,12 +7,12 @@ internal static class ReadOnlyCollection
 	public static IReadOnlyCollection<T> From<T>(params T[] items) =>
 		new ListCollection<T[], T>(items);
 
-	private sealed class ListCollection<TList, T> : IReadOnlyCollection<T>
+	private sealed class ListCollection<TList, T>(
+		TList list
+	) : IReadOnlyCollection<T>
 		where TList : IList<T>
 	{
-		private readonly TList _list;
-
-		public ListCollection(TList list) => _list = list;
+		private readonly TList _list = list;
 
 		public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Tests/SuperLinq.Test/TestingSequence.cs
+++ b/Tests/SuperLinq.Test/TestingSequence.cs
@@ -48,10 +48,7 @@ internal static class TestingSequence
 	}
 }
 
-public class TestingSequenceException : Exception
-{
-	public TestingSequenceException(string message) : base(message) { }
-}
+public class TestingSequenceException(string message) : Exception(message);
 
 /// <summary>
 /// Sequence that asserts whether its iterator has been disposed

--- a/Tests/SuperLinq.Test/ToDataTableTest.cs
+++ b/Tests/SuperLinq.Test/ToDataTableTest.cs
@@ -5,29 +5,19 @@ namespace Test;
 
 public class ToDataTableTest
 {
-	private class TestObject
+	private class TestObject(int key)
 	{
-		public int _keyField;
-		public Guid? _aNullableGuidField;
+		public int _keyField = key;
+		public Guid? _aNullableGuidField = Guid.NewGuid();
 
-		public string AString { get; }
-		public decimal? ANullableDecimal { get; }
+		public string AString { get; } = "ABCDEFGHIKKLMNOPQRSTUVWXYSZ";
+		public decimal? ANullableDecimal { get; } = key / 3;
 		public object Unreadable { set => throw new NotImplementedException(); }
 
 		public object this[int index]
 		{
 			get => new();
 			set { }
-		}
-
-
-		public TestObject(int key)
-		{
-			_keyField = key;
-			_aNullableGuidField = Guid.NewGuid();
-
-			ANullableDecimal = key / 3;
-			AString = "ABCDEFGHIKKLMNOPQRSTUVWXYSZ";
 		}
 	}
 

--- a/Tests/SuperLinq.Test/TraverseTest.cs
+++ b/Tests/SuperLinq.Test/TraverseTest.cs
@@ -33,16 +33,13 @@ public class TraverseTest
 		res.AssertSequenceEqual(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	}
 
-	private class Tree<T>
+	private class Tree<T>(
+		T value,
+		IEnumerable<Tree<T>> children
+	)
 	{
-		public T Value { get; }
-		public IEnumerable<Tree<T>> Children { get; }
-
-		public Tree(T value, IEnumerable<Tree<T>> children)
-		{
-			Value = value;
-			Children = children;
-		}
+		public T Value { get; } = value;
+		public IEnumerable<Tree<T>> Children { get; } = children;
 	}
 
 	private static class Tree

--- a/Tests/SuperLinq.Test/TrySingleTest.cs
+++ b/Tests/SuperLinq.Test/TrySingleTest.cs
@@ -50,18 +50,15 @@ public class TrySingleTest
 		Assert.Equal(10, value);
 	}
 
-	private sealed class BreakingSingleElementCollection<T> : ICollection<T>
+	private sealed class BreakingSingleElementCollection<T>(
+		T element
+	) : ICollection<T>
 	{
-		private readonly T _element;
-
-		public BreakingSingleElementCollection(T element) =>
-			_element = element;
-
 		public int Count { get; } = 1;
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			yield return _element;
+			yield return element;
 			throw new InvalidOperationException($"{nameof(SuperEnumerable.TrySingle)} should not have attempted to consume a second element.");
 		}
 


### PR DESCRIPTION
resolves #611 

- Add primary ctor where possible.
- Turn [primary constructor warnings](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/constructor-errors#primary-constructor-declaration) into errors:

>  
    CS9107: Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well. This warning indicates that your code may be allocated two copies of a primary constructor parameter. Because the parameter is passed to the base class, the base class likely uses it. Because the derived class accesses it, it may have a second copy of the same parameter. That extra storage may not be intended.
    CS9113: Parameter is unread. This warning indicates that your class never references the primary constructor, even to pass it to the base primary constructor. It likely isn't needed.
    CS9124: Parameter is captured into the state of the enclosing type and its value is also used to initialize a field, property, or event. This warning indicates that the constructor parameter of a nested type is also captured by the enclosing type. The parameter is likely stored twice.
    CS9179: Primary constructor parameter is shadowed by a member from base


**Note**: There was a need to add a field in `Replace` and `Insert` in order to prevent a naming conflict between the `index` parameter of primary ctor and `ElementAt`.
