### PR TITLE
Adding unit tests for `ValueTupleComparer` and `ValueTupleEqualityComparer`

### DIFF
--- a/Source/SuperLinq/UnreachableException.cs
+++ b/Source/SuperLinq/UnreachableException.cs
@@ -1,7 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable IDE0130
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Diagnostics;
 
@@ -9,6 +11,7 @@ namespace System.Diagnostics;
 /// <summary>
 /// Exception thrown when the program executes an instruction that was thought to be unreachable.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public sealed class UnreachableException : Exception
 {
 	/// <summary>

--- a/Source/SuperLinq/UnreachableException.cs
+++ b/Source/SuperLinq/UnreachableException.cs
@@ -3,7 +3,9 @@
 
 #pragma warning disable IDE0130
 
+#if !NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace System.Diagnostics;
 

--- a/Tests/SuperLinq.Test/SuperLinq.Test.csproj
+++ b/Tests/SuperLinq.Test/SuperLinq.Test.csproj
@@ -14,6 +14,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\SuperLinq\SuperLinq.csproj" />
 		<Compile Include="..\..\Source\SuperLinq\ValueTupleEqualityComparer.cs" Link="ValueTupleEqualityComparer.cs" />
+		<Compile Include="..\..\Source\SuperLinq\ValueTupleComparer.cs" Link="ValueTupleComparer.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/SuperLinq.Test/ValueTupleComparerTest.cs
+++ b/Tests/SuperLinq.Test/ValueTupleComparerTest.cs
@@ -1,7 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Test;
 
 public class ValueTupleComparerTest
 {
+	private class TestComparer : IComparer<string>
+	{
+		public int Compare([AllowNull] string x, [AllowNull] string y)
+		{
+			var xLen = x?.Length ?? 0;
+			var yLen = y?.Length ?? 0;
+			return xLen.CompareTo(yLen);
+		}
+	}
+
 	[Fact]
 	public void ValueTupleComparerShouldCreateWithDefaultComparers()
 	{
@@ -20,5 +32,17 @@ public class ValueTupleComparerTest
 		ValueTuple<int, int> right = new(1, 2);
 		var result = comparer.Compare(left, right);
 		Assert.Equal(1, result);
+	}
+
+	[Fact]
+	public void ValueTupleComparerShouldAcceptCustomComparers()
+	{
+		TestComparer innerLeftComparer = new();
+		TestComparer innerRightComparer = new();
+		var comparer = ValueTupleComparer.Create(innerLeftComparer, innerRightComparer);
+		ValueTuple<string, string> left = new("123", "1");
+		ValueTuple<string, string> right = new("123", "123");
+		var result = comparer.Compare(left, right);
+		Assert.Equal(-1, result);
 	}
 }

--- a/Tests/SuperLinq.Test/ValueTupleComparerTest.cs
+++ b/Tests/SuperLinq.Test/ValueTupleComparerTest.cs
@@ -1,0 +1,24 @@
+namespace Test;
+
+public class ValueTupleComparerTest
+{
+	[Fact]
+	public void ValueTupleComparerShouldCreateWithDefaultComparers()
+	{
+		var comparer = ValueTupleComparer.Create<int, int>(null, null);
+		ValueTuple<int, int> left = new(1, 2);
+		ValueTuple<int, int> right = new(3, 4);
+		var result = comparer.Compare(left, right);
+		Assert.Equal(-1, result);
+	}
+
+	[Fact]
+	public void ValueTupleComparerShouldCheckSecondItemIfFirstIsZero()
+	{
+		var comparer = ValueTupleComparer.Create<int, int>(null, null);
+		ValueTuple<int, int> left = new(1, 3);
+		ValueTuple<int, int> right = new(1, 2);
+		var result = comparer.Compare(left, right);
+		Assert.Equal(1, result);
+	}
+}

--- a/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
+++ b/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
@@ -22,6 +22,19 @@ public class ValueTupleEqualityComparerTest
 	}
 
 	[Fact]
