### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#618)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
       run: dotnet test -c Release --no-build --logger GitHubActions
 
     - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
This reverts commit 8fcdd111806fbbfaac68387f1a040301b122583e.

Codecov currently has issues uploading files with v4. Reverting for now. 

https://github.com/codecov/codecov-action/issues/1292