### PR TITLE
Use tabs in project files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -138,14 +138,10 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false:warnin
 csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
 csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false:warning
 
-# Build scripts
-[*.{yml,yaml}]
+# Build scripts and XML project files
+[*.{yml,yaml,json,csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
 indent_style = spaces
-indent_size = 2
-
-# XML project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
-indent_size = 2
 
 # Code files
 [*.cs]

--- a/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
+++ b/Docs/SuperLinq.Docs/SuperLinq.Docs.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0</TargetFrameworks>
-		<NoWarn>$(NoWarn);CA1852;NU1701</NoWarn>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CA1852;NU1701</NoWarn>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="DocFx.App" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="DocFx.App" />
+  </ItemGroup>
 
 </Project>

--- a/Generators/SuperLinq.Async.Generator/SuperLinq.Async.Generator.csproj
+++ b/Generators/SuperLinq.Async.Generator/SuperLinq.Async.Generator.csproj
@@ -1,44 +1,44 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IsPackable>false</IsPackable>
-		<IsRoslynComponent>true</IsRoslynComponent>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
 
-		<!-- Avoid figuring out an actual dependency on Scriban -->
-		<PackageScribanIncludeSource>true</PackageScribanIncludeSource>
+    <!-- Avoid figuring out an actual dependency on Scriban -->
+    <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
 
-		<!-- Scriban fails a lot of things in latest-all... -->
-		<AnalysisLevel>latest-default</AnalysisLevel>
+    <!-- Scriban fails a lot of things in latest-all... -->
+    <AnalysisLevel>latest-default</AnalysisLevel>
 
-		<!-- Analyzer checks-->
-		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Analyzer checks-->
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
-		<!-- Other things to turn off -->
-		<NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
-	</PropertyGroup>
+    <!-- Other things to turn off -->
+    <NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-		<PackageReference Include="Scriban" IncludeAssets="build" />
-		<PackageReference Include="ThisAssembly.Resources" PrivateAssets="all" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Scriban" IncludeAssets="build" />
+    <PackageReference Include="ThisAssembly.Resources" PrivateAssets="all" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Remove="*.sbntxt" />
-		<EmbeddedResource Include="*.sbntxt" Kind="Text" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="*.sbntxt" />
+    <EmbeddedResource Include="*.sbntxt" Kind="Text" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Include="../SuperLinq.Generator/ArgumentNames.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="../SuperLinq.Generator/ArgumentNames.cs" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <EmbeddedResource Update="ZipLongest.sbntxt">
-	    <Kind>Text</Kind>
-	  </EmbeddedResource>
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="ZipLongest.sbntxt">
+      <Kind>Text</Kind>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/Generators/SuperLinq.Generator/SuperLinq.Generator.csproj
+++ b/Generators/SuperLinq.Generator/SuperLinq.Generator.csproj
@@ -1,35 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IsPackable>false</IsPackable>
-		<IsRoslynComponent>true</IsRoslynComponent>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
 
-		<!-- Avoid figuring out an actual dependency on Scriban -->
-		<PackageScribanIncludeSource>true</PackageScribanIncludeSource>
+    <!-- Avoid figuring out an actual dependency on Scriban -->
+    <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
 
-		<!-- Scriban fails a lot of things in latest-all... -->
-		<AnalysisLevel>latest-default</AnalysisLevel>
+    <!-- Scriban fails a lot of things in latest-all... -->
+    <AnalysisLevel>latest-default</AnalysisLevel>
 
-		<!-- Analyzer checks-->
-		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Analyzer checks-->
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
-		<!-- Other things to turn off -->
-		<NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
-	</PropertyGroup>
+    <!-- Other things to turn off -->
+    <NoWarn>$(NoWarn);RS1035;SL03</NoWarn>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-		<PackageReference Include="Scriban" IncludeAssets="build" />
-		<PackageReference Include="ThisAssembly.Resources" PrivateAssets="all" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Scriban" IncludeAssets="build" />
+    <PackageReference Include="ThisAssembly.Resources" PrivateAssets="all" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Remove="*.sbntxt" />
-		<EmbeddedResource Include="*.sbntxt" Kind="Text" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="*.sbntxt" />
+    <EmbeddedResource Include="*.sbntxt" Kind="Text" />
+  </ItemGroup>
 
 </Project>
-

--- a/Source/SuperLinq.Async/SuperLinq.Async.csproj
+++ b/Source/SuperLinq.Async/SuperLinq.Async.csproj
@@ -3,142 +3,142 @@
   <Import Project="../../TargetFrameworks.props" />
 
   <PropertyGroup>
-	<AssemblyName>SuperLinq.Async</AssemblyName>
-	<RootNamespace>SuperLinq.Async</RootNamespace>
+    <AssemblyName>SuperLinq.Async</AssemblyName>
+    <RootNamespace>SuperLinq.Async</RootNamespace>
 
-	<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-	<Title>SuperLinq.Async</Title>
+    <Title>SuperLinq.Async</Title>
 
-	<Authors>SuperLinq Developers</Authors>
-	<PackageTags>linq;extensions;async</PackageTags>
+    <Authors>SuperLinq Developers</Authors>
+    <PackageTags>linq;extensions;async</PackageTags>
 
-	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-	<PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
 
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<RepositoryUrl>https://github.com/viceroypenguin/SuperLinq</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/viceroypenguin/SuperLinq</RepositoryUrl>
 
-	<IncludeSymbols>true</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup>
-	<Description>
-	  This project enhances Async LINQ to Objects with the following methods:
+    <Description>
+      This project enhances Async LINQ to Objects with the following methods:
 
-	  - AggregateRight
-	  - AssertCount
-	  - AtLeast
-	  - AtMost
-	  - Choose
-	  - CollectionEqual
-	  - CompareCount
-	  - ConcurrentMerge
-	  - Consume
-	  - CountBetween
-	  - CountBy
-	  - CountDown
-	  - DenseRank
-	  - DenseRankBy
-	  - DistinctBy
-	  - ElementAt
-	  - EndsWith
-	  - Exactly
-	  - ExceptBy
-	  - FallbackIfEmpty
-	  - FillBackward
-	  - FillForward
-	  - Fold
-	  - From
-	  - Generate
-	  - GroupAdjacent
-	  - Index
-	  - IndexBy
-	  - Insert
-	  - Interleave
-	  - OrderBy
-	  - Pad
-	  - PadStart
-	  - PartialSort
-	  - PartialSortBy
-	  - Random
-	  - Rank
-	  - RankBy
-	  - RunLengthEncode
-	  - ScanBy
-	  - ScanRight
-	  - Segment
-	  - Sequence
-	  - SkipUntil
-	  - SortedMerge
-	  - Split
-	  - StartsWith
-	  - TagFirstLast
-	  - Take
-	  - TakeEvery
-	  - TakeUntil
-	  - ThenBy
-	  - Where
-	  - Window
-	  - WindowLeft
-	  - WindowRight
-	  - ZipLongest
-	  - ZipMap
-	  - ZipShortest
-	</Description>
-	<Description>$([System.Text.RegularExpressions.Regex]::Replace($(Description), `\s+`, ` `).Trim().Replace(` - `, `, `).Replace(`:,`, `:`))</Description>
+      - AggregateRight
+      - AssertCount
+      - AtLeast
+      - AtMost
+      - Choose
+      - CollectionEqual
+      - CompareCount
+      - ConcurrentMerge
+      - Consume
+      - CountBetween
+      - CountBy
+      - CountDown
+      - DenseRank
+      - DenseRankBy
+      - DistinctBy
+      - ElementAt
+      - EndsWith
+      - Exactly
+      - ExceptBy
+      - FallbackIfEmpty
+      - FillBackward
+      - FillForward
+      - Fold
+      - From
+      - Generate
+      - GroupAdjacent
+      - Index
+      - IndexBy
+      - Insert
+      - Interleave
+      - OrderBy
+      - Pad
+      - PadStart
+      - PartialSort
+      - PartialSortBy
+      - Random
+      - Rank
+      - RankBy
+      - RunLengthEncode
+      - ScanBy
+      - ScanRight
+      - Segment
+      - Sequence
+      - SkipUntil
+      - SortedMerge
+      - Split
+      - StartsWith
+      - TagFirstLast
+      - Take
+      - TakeEvery
+      - TakeUntil
+      - ThenBy
+      - Where
+      - Window
+      - WindowLeft
+      - WindowRight
+      - ZipLongest
+      - ZipMap
+      - ZipShortest
+    </Description>
+    <Description>$([System.Text.RegularExpressions.Regex]::Replace($(Description), `\s+`, ` `).Trim().Replace(` - `, `, `).Replace(`:,`, `:`))</Description>
 
-	<Copyright>
-	  Portions © 2008 Jonathan Skeet.
-	  Portions © 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph.
-	  Portions © 2010 Johannes Rudolph, Leopold Bushkin.
-	  Portions © 2015 Felipe Sateler, “sholland”.
-	  Portions © 2016 Andreas Gullberg Larsen, Leandro F. Vieira (leandromoh).
-	  Portions © 2017 Jonas Nyrup (jnyrup).
-	  Portions © 2022 Turning Code, LLC
-	  Portions © 2022 Amichai Mantinband
-	  Portions © Microsoft. All rights reserved.
-	</Copyright>
-	<Copyright>$([System.Text.RegularExpressions.Regex]::Replace($(Copyright), `\s+`, ` `).Trim())</Copyright>
+    <Copyright>
+      Portions © 2008 Jonathan Skeet.
+      Portions © 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph.
+      Portions © 2010 Johannes Rudolph, Leopold Bushkin.
+      Portions © 2015 Felipe Sateler, “sholland”.
+      Portions © 2016 Andreas Gullberg Larsen, Leandro F. Vieira (leandromoh).
+      Portions © 2017 Jonas Nyrup (jnyrup).
+      Portions © 2022 Turning Code, LLC
+      Portions © 2022 Amichai Mantinband
+      Portions © Microsoft. All rights reserved.
+    </Copyright>
+    <Copyright>$([System.Text.RegularExpressions.Regex]::Replace($(Copyright), `\s+`, ` `).Trim())</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-	<None Include="readme.md" Pack="true" PackagePath="\" />
-	<AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
-	<AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+    <None Include="readme.md" Pack="true" PackagePath="\" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>
-	<Using Include="SuperLinq.Exceptions" />
-	<Using Include="System.Runtime.CompilerServices" />
+    <Using Include="SuperLinq.Exceptions" />
+    <Using Include="System.Runtime.CompilerServices" />
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
-	<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-	<PackageReference Include="MinVer" PrivateAssets="All" />
-	<PackageReference Include="System.Linq.Async" />
-	<ProjectReference Include="..\SuperLinq\SuperLinq.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="MinVer" PrivateAssets="All" />
+    <PackageReference Include="System.Linq.Async" />
+    <ProjectReference Include="..\SuperLinq\SuperLinq.csproj" />
   </ItemGroup>
 
   <PropertyGroup Label="SourceGenerator">
-	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-	<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup Label="SourceGenerator">
-	<ProjectReference Include="..\..\Generators\SuperLinq.Async.Generator\SuperLinq.Async.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	<Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
-	<None Include="$(CompilerGeneratedFilesOutputPath)/SuperLinq.Async.Generator/**/*.cs" />
+    <ProjectReference Include="..\..\Generators\SuperLinq.Async.Generator\SuperLinq.Async.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+    <None Include="$(CompilerGeneratedFilesOutputPath)/SuperLinq.Async.Generator/**/*.cs" />
   </ItemGroup>
 
   <PropertyGroup Label="MinVer">
-	<MinVerAutoIncrement>minor</MinVerAutoIncrement>
-	<MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
-	<MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
 </Project>

--- a/Source/SuperLinq/SuperLinq.csproj
+++ b/Source/SuperLinq/SuperLinq.csproj
@@ -3,185 +3,185 @@
   <Import Project="../../TargetFrameworks.props" />
 
   <PropertyGroup>
-	<AssemblyName>SuperLinq</AssemblyName>
-	<RootNamespace>SuperLinq</RootNamespace>
+    <AssemblyName>SuperLinq</AssemblyName>
+    <RootNamespace>SuperLinq</RootNamespace>
 
-	<PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
-	<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-	<Title>SuperLinq</Title>
+    <Title>SuperLinq</Title>
 
-	<Authors>SuperLinq Developers</Authors>
-	<PackageTags>linq;extensions;linqpad-samples</PackageTags>
+    <Authors>SuperLinq Developers</Authors>
+    <PackageTags>linq;extensions;linqpad-samples</PackageTags>
 
-	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-	<PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
 
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<RepositoryUrl>https://github.com/viceroypenguin/SuperLinq</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/viceroypenguin/SuperLinq</RepositoryUrl>
 
-	<IncludeSymbols>true</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup>
-	<Description>
-	  This project enhances LINQ to Objects with the following methods:
+    <Description>
+      This project enhances LINQ to Objects with the following methods:
 
-	  - AggregateRight
-	  - AssertCount
-	  - AtLeast
-	  - AtMost
-	  - Cartesian
-	  - Choose
-	  - CountBetween
-	  - CollectionEqual
-	  - CompareCount
-	  - CountBy
-	  - CountDown
-	  - Consume
-	  - DenseRank
-	  - DenseRankBy
-	  - DistinctBy
-	  - ElementAt (pre-.NET 6.0)
-	  - EndsWith
-	  - EquiZip
-	  - Evaluate
-	  - Exactly
-	  - ExceptBy
-	  - Exclude
-	  - FallbackIfEmpty
-	  - FillBackward
-	  - FillForward
-	  - Flatten
-	  - Fold
-	  - From
-	  - FullGroupJoin
-	  - FullJoin
-	  - Generate
-	  - GetShortestPath
-	  - GetShortestPathCost
-	  - GetShortestPaths
-	  - GroupAdjacent
-	  - Index
-	  - IndexBy
-	  - Insert
-	  - Interleave
-	  - Lag
-	  - Lead
-	  - LeftJoin
-	  - Move
-	  - OrderBy
-	  - OrderedMerge
-	  - Pad
-	  - PadStart
-	  - PartialSort
-	  - PartialSortBy
-	  - Partition
-	  - Permutations
-	  - Pipe
-	  - PreScan
-	  - Random
-	  - RandomDouble
-	  - RandomSubset
-	  - Rank
-	  - RankBy
-	  - Return
-	  - RightJoin
-	  - RunLengthEncode
-	  - ScanBy
-	  - ScanRight
-	  - Segment
-	  - Sequence
-	  - Shuffle
-	  - SkipUntil
-	  - Slice
-	  - SortedMerge
-	  - Split
-	  - StartsWith
-	  - Subsets
-	  - TagFirstLast
-	  - Take (pre-.NET 6.0)
-	  - TakeEvery
-	  - TakeUntil
-	  - ThenBy
-	  - ToArrayByIndex
-	  - ToDataTable
-	  - ToDelimitedString
-	  - ToDictionary
-	  - ToLookup
-	  - Trace
-	  - Transpose
-	  - TraverseBreadthFirst
-	  - TraverseDepthFirst
-	  - TrySingle
-	  - Where
-	  - Window
-	  - WindowLeft
-	  - WindowRight
-	  - ZipLongest
-	  - ZipMap
-	  - ZipShortest
-	</Description>
-	<Description>$([System.Text.RegularExpressions.Regex]::Replace($(Description), `\s+`, ` `).Trim().Replace(` - `, `, `).Replace(`:,`, `:`))</Description>
+      - AggregateRight
+      - AssertCount
+      - AtLeast
+      - AtMost
+      - Cartesian
+      - Choose
+      - CountBetween
+      - CollectionEqual
+      - CompareCount
+      - CountBy
+      - CountDown
+      - Consume
+      - DenseRank
+      - DenseRankBy
+      - DistinctBy
+      - ElementAt (pre-.NET 6.0)
+      - EndsWith
+      - EquiZip
+      - Evaluate
+      - Exactly
+      - ExceptBy
+      - Exclude
+      - FallbackIfEmpty
+      - FillBackward
+      - FillForward
+      - Flatten
+      - Fold
+      - From
+      - FullGroupJoin
+      - FullJoin
+      - Generate
+      - GetShortestPath
+      - GetShortestPathCost
+      - GetShortestPaths
+      - GroupAdjacent
+      - Index
+      - IndexBy
+      - Insert
+      - Interleave
+      - Lag
+      - Lead
+      - LeftJoin
+      - Move
+      - OrderBy
+      - OrderedMerge
+      - Pad
+      - PadStart
+      - PartialSort
+      - PartialSortBy
+      - Partition
+      - Permutations
+      - Pipe
+      - PreScan
+      - Random
+      - RandomDouble
+      - RandomSubset
+      - Rank
+      - RankBy
+      - Return
+      - RightJoin
+      - RunLengthEncode
+      - ScanBy
+      - ScanRight
+      - Segment
+      - Sequence
+      - Shuffle
+      - SkipUntil
+      - Slice
+      - SortedMerge
+      - Split
+      - StartsWith
+      - Subsets
+      - TagFirstLast
+      - Take (pre-.NET 6.0)
+      - TakeEvery
+      - TakeUntil
+      - ThenBy
+      - ToArrayByIndex
+      - ToDataTable
+      - ToDelimitedString
+      - ToDictionary
+      - ToLookup
+      - Trace
+      - Transpose
+      - TraverseBreadthFirst
+      - TraverseDepthFirst
+      - TrySingle
+      - Where
+      - Window
+      - WindowLeft
+      - WindowRight
+      - ZipLongest
+      - ZipMap
+      - ZipShortest
+    </Description>
+    <Description>$([System.Text.RegularExpressions.Regex]::Replace($(Description), `\s+`, ` `).Trim().Replace(` - `, `, `).Replace(`:,`, `:`))</Description>
 
-	<Copyright>
-	  Portions © 2008 Jonathan Skeet.
-	  Portions © 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph.
-	  Portions © 2010 Johannes Rudolph, Leopold Bushkin.
-	  Portions © 2015 Felipe Sateler, “sholland”.
-	  Portions © 2016 Andreas Gullberg Larsen, Leandro F. Vieira (leandromoh).
-	  Portions © 2017 Jonas Nyrup (jnyrup).
-	  Portions © 2022 Turning Code, LLC
-	  Portions © 2022 Amichai Mantinband
-	  Portions © Microsoft. All rights reserved.
-	</Copyright>
-	<Copyright>$([System.Text.RegularExpressions.Regex]::Replace($(Copyright), `\s+`, ` `).Trim())</Copyright>
+    <Copyright>
+      Portions © 2008 Jonathan Skeet.
+      Portions © 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph.
+      Portions © 2010 Johannes Rudolph, Leopold Bushkin.
+      Portions © 2015 Felipe Sateler, “sholland”.
+      Portions © 2016 Andreas Gullberg Larsen, Leandro F. Vieira (leandromoh).
+      Portions © 2017 Jonas Nyrup (jnyrup).
+      Portions © 2022 Turning Code, LLC
+      Portions © 2022 Amichai Mantinband
+      Portions © Microsoft. All rights reserved.
+    </Copyright>
+    <Copyright>$([System.Text.RegularExpressions.Regex]::Replace($(Copyright), `\s+`, ` `).Trim())</Copyright>
   </PropertyGroup>
 
   <ItemGroup Label="Nuget Package">
-	<None Include="readme.md" Pack="true" PackagePath="\" />
-	<None Include="..\..\Docs\SuperLinq.Docs\apidoc\SuperLinq\**"
-		  Visible="false"
-		  Pack="true" PackagePath="\linqpad-samples\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="readme.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\Docs\SuperLinq.Docs\apidoc\SuperLinq\**"
+          Visible="false"
+          Pack="true" PackagePath="\linqpad-samples\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>
-	<AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
-	<AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>
-	<Using Include="SuperLinq.Exceptions" />
+    <Using Include="SuperLinq.Exceptions" />
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
-	<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-	<PackageReference Include="MinVer" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Label="SourceGenerator">
-	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-	<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup Label="SourceGenerator">
-	<ProjectReference Include="..\..\Generators\SuperLinq.Generator\SuperLinq.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	<Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
-	<None Include="$(CompilerGeneratedFilesOutputPath)/SuperLinq.Generator/**/*.cs" />
+    <ProjectReference Include="..\..\Generators\SuperLinq.Generator\SuperLinq.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+    <None Include="$(CompilerGeneratedFilesOutputPath)/SuperLinq.Generator/**/*.cs" />
   </ItemGroup>
 
   <PropertyGroup Label="MinVer">
-	<MinVerAutoIncrement>minor</MinVerAutoIncrement>
-	<MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
-	<MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-	<InternalsVisibleTo Include="SuperLinq.Async" />
+    <InternalsVisibleTo Include="SuperLinq.Async" />
   </ItemGroup>
 
 </Project>

--- a/Tests/SuperLinq.Async.Test/SuperLinq.Async.Test.csproj
+++ b/Tests/SuperLinq.Async.Test/SuperLinq.Async.Test.csproj
@@ -1,45 +1,45 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<Import Project="../../TargetFrameworks.props" />
+  <Import Project="../../TargetFrameworks.props" />
 
-	<PropertyGroup>
-		<AssemblyTitle>SuperLinq.Async.Test</AssemblyTitle>
-		<AssemblyName>SuperLinq.Async.Test</AssemblyName>
-		<RootNamespace>Test.Async</RootNamespace>
+  <PropertyGroup>
+    <AssemblyTitle>SuperLinq.Async.Test</AssemblyTitle>
+    <AssemblyName>SuperLinq.Async.Test</AssemblyName>
+    <RootNamespace>Test.Async</RootNamespace>
 
-		<IsPackable>false</IsPackable>
-		<AnalysisLevel>latest-recommended</AnalysisLevel>
-	</PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Source\SuperLinq\SuperLinq.csproj" />
-		<ProjectReference Include="..\..\Source\SuperLinq.Async\SuperLinq.Async.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\SuperLinq\SuperLinq.csproj" />
+    <ProjectReference Include="..\..\Source\SuperLinq.Async\SuperLinq.Async.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Include="..\SuperLinq.Test\BreakingAction.cs" Link="BreakingAction.cs" />
-		<Compile Include="..\SuperLinq.Test\BreakingFunc.cs" Link="BreakingFunc.cs" />
-		<Compile Include="..\SuperLinq.Test\EqualityComparer.cs" Link="EqualityComparer.cs" />
-		<Compile Include="..\SuperLinq.Test\FuncModule.cs" Link="FuncModule.cs" />
-		<Compile Include="..\SuperLinq.Test\TestException.cs" Link="TestException.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SuperLinq.Test\BreakingAction.cs" Link="BreakingAction.cs" />
+    <Compile Include="..\SuperLinq.Test\BreakingFunc.cs" Link="BreakingFunc.cs" />
+    <Compile Include="..\SuperLinq.Test\EqualityComparer.cs" Link="EqualityComparer.cs" />
+    <Compile Include="..\SuperLinq.Test\FuncModule.cs" Link="FuncModule.cs" />
+    <Compile Include="..\SuperLinq.Test\TestException.cs" Link="TestException.cs" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Using Include="SuperLinq" />
-		<Using Include="SuperLinq.Async" />
-		<Using Include="Xunit" />
-		<Using Include="Test.FuncModule" Static="true" />
-		<Using Include="Test.Async.TestExtensions" Static="true" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="SuperLinq" />
+    <Using Include="SuperLinq.Async" />
+    <Using Include="Xunit" />
+    <Using Include="Test.FuncModule" Static="true" />
+    <Using Include="Test.Async.TestExtensions" Static="true" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Diagnostics" />
-		<PackageReference Include="coverlet.collector" PrivateAssets="All" />
-		<PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-		<PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project>

--- a/Tests/SuperLinq.Test/SuperLinq.Test.csproj
+++ b/Tests/SuperLinq.Test/SuperLinq.Test.csproj
@@ -1,35 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<Import Project="../../TargetFrameworks.props" />
+  <Import Project="../../TargetFrameworks.props" />
 
-	<PropertyGroup>
-		<AssemblyTitle>SuperLinq.Test</AssemblyTitle>
-		<AssemblyName>SuperLinq.Test</AssemblyName>
-		<RootNamespace>Test</RootNamespace>
-		
-		<IsPackable>false</IsPackable>
-		<AnalysisLevel>latest-recommended</AnalysisLevel>
-	</PropertyGroup>
+  <PropertyGroup>
+    <AssemblyTitle>SuperLinq.Test</AssemblyTitle>
+    <AssemblyName>SuperLinq.Test</AssemblyName>
+    <RootNamespace>Test</RootNamespace>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Source\SuperLinq\SuperLinq.csproj" />
-	</ItemGroup>
+    <IsPackable>false</IsPackable>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Using Include="SuperLinq" />
-		<Using Include="Test.FuncModule" Static="true" />
-		<Using Include="Test.TestExtensions" Static="true" />
-		<Using Include="Xunit" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\SuperLinq\SuperLinq.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Diagnostics" />
-		<PackageReference Include="coverlet.collector" PrivateAssets="All" />
-		<PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-		<PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="SuperLinq" />
+    <Using Include="Test.FuncModule" Static="true" />
+    <Using Include="Test.TestExtensions" Static="true" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The csproj files mix spaces and tabs. My editor (Rider) was apparently showing tabs as 2 spaces, resulting in an unreadable csproj file:

![image](https://github.com/user-attachments/assets/72d09dd2-3e16-4cb7-9e72-8b8dc31d24f7)

This PR formats the csproj files to use tab consistently.

I also noticed that various cs files have inconsistent tab/space usage. Not a big concern to me, but as I typically set my editor to auto-format, this produces quite some whitespace changes.