### PR TITLE
Add linqpad samples for new `XxxJoin` methods

### DIFF
--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FullOuterJoin.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.FullOuterJoin.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.FullOuterHashJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an full outer hash join of two sequences using `FullOuterHashJoin`.
+[!code-csharp[](SuperLinq/FullOuterHashJoin/FullOuterHashJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullOuterHashJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``3},System.Func{``1,``3},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an full outer hash join of two sequences using `FullOuterHashJoin`.
+[!code-csharp[](SuperLinq/FullOuterHashJoin/FullOuterHashJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullOuterMergeJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an full outer merge join of two sequences using `FullOuterMergeJoin`.
+[!code-csharp[](SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.FullOuterMergeJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``3},System.Func{``1,``3},System.Func{``0,``1,``3},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an full outer merge join of two sequences using `FullOuterMergeJoin`.
+[!code-csharp[](SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.InnerJoin.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.InnerJoin.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.InnerHashJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner hash join of two sequences using `InnerHashJoin`.
+[!code-csharp[](SuperLinq/InnerHashJoin/InnerHashJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.InnerHashJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner hash join of two sequences using `InnerHashJoin`.
+[!code-csharp[](SuperLinq/InnerHashJoin/InnerHashJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.InnerLoopJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner loop join of two sequences using `InnerLoopJoin`.
+[!code-csharp[](SuperLinq/InnerLoopJoin/InnerLoopJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.InnerLoopJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner loop join of two sequences using `InnerLoopJoin`.
+[!code-csharp[](SuperLinq/InnerLoopJoin/InnerLoopJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.InnerMergeJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner merge join of two sequences using `InnerMergeJoin`.
+[!code-csharp[](SuperLinq/InnerMergeJoin/InnerMergeJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.InnerMergeJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an inner merge join of two sequences using `InnerMergeJoin`.
+[!code-csharp[](SuperLinq/InnerMergeJoin/InnerMergeJoin2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.LeftOuterJoin.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.LeftOuterJoin.md
@@ -1,0 +1,41 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.LeftOuterHashJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer hash join of two sequences using `LeftOuterHashJoin`.
+[!code-csharp[](SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LeftOuterHashJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``3},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer hash join of two sequences using `LeftOuterHashJoin`.
+[!code-csharp[](SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LeftOuterLoopJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer loop join of two sequences using `LeftOuterLoopJoin`.
+[!code-csharp[](SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LeftOuterLoopJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``3},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer loop join of two sequences using `LeftOuterLoopJoin`.
+[!code-csharp[](SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LeftOuterMergeJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer merge join of two sequences using `LeftOuterMergeJoin`.
+[!code-csharp[](SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.LeftOuterMergeJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``3},System.Func{``0,``1,``3},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an left outer merge join of two sequences using `LeftOuterMergeJoin`.
+[!code-csharp[](SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RightOuterJoin.md
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq.SuperEnumerable.RightOuterJoin.md
@@ -1,0 +1,27 @@
+﻿---
+uid: SuperLinq.SuperEnumerable.RightOuterHashJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an right outer hash join of two sequences using `RightOuterHashJoin`.
+[!code-csharp[](SuperLinq/RightOuterHashJoin/RightOuterHashJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.RightOuterHashJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``1,``3},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an right outer hash join of two sequences using `RightOuterHashJoin`.
+[!code-csharp[](SuperLinq/RightOuterHashJoin/RightOuterHashJoin2.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.RightOuterMergeJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an right outer merge join of two sequences using `RightOuterMergeJoin`.
+[!code-csharp[](SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin1.linq#L6-)]
+
+---
+uid: SuperLinq.SuperEnumerable.RightOuterMergeJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``1,``3},System.Func{``0,``1,``3},System.Collections.Generic.IComparer{``2})
+example: [*content]
+---
+The following code example demonstrates how to execute an right outer merge join of two sequences using `RightOuterMergeJoin`.
+[!code-csharp[](SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin2.linq#L6-)]

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterHashJoin/FullOuterHashJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterHashJoin/FullOuterHashJoin1.linq
@@ -1,0 +1,50 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.FullOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person?.Name ?? "N/A"}, {pet?.Name ?? "No Pets"})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterHashJoin/FullOuterHashJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterHashJoin/FullOuterHashJoin2.linq
@@ -1,0 +1,51 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.FullOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		person => $"({person.Name}, No Pets)",
+		pet => $"(N/A, {pet.Name})",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin1.linq
@@ -1,0 +1,50 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.FullOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person?.Name ?? "N/A"}, {pet?.Name ?? "No Pets"})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/FullOuterMergeJoin/FullOuterMergeJoin2.linq
@@ -1,0 +1,51 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.FullOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId,
+		person => $"({person.Name}, No Pets)",
+		pet => $"(N/A, {pet.Name})",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerHashJoin/InnerHashJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerHashJoin/InnerHashJoin1.linq
@@ -1,0 +1,45 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.InnerHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet.Name})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerHashJoin/InnerHashJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerHashJoin/InnerHashJoin2.linq
@@ -1,0 +1,44 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.InnerHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerLoopJoin/InnerLoopJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerLoopJoin/InnerLoopJoin1.linq
@@ -1,0 +1,45 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.InnerLoopJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet.Name})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerLoopJoin/InnerLoopJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerLoopJoin/InnerLoopJoin2.linq
@@ -1,0 +1,44 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.InnerLoopJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerMergeJoin/InnerMergeJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerMergeJoin/InnerMergeJoin1.linq
@@ -1,0 +1,45 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.InnerMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet?.Name})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerMergeJoin/InnerMergeJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/InnerMergeJoin/InnerMergeJoin2.linq
@@ -1,0 +1,44 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.InnerMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId,
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin1.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.LeftOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet?.Name ?? "No Pets"})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterHashJoin/LeftOuterHashJoin2.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.LeftOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		person => $"({person.Name}, No Pets)",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin1.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.LeftOuterLoopJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet?.Name ?? "No Pets"})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterLoopJoin/LeftOuterLoopJoin2.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.LeftOuterLoopJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		person => $"({person.Name}, No Pets)",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin1.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.LeftOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person.Name}, {pet?.Name ?? "No Pets"})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/LeftOuterMergeJoin/LeftOuterMergeJoin2.linq
@@ -1,0 +1,49 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.LeftOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId,
+		person => $"({person.Name}, No Pets)",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Jane Doe, No Pets)
+// (Lucy Ricardo, No Pets)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (Fred Mertz, No Pets)
+// (Ethel Mertz, No Pets)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterHashJoin/RightOuterHashJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterHashJoin/RightOuterHashJoin1.linq
@@ -1,0 +1,46 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.RightOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person?.Name ?? "N/A"}, {pet.Name})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterHashJoin/RightOuterHashJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterHashJoin/RightOuterHashJoin2.linq
@@ -1,0 +1,46 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people
+	.RightOuterHashJoin(
+		pets,
+		p => p.PersonId,
+		p => p.PersonId,
+		pet => $"(N/A, {pet.Name})",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin1.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin1.linq
@@ -1,0 +1,46 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.RightOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId);
+
+foreach (var (person, pet) in results)
+{
+	Console.WriteLine($"({person?.Name ?? "N/A"}, {pet.Name})");
+}
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);

--- a/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin2.linq
+++ b/Docs/SuperLinq.Docs/apidoc/SuperLinq/RightOuterMergeJoin/RightOuterMergeJoin2.linq
@@ -1,0 +1,46 @@
+<Query Kind="Statements">
+  <NuGetReference>SuperLinq</NuGetReference>
+  <Namespace>SuperLinq</Namespace>
+</Query>
+
+var people = new Person[]
+{
+	new("John Doe", 1),
+	new("Jane Doe", 6),
+	new("Lucy Ricardo", 4),
+	new("Ricky Ricardo", 2),
+	new("Fred Mertz", 3),
+	new("Ethel Mertz", 5),
+};
+
+var pets = new Pet[]
+{
+	new("Bear", 8),
+	new("Polly", 2),
+	new("Minnie", 2),
+	new("Mittens", 1),
+	new("Patches", 1),
+	new("Paws", 1),
+};
+
+var results = people.OrderBy(p => p.PersonId)
+	.RightOuterMergeJoin(
+		pets.OrderBy(p => p.PersonId),
+		p => p.PersonId,
+		p => p.PersonId,
+		pet => $"(N/A, {pet.Name})",
+		(person, pet) => $"({person.Name}, {pet.Name})");
+
+foreach (var str in results)
+	Console.WriteLine(str);
+
+// This code produces the following output:
+// (John Doe, Mittens)
+// (John Doe, Patches)
+// (John Doe, Paws)
+// (Ricky Ricardo, Polly)
+// (Ricky Ricardo, Minnie)
+// (N/A, Bear)
+
+record Person(string Name, int PersonId);
+record Pet(string Name, int PersonId);


### PR DESCRIPTION
This PR adds missing linqpad samples for the InnerXxxJoin, LeftOuterXxxJoin, RightOuterXxxJoin, and FullOuterXxxJoin methods.

Fixes #594 