+	public void ValueTupleEqualityComparerWithOneTypeArgShouldGetHashCode()
+	{
+		var comparer = ValueTupleEqualityComparer.Create<int?>(null);
+		ValueTuple<int?> first = new(null);
+		var firstHashCode = comparer.GetHashCode(first);
+		Assert.Equal(0, firstHashCode);
+
+		ValueTuple<int?> second = new(2);
+		var secondHashCode = comparer.GetHashCode(second);
+		Assert.Equal(2.GetHashCode(), secondHashCode);
+	}
+
+	[Fact]
 	public void ValueTupleEqualityComparerWithOneTypeArgShouldCreateWhenComparerProvided()
 	{
 		var innerComparer = new TestComparer<TestObject>((x, y) => x?.Value == y?.Value);
@@ -40,5 +53,27 @@ public class ValueTupleEqualityComparerTest
 		ValueTuple<int, int> right = new(1, 2);
 		var result = comparer.Equals(left, right);
 		Assert.True(result);
+	}
+
+	[Fact]
+	public void ValueTupleEqualityComparerWithTwoTypeArgsShouldCreateWhenComparerProvided()
+	{
+		var innerComparerLeft = new TestComparer<TestObject>((x, y) => x?.Value == y?.Value);
+		var innerComparerRight = new TestComparer<TestObject>((x, y) => x?.Value == y?.Value);
+		var comparer = ValueTupleEqualityComparer.Create(innerComparerLeft, innerComparerRight);
+		ValueTuple<TestObject, TestObject> left = new(new("1"), new("2"));
+		ValueTuple<TestObject, TestObject> right = new(new("1"), new("2"));
+		var result = comparer.Equals(left, right);
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void ValueTupleEqualityComparerWithTwoTypeArgsShouldGetHashCode()
+	{
+		var comparer = ValueTupleEqualityComparer.Create<int, int>(null, null);
+		ValueTuple<int, int> first = new(1, 2);
+		var firstHashCode = comparer.GetHashCode(first);
+		var expectedHashCode = HashCode.Combine(1.GetHashCode(), 2.GetHashCode());
+		Assert.Equal(expectedHashCode, firstHashCode);
 	}
 }

--- a/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
+++ b/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
@@ -12,7 +12,7 @@ public class ValueTupleEqualityComparerTest
 	}
 
 	[Fact]
-	public void ValueTupleEqualityComparerShouldCreateWhenNoComparerProvided()
+	public void ValueTupleEqualityComparerWithOneTypeArgShouldCreateWhenNoComparerProvided()
 	{
 		var comparer = ValueTupleEqualityComparer.Create<int>(null);
 		ValueTuple<int> left = new(1);
@@ -22,12 +22,22 @@ public class ValueTupleEqualityComparerTest
 	}
 
 	[Fact]
-	public void ValueTupleEqualityComparerShouldCreateWhenComparerProvided()
+	public void ValueTupleEqualityComparerWithOneTypeArgShouldCreateWhenComparerProvided()
 	{
 		var innerComparer = new TestComparer<TestObject>((x, y) => x?.Value == y?.Value);
 		var comparer = ValueTupleEqualityComparer.Create(innerComparer);
 		ValueTuple<TestObject> left = new(new("testing"));
 		ValueTuple<TestObject> right = new(new("testing"));
+		var result = comparer.Equals(left, right);
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void ValueTupleEqualityComparerWithTwoTypeArgsShouldCreateWhenNoComparerProvided()
+	{
+		var comparer = ValueTupleEqualityComparer.Create<int, int>(null, null);
+		ValueTuple<int, int> left = new(1, 2);
+		ValueTuple<int, int> right = new(1, 2);
 		var result = comparer.Equals(left, right);
 		Assert.True(result);
 	}

--- a/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
+++ b/Tests/SuperLinq.Test/ValueTupleEqualityComparerTest.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Test;
+
+public class ValueTupleEqualityComparerTest
+{
+	private record TestObject(string Value);
+	private class TestComparer<T>(Func<T?, T?, bool> comparer) : IEqualityComparer<T>
+	{
+		public bool Equals(T? x, T? y) => comparer(x, y);
+		public int GetHashCode([DisallowNull] T obj) => obj.GetHashCode();
+	}
+
+	[Fact]
+	public void ValueTupleEqualityComparerShouldCreateWhenNoComparerProvided()
+	{
+		var comparer = ValueTupleEqualityComparer.Create<int>(null);
+		ValueTuple<int> left = new(1);
+		ValueTuple<int> right = new(1);
+		var result = comparer.Equals(left, right);
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void ValueTupleEqualityComparerShouldCreateWhenComparerProvided()
+	{
+		var innerComparer = new TestComparer<TestObject>((x, y) => x?.Value == y?.Value);
+		var comparer = ValueTupleEqualityComparer.Create(innerComparer);
+		ValueTuple<TestObject> left = new(new("testing"));
+		ValueTuple<TestObject> right = new(new("testing"));
+		var result = comparer.Equals(left, right);
+		Assert.True(result);
+	}
+}


### PR DESCRIPTION
Addresses #621 by adding unit tests for `ValueTupleComparer` and `ValueTupleEqualityComparer`, as well as marking `UnreachableException` with `[ExcludeFromCodeCoverage]`.

Fixes #621 