### PR TITLE
Generate platform-specific line endings

### DIFF
--- a/Generators/SuperLinq.Generator/ToDelimitedString.cs
+++ b/Generators/SuperLinq.Generator/ToDelimitedString.cs
@@ -28,7 +28,7 @@ internal static class ToDelimitedString
 		// Apply formatting since indenting isn't that nice in Scriban when rendering nested 
 		// structures via functions.
 		output = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseCompilationUnit(output)
-			.NormalizeWhitespace()
+			.NormalizeWhitespace(eol: Environment.NewLine)
 			.GetText()
 			.ToString();
 


### PR DESCRIPTION
On macOS the generator produces Windows-style line endings; causing git to pick up EOL changes. This PR changes the generation to use the platform-appropriate line-endings